### PR TITLE
[WIP] Create storages with example system setups

### DIFF
--- a/examples/ipython/create_example_data.ipynb
+++ b/examples/ipython/create_example_data.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create example system to be loaded later for examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A 3 well test potential in 2D with ToyDynamics and a Langevin Integrator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import openpathsampling as paths\n",
+    "import numpy as np\n",
+    "import openpathsampling.engines.toy as toys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Toy_PES supports adding/subtracting various PESs. \n",
+    "# The OuterWalls PES type gives an x^6+y^6 boundary to the system.\n",
+    "pes = (\n",
+    "    toys.OuterWalls([1.0, 1.0], [0.0, 0.0]) +\n",
+    "    toys.Gaussian(-0.7, [12.0, 12.0], [0.0, 0.4]) +\n",
+    "    toys.Gaussian(-0.7, [12.0, 12.0], [-0.5, -0.5]) +\n",
+    "    toys.Gaussian(-0.7, [12.0, 12.0], [0.5, -0.5])\n",
+    ")\n",
+    "\n",
+    "topology=toys.Topology(\n",
+    "    n_spatial = 2,\n",
+    "    masses =[1.0, 1.0],\n",
+    "    pes = pes\n",
+    ")\n",
+    "\n",
+    "template = toys.Snapshot(\n",
+    "    coordinates=np.array([[-0.5, -0.5]]), \n",
+    "    velocities=np.array([[0.0,0.0]]),\n",
+    "    topology=topology\n",
+    ")\n",
+    "integ = toys.LangevinBAOABIntegrator(dt=0.02, temperature=0.1, gamma=2.5)\n",
+    "\n",
+    "options={\n",
+    "    'integ' : integ,\n",
+    "    'n_frames_max' : 5000,\n",
+    "    'nsteps_per_frame' : 10\n",
+    "}\n",
+    "\n",
+    "engine = toys.Engine(\n",
+    "    options=options,\n",
+    "    template=template\n",
+    ")\n",
+    "engine.initialized = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "st = paths.Storage('setup_3well2D_toysystem.nc', mode='w', template=template)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "st.tag['engine'] = engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "st.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Alanine Test System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import openpathsampling.engines.openmm as peng\n",
+    "\n",
+    "import mdtraj as md\n",
+    "import simtk.openmm as mm\n",
+    "from simtk.openmm import app\n",
+    "from simtk import unit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "template = peng.snapshot_from_pdb(\"../data/Alanine_solvated.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "st = paths.Storage(filename=\"setup_alanine.nc\", template=template, mode='w')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "topology = peng.to_openmm_topology(template)            \n",
+    "\n",
+    "# Generated using OpenMM Script Builder\n",
+    "# http://builder.openmm.org\n",
+    "\n",
+    "forcefield = app.ForceField(\n",
+    "    'amber96.xml',  # solute FF\n",
+    "    'tip3p.xml'     # solvent FF\n",
+    ")\n",
+    "\n",
+    "# OpenMM System\n",
+    "system = forcefield.createSystem(\n",
+    "    topology, \n",
+    "    nonbondedMethod=app.PME, \n",
+    "    nonbondedCutoff=1.0*unit.nanometers, \n",
+    "    constraints=app.HBonds, \n",
+    "    rigidWater=True, \n",
+    "    ewaldErrorTolerance=0.0005\n",
+    ")\n",
+    "\n",
+    "# OpenMM Integrator\n",
+    "integrator = mm.LangevinIntegrator(\n",
+    "    300*unit.kelvin, \n",
+    "    1.0/unit.picoseconds, \n",
+    "    2.0*unit.femtoseconds\n",
+    ")\n",
+    "integrator.setConstraintTolerance(0.00001)\n",
+    "\n",
+    "# Engine options\n",
+    "options = {\n",
+    "    'nsteps_per_frame': 10,\n",
+    "    'platform': 'CPU'\n",
+    "}\n",
+    "\n",
+    "engine = peng.Engine(\n",
+    "    template, \n",
+    "    system,\n",
+    "    integrator,\n",
+    "    options\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "st.tag['engine'] = engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "psi_atoms = [6,8,14,16]\n",
+    "psi = paths.CV_MDTraj_Function(\"psi\", md.compute_dihedrals, indices=[psi_atoms])\n",
+    "\n",
+    "phi_atoms = [4,6,8,14]\n",
+    "phi = paths.CV_MDTraj_Function(\"phi\", md.compute_dihedrals, indices=[phi_atoms])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "st.tag['phi'] = phi\n",
+    "st.tag['psi'] = psi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "st.cvs.sync()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "st.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
### What this is

I find myself constantly needing the code to to create example systems. Instead of copying the code cells and hoping that I did not forget anything this will just store a template and the corrresonding engine in a storage file. 
Currently it will only generate the mstis toy setup (not the MISTIS) and the alanine. You can then load a setup simply by 

```py
setup = Storage('setup_xyz.nc', mode='r')
template = setup.template
# or
template = setup.tag['template']
engine = setup.tag['engine']
# if necessary like for OpenMM
engine.initialize()
```

For alanine I have also added psi and psi which seemed to be useful.

If we split of the set up of the system we could even split of this part in the examples.
```
mstis_system.ipynb # only setup the system and engine
mstis_prepare.ipynb # generate initial pathways
mstis_generation.ipynb # here actual OPS starts
mstis_analysis.ipynb # analyze
```