### PR TITLE
Fix input ensemble for ConditionalSequentialEnsemble

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -1497,6 +1497,9 @@ class ConditionalSequentialMover(SequentialMover):
     ConditionalSequentialMover only works if there is a *single* active
     sample per replica.
     """
+    def _get_in_ensembles(self):
+        return [self.submovers[0].input_ensembles]
+
     def move(self, globalstate):
         logger.debug("Starting conditional sequential move")
 


### PR DESCRIPTION
Should be only the inputs of the first submover.

Resolves #452. 

New results look something like this:

<img width="412" alt="fixed_cond_seq_ens" src="https://cloud.githubusercontent.com/assets/8178546/14020589/150f8d9c-f1d8-11e5-8c21-efc658a49a6b.png">

Note that the `RandomChoice` and `ConditionalSequential`s allow output from B (in case of abort, that's where you end) but the EnsembleFilter doesn't (filtering that is its job.) However, they do not allow input in B, fixing the problem.