### PR TITLE
DirectSimulation for rate and flux

### DIFF
--- a/examples/ipython/mistis_flux.ipynb
+++ b/examples/ipython/mistis_flux.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import openpathsampling as paths\n",
+    "import numpy as np\n",
+    "\n",
+    "from openpathsampling.pathsimulator import DirectSimulation # until officially added"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As always, we load things from files so we don't have to set them up again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "old = paths.AnalysisStorage(\"mistis.nc\")\n",
+    "engine = old.engines[0]\n",
+    "network = old.networks[0]\n",
+    "states = set(network.initial_states + network.final_states)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `flux_pairs` variable is a list of 2-tuples, where the first element is the state we're calculating the flux out of, and the second element in the interface we're calculating the flux through."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "flux_pairs = [(trans.stateA, trans.interfaces[0]) for trans in network.transitions.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up the simulation and run it!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sim = DirectSimulation(\n",
+    "    storage=None,\n",
+    "    engine=engine,\n",
+    "    states=states,\n",
+    "    flux_pairs=flux_pairs,\n",
+    "    initial_snapshot=old.snapshots[0]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 34.6 s, sys: 40 ms, total: 34.7 s\n",
+      "Wall time: 34.7 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "sim.run(150000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we move on to the analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
+       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
+       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0.3, inf]})</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>4.8746e-05</td>\n",
+       "      <td>0.000285878</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
+       "      <td>0.00127065</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000315457</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0.3, inf]})</th>\n",
+       "      <td>2.74699e-05</td>\n",
+       "      <td>0.00016372</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                   ({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-inf, -0.3]})  \\\n",
+       "({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-in...                                                NaN          \n",
+       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-...                                         0.00127065          \n",
+       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0...                                        2.74699e-05          \n",
+       "\n",
+       "                                                   ({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-inf, -0.3]})  \\\n",
+       "({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-in...                                         4.8746e-05            \n",
+       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-...                                                NaN            \n",
+       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0...                                         0.00016372            \n",
+       "\n",
+       "                                                   ({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0.3, inf]})  \n",
+       "({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-in...                                        0.000285878         \n",
+       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-...                                        0.000315457         \n",
+       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0...                                                NaN         "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.rate_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{(<openpathsampling.volume.IntersectionVolume at 0x115180f10>,\n",
+       "  <openpathsampling.volume.IntersectionVolume at 0x11526d9d0>): 2,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x115180f10>,\n",
+       "  <openpathsampling.volume.IntersectionVolume at 0x11526de90>): 1,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526d9d0>,\n",
+       "  <openpathsampling.volume.IntersectionVolume at 0x115180f10>): 1,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526d9d0>,\n",
+       "  <openpathsampling.volume.IntersectionVolume at 0x11526de90>): 2,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526de90>,\n",
+       "  <openpathsampling.volume.IntersectionVolume at 0x115180f10>): 2,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526de90>,\n",
+       "  <openpathsampling.volume.IntersectionVolume at 0x11526d9d0>): 1}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.n_transitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{(<openpathsampling.volume.IntersectionVolume at 0x115180f10>,\n",
+       "  <openpathsampling.volume.CVRangeVolume at 0x115180e90>): 1.4441222676433058e-05,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526d9d0>,\n",
+       "  <openpathsampling.volume.CVRangeVolume at 0x115255b90>): 1.5083045633215883e-05,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526d9d0>,\n",
+       "  <openpathsampling.volume.CVRangeVolume at 0x1152a65d0>): 2.6099058207808377e-05}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.fluxes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{(<openpathsampling.volume.IntersectionVolume at 0x115180f10>,\n",
+       "  <openpathsampling.volume.CVRangeVolume at 0x115180e90>): 63,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526d9d0>,\n",
+       "  <openpathsampling.volume.CVRangeVolume at 0x115255b90>): 14,\n",
+       " (<openpathsampling.volume.IntersectionVolume at 0x11526d9d0>,\n",
+       "  <openpathsampling.volume.CVRangeVolume at 0x1152a65d0>): 17}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.n_flux_events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -74,7 +74,7 @@ from pathmover import (
 
 from pathsimulator import (
     PathSimulator, FullBootstrapping, Bootstrapping, PathSampling, MCStep,
-    CommittorSimulation
+    CommittorSimulation, DirectSimulation
 )
 
 from sample import Sample, SampleSet

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -662,14 +662,34 @@ class DirectSimulation(PathSimulator):
 
     Parameters
     ----------
-    storage
+    storage : paths.Storage
+        file to store the trajectory in. Default is None, meaning that the
+        trajectory isn't stored (also faster)
     engine : paths.engine.DynamicsEngine
         the engine for the molecular dynamics
     states : list of paths.Volume
-        states
+        states to look for transitions between
     flux_pairs : list of 2-tuples of (state, interface)
+        fluxes will calculate the flux out of `state` and through
+        `interface` for each pair in this list
     initial_snapshot : paths.engines.Snapshot
         initial snapshot for the MD
+
+    Attributes
+    ----------
+    transitions : dict with keys 2-tuple of paths.Volume, values list of int
+        for each pair of states (from_state, to_state) as a key, gives the
+        number of frames for each transition from the entry into from_state
+        to entry into to_state
+    rate_matrix : pd.DataFrame
+        calculates the rate matrix, in units of per-frames
+    fluxes : dict with keys 2-tuple of paths.Volume, values float
+        flux out of state and through interface for each (state, interface)
+        key pair
+    n_transitions : dict with keys 2-tuple of paths.Volume, values int
+        number of transition events for each pair of states
+    n_flux_events : dict with keys 2-tuple of paths.Volume, values int
+        number of flux events for each (state, interface) pair
     """
     def __init__(self, storage=None, engine=None, states=None,
                  flux_pairs=None, initial_snapshot=None):

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -715,9 +715,10 @@ class DirectSimulation(PathSimulator):
                 is_in_interface = interface(frame)
                 if not is_in_interface and was_in_interface[p]:
                     if state is most_recent_state:
+                        last_exit = last_interface_exit[p]
                         # successful exit
-                        if last_interface_exit[p] < last_state_visit[state]:
-                            flux_time_range = (step, last_interface_exit[p])
+                        if 0 < last_exit < last_state_visit[state]:
+                            flux_time_range = (step, last_exit)
                             self.flux_events[p].append(flux_time_range)
                         last_interface_exit[p] = step
                 was_in_interface[p] = is_in_interface

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -760,8 +760,14 @@ class DirectSimulation(PathSimulator):
 
     @property
     def fluxes(self):
-        return {p : 1.0 / np.array(self.flux_events[p]).mean()
-                for p in self.flux_events}
+        results = {}
+        for p in self.flux_events:
+            lags = [t[0] - t[1] for t in self.flux_events[p]]
+            results[p] = 1.0 / np.mean(lags)
+        return results
+
+        # return {p : 1.0 / np.array(self.flux_events[p]).mean()
+                # for p in self.flux_events}
 
     @property
     def n_transitions(self):

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -650,6 +650,27 @@ class CommittorSimulation(PathSimulator):
                     if self.step % self.save_frequency == 0:
                         self.sync_storage()
 
-                pass
+class DirectSimulation(PathSimulator):
+    def __init__(self, storage=None, engine=None, states=None,
+                 interfaces=None, initial_snapshot=None):
+        super(DirectSimulation, self).__init__(storage)
+        self.engine = engine
+        self.states = states
+        self.interfaces = interfaces
+        self.initial_snapshot = initial_snapshot
+        self.engine.current_snapshot = initial_snapshot
+        self.save_every = 1
+        # TODO: might set these elsewhere for reloading purposes?
+        self.transitions = []
+        self.fluxes = {state: {'in': [], 'out': []} for state in self.states}
 
+    def run(self, n_steps):
+        pass
 
+    @property
+    def rate(self):
+        pass
+
+    @property
+    def flux(self):
+        pass

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -691,7 +691,7 @@ class DirectSimulation(PathSimulator):
         last_interface_exit = {p : -1 for p in self.flux_pairs}
         last_state_visit = {s : -1 for s in self.states}
         was_in_interface = {p : None for p in self.flux_pairs}
-        local_traj = [self.initial_snapshot]
+        local_traj = paths.Trajectory([self.initial_snapshot])
         self.engine.current_snapshot = self.initial_snapshot
         for step in range(n_steps):
             frame = self.engine.generate_next_frame()
@@ -730,6 +730,12 @@ class DirectSimulation(PathSimulator):
                             self.flux_events[p].append(flux_time_range)
                         last_interface_exit[p] = step
                 was_in_interface[p] = is_in_interface
+
+            if self.storage is not None:
+                local_traj += [frame]
+
+        if self.storage is not None:
+            self.storage.save(local_traj)
 
     @property
     def transitions(self):

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -704,6 +704,14 @@ class DirectSimulation(PathSimulator):
             if state: 
                 last_state_visit[state] = step
                 if state is not most_recent_state:
+                    # we've made a transition: on the first entrance into
+                    # this state, we reset the last_interface_exit
+                    state_flux_pairs = [p for p in self.flux_pairs 
+                                        if p[0] == state]
+                    for p in state_flux_pairs:
+                        last_interface_exit[p] = -1
+                    # if this isn't the first change of state, we add the
+                    # transition
                     if most_recent_state:
                         self.transition_count.append((state, step))
                     most_recent_state = state

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -213,23 +213,47 @@ class testDirectSimulation(object):
         cv = paths.CV_Function("Id", lambda snap : snap.coordinates[0][0])
         self.center = paths.CVRangeVolume(cv, -0.2, 0.2)
         self.interface = paths.CVRangeVolume(cv, -0.3, 0.3)
-        self.outside = ~paths.CVRangeVolume(cv, -0.9, 0.9)
-        flux_pairs = [(self.center, self.interface)]
+        self.outside = paths.CVRangeVolume(cv, 0.6, 0.9)
+        self.extra = paths.CVRangeVolume(cv, -1.5, -0.9)
+        self.flux_pairs = [(self.center, self.interface)]
         self.sim = DirectSimulation(storage=None,
                                     engine=self.engine,
                                     states=[self.center, self.outside],
-                                    flux_pairs=flux_pairs,
+                                    flux_pairs=self.flux_pairs,
                                     initial_snapshot=self.snap0)
 
     def test_run(self):
-
-        raise SkipTest
+        self.sim.run(200)
+        assert_true(len(self.sim.transition_count) > 1)
+        assert_true(len(self.sim.flux_events[self.flux_pairs[0]]) > 1)
 
     def test_transitions(self):
-        raise SkipTest
+        # set fake data
+        self.sim.transition_count = [
+            (self.center, 1), (self.outside, 4), (self.center, 7),
+            (self.extra, 10), (self.center, 12), (self.outside, 14)
+        ]
+        assert_equal(self.sim.n_transitions,
+                     {(self.center, self.outside): 2,
+                      (self.outside, self.center): 1,
+                      (self.center, self.extra): 1,
+                      (self.extra, self.center): 1})
+        assert_equal(self.sim.transitions,
+                     {(self.center, self.outside) : [3, 2],
+                      (self.outside, self.center) : [3],
+                      (self.center, self.extra): [3],
+                      (self.extra, self.center): [2]})
 
     def test_rate_matrix(self):
+        self.sim.transition_count = [
+            (self.center, 1), (self.outside, 4), (self.center, 7),
+            (self.extra, 10), (self.center, 12), (self.outside, 14)
+        ]
+        # rate_matrix = self.sim.rate_matrix
         raise SkipTest
 
     def test_fluxes(self):
+        raise SkipTest
+
+    def test_sim_with_storage(self):
         raise SkipTest

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -195,3 +195,19 @@ class testCommittorSimulation(object):
         assert_true(counts['None-Left'] > 0)
         assert_true(counts['None-Right'] > 0)
         assert_equal(sum(counts.values()), 50)
+
+class testDirectSimulation(object):
+    def setup(self):
+        pass
+
+    def test_run(self):
+        raise SkipTest
+
+    def test_transitions(self):
+        raise SkipTest
+
+    def test_rate_matrix(self):
+        raise SkipTest
+
+    def test_fluxes(self):
+        raise SkipTest

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -281,14 +281,19 @@ class testDirectSimulation(object):
                                            (self.center, right_interface)],
                                initial_snapshot=self.snap0)
         fake_flux_events = {(self.center, right_interface):
-                            [(3, -1), (15, 3), (23, 15), (48, 23)],
+                            [(15, 3), (23, 15), (48, 23)],
                             (self.center, left_interface):
-                            [(34, -1), (97, 34), (160, 97)]}
+                            [(97, 34), (160, 97)]}
         sim.flux_events = fake_flux_events
-        n_flux_events = {(self.center, right_interface): 4,
-                         (self.center, left_interface): 3}
+        n_flux_events = {(self.center, right_interface): 3,
+                         (self.center, left_interface): 2}
         assert_equal(sim.n_flux_events, n_flux_events)
-        raise SkipTest
+        expected_fluxes = {(self.center, right_interface):
+                           1.0 / (((15-3) + (23-15) + (48-23))/3.0),
+                           (self.center, left_interface):
+                           1.0 / (((97-34) + (160-97))/2.0)}
+        for p in expected_fluxes:
+            assert_almost_equal(sim.fluxes[p], expected_fluxes[p])
 
     def test_flux_from_calvinist_dynamics(self):
         # To check for the multiple interface set case, we need to have two 

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -198,9 +198,31 @@ class testCommittorSimulation(object):
 
 class testDirectSimulation(object):
     def setup(self):
-        pass
+        pes = toys.HarmonicOscillator(A=[1.0], omega=[1.0], x0=[0.0])
+        topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
+        self.snap0 = toys.Snapshot(coordinates=np.array([[0.0]]),
+                                   velocities=np.array([[1.0]]),
+                                   topology=topology)
+        integrator = toys.LeapfrogVerletIntegrator(0.1)
+        options = {
+            'integ': integrator,
+            'n_frames_max': 100000,
+            'nsteps_per_frame': 2
+        }
+        self.engine = toys.Engine(options=options, template=self.snap0)
+        cv = paths.CV_Function("Id", lambda snap : snap.coordinates[0][0])
+        self.center = paths.CVRangeVolume(cv, -0.2, 0.2)
+        self.interface = paths.CVRangeVolume(cv, -0.3, 0.3)
+        self.outside = ~paths.CVRangeVolume(cv, -0.9, 0.9)
+        flux_pairs = [(self.center, self.interface)]
+        self.sim = DirectSimulation(storage=None,
+                                    engine=self.engine,
+                                    states=[self.center, self.outside],
+                                    flux_pairs=flux_pairs,
+                                    initial_snapshot=self.snap0)
 
     def test_run(self):
+
         raise SkipTest
 
     def test_transitions(self):

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -245,12 +245,26 @@ class testDirectSimulation(object):
                       (self.extra, self.center): [2]})
 
     def test_rate_matrix(self):
+        self.sim.states += [self.extra]
         self.sim.transition_count = [
             (self.center, 1), (self.outside, 4), (self.center, 7),
             (self.extra, 10), (self.center, 12), (self.outside, 14)
         ]
-        # rate_matrix = self.sim.rate_matrix
-        raise SkipTest
+        rate_matrix = self.sim.rate_matrix.as_matrix()
+        nan = float("nan")
+        test_matrix = np.array([[nan, 1.0/2.5, 1.0/3.0],
+                                [1.0/3.0, nan, nan],
+                                [1.0/2.0, nan, nan]])
+        # for some reason, np.testing.assert_allclose(..., equal_nan=True)
+        # was raising errors on this input. this hack gets the behavior
+        for i in range(len(self.sim.states)):
+            for j in range(len(self.sim.states)):
+                if np.isnan(test_matrix[i][j]):
+                    assert_true(np.isnan(rate_matrix[i][j]))
+                else:
+                    assert_almost_equal(rate_matrix[i][j],
+                                        test_matrix[i][j])
+
 
     def test_fluxes(self):
         raise SkipTest


### PR DESCRIPTION
This PR adds a simulator class for direct MD calculations of the flux through an interface or of the rate. This is useful because MISTIS requires a separate flux calculation. Although we can calculate the flux from an existing trajectory (see `single_trajectory_analysis` and #435), we often want to calculate the flux without saving every frame (especially with toy models). That is possible with this PR.

- [x] Direct MD calculation of flux and rates
- [x] Tests for rates
- [x] Test with Calvinist dynamics
- [x] Tests for flux
- [x] Tests for storage
- [x] Docstrings