### PR TITLE
Removed import of attic'd things from sandbox.

### DIFF
--- a/code/python/PySRMSTIS/src/sandbox.py
+++ b/code/python/PySRMSTIS/src/sandbox.py
@@ -6,8 +6,6 @@ Created on 08.07.2014
 
 import numpy as np
 
-from tis_interfaces import TISInterfaces
-from transition_interface_sampling import TransitionInterfaceSampling
 from Simulator import Simulator
 from orderparameter import OP_RMSD_To_Lambda, OP_Multi_RMSD
 from volume import LambdaVolume, VoronoiVolume


### PR DESCRIPTION
Last part of attic'ing old and unused tis_interfaces and transition_interface_sampling. After it calls `exit`, there are still parts of sandbox.py that refer back to these, but I'll leave that cleanup to @jhprinz in case he needs any of that for future reference.
