### PR TITLE
Annoying test output fix

### DIFF
--- a/opentis/snapshot.py
+++ b/opentis/snapshot.py
@@ -447,6 +447,8 @@ class Snapshot(object):
         if kinetic_energy is not None: 
             self.momentum._kinetic_energy = copy.deepcopy(kinetic_energy)
 
+        # TODO: consider whether it is cleaner to move this logic into the
+        # main allocation process instead of fixing things after the fact
         config = self.configuration
         if config.coordinates is None and config.box_vectors is None and config.potential_energy is None:
             self.configuration = None


### PR DESCRIPTION
In recent tests, there's some output that claims an error, but doesn't actually throw an error. In particular, you'd get the lines:

```
ERROR : Momentum should not be empty
Think about how to handle this. It should only be None if loaded lazy and in this case it will never be saved.
```

These come from lines 208 and 213 in `storage/snapshot_store.py`. The issue is that we're storing a `Momentum` object with empty velocities and empty kinetic energy. This is an odd thing, and not normally desired; however, in testing (and setup) it can occur. Specifically, it _does_ occur in testing as part of the nosetests package-level setup. Our .nc files are still extremely large, and so rather than include them in the repository, I included a short trajectory in PDB format for test purposes. This trajectory doesn't have velocities associated with it, so it really shouldn't have a `Momentum` object at all. But until now we initialized a `Snapshot` with a `Momentum` object, but that object didn't contain anything.

This PR changes the way we initialize `Snapshot`s so that they only have `Configuration` or `Momentum` objects if they have at least one of the elements stored in those. Otherwise the `snapshot.configuration` or `snapshot.momentum` is `None`.

(There may be cleaner ways of redoing `Snapshot` to handle this, but this was a quick fix so I don't see "ERROR" when my tests pass!)
