### PR TITLE
Tests and cleanup of bootstrapping

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ omit =
     */python?.?/*
     */site-packages/nose/*
     */openpathsampling/tests/*
+    */mdtraj/*
 exclude_lines = 
     pragma: no cover
     def __repr__

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -555,7 +555,7 @@ class MISTISNetwork(TISNetwork):
         unnamed_states = [s for s in list_all_states if not s.is_named]
         name_index = 0
         for state in unnamed_states:
-            while index_to_string(name_index) in all_names:
+            while index_to_string(name_index) in all_state_names:
                 name_index += 1
             state.named(index_to_string(name_index))
             name_index += 1

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -253,7 +253,8 @@ class Bootstrapping(PathSimulator):
             paths.tools.refresh_output(
                 ("Working on Bootstrapping cycle step %d" +
                 " in ensemble %d/%d .\n") %
-                ( self.step, ens_num + 1, len(self.ensembles) )
+                ( self.step, ens_num + 1, len(self.ensembles) ),
+                output_stream=self.output_stream
             )
 
             movepath = bootstrapmove.move(self.globalstate)
@@ -310,10 +311,11 @@ class Bootstrapping(PathSimulator):
         self.sync_storage()
 
         paths.tools.refresh_output(
-                ("DONE! Completed Bootstrapping cycle step %d" +
-                " in ensemble %d/%d .\n") %
-                ( self.step, ens_num + 1, len(self.ensembles) )
-            )
+            ("DONE! Completed Bootstrapping cycle step %d" +
+            " in ensemble %d/%d.\n") %
+            ( self.step, ens_num + 1, len(self.ensembles) ),
+            output_stream=self.output_stream
+        )
 
 
 class FullBootstrapping(PathSimulator):
@@ -322,6 +324,24 @@ class FullBootstrapping(PathSimulator):
     for every ensemble in the transition.
 
     Someday this will be combined with the regular bootstrapping code. 
+
+    Parameters
+    ----------
+    transition : :class:`.TISTransition`
+        the TIS transition to fill by bootstrapping
+    snapshot : :class:`.Snapshot`
+        the initial snapshot
+    storage : :class:`.Storage`
+        storage file to record the steps (optional)
+    engine : :class:`.DynamicsEngine`
+        MD engine to use for dynamics
+    extra_interfaces : list of :class:`.Volume`
+        additional interfaces to make into TIS ensembles (beyond those in
+        the transition)
+    forbidden_staes : list of :class:`.Volume`
+        states that should not be sampled
+    initial_max_length : int
+        maximum length of the initial A->A trajectory
     """
     calc_name = "FullBootstrapping"
 
@@ -421,6 +441,7 @@ class FullBootstrapping(PathSimulator):
             movers=self.transition_shooters + self.extra_shooters,
             trajectory=subtraj
         )
+        bootstrap.output_stream = self.output_stream
         self.output_stream.write("Beginning bootstrapping\n")
         n_rounds = 0
         n_filled = len(bootstrap.globalstate)

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -323,7 +323,7 @@ class FullBootstrapping(PathSimulator):
     Takes a snapshot as input; gives you back a sample set with trajectories
     for every ensemble in the transition.
 
-    Someday this will be combined with the regular bootstrapping code. 
+    This includes
 
     Parameters
     ----------
@@ -338,8 +338,9 @@ class FullBootstrapping(PathSimulator):
     extra_interfaces : list of :class:`.Volume`
         additional interfaces to make into TIS ensembles (beyond those in
         the transition)
-    forbidden_staes : list of :class:`.Volume`
-        states that should not be sampled
+    forbidden_states : list of :class:`.Volume`
+        regions that are disallowed during the initial trajectory. Note that
+        these region *are* allowed during the interface sampling
     initial_max_length : int
         maximum length of the initial A->A trajectory
     """
@@ -459,9 +460,9 @@ class FullBootstrapping(PathSimulator):
                        + " round of " + str(n_steps_per_round) + " steps.")
                 if self.error_max_rounds:
                     raise RuntimeError(msg)
-                else: # pragma: no-cover
+                else: # pragma: no cover
                     logger.warning(msg)
-                break
+                    break
             n_filled = len(bootstrap.globalstate)
 
         return bootstrap.globalstate

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -325,7 +325,8 @@ class FullBootstrapping(PathSimulator):
     calc_name = "FullBootstrapping"
 
     def __init__(self, transition, snapshot, storage=None, engine=None,
-                 extra_interfaces=None, forbidden_states=None, initial_max_length=None):
+                 extra_interfaces=None, forbidden_states=None,
+                 initial_max_length=None):
         super(FullBootstrapping, self).__init__(storage)
         self.engine = engine
         paths.EngineMover.default_engine = engine  # set the default
@@ -353,12 +354,15 @@ class FullBootstrapping(PathSimulator):
         self.initial_max_length = initial_max_length
 
         if self.initial_max_length is not None:
-            self.first_traj_ensemble = paths.LengthEnsemble(slice(0, self.initial_max_length)) & self.first_traj_ensemble
+            self.first_traj_ensemble = (
+                paths.LengthEnsemble(slice(0, self.initial_max_length)) & 
+                self.first_traj_ensemble
+            )
 
-        self.extra_ensembles = [paths.TISEnsemble(transition.stateA,
-                                                  transition.stateB, iface,
-                                                  transition.orderparameter)
-                                for iface in extra_interfaces
+        self.extra_ensembles = [
+            paths.TISEnsemble(transition.stateA, transition.stateB, iface,
+                              transition.orderparameter)
+            for iface in extra_interfaces
         ]
 
         self.transition_shooters = [
@@ -381,7 +385,8 @@ class FullBootstrapping(PathSimulator):
         self.error_max_rounds = True
 
 
-    def run(self, max_ensemble_rounds=None, n_steps_per_round=20, build_attempts = 20):
+    def run(self, max_ensemble_rounds=None, n_steps_per_round=20,
+            build_attempts=20):
         #print first_traj_ensemble #DEBUG
         has_AA_path = False
         while not has_AA_path:

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -436,7 +436,7 @@ class FullBootstrapping(PathSimulator):
                        + " round of " + str(n_steps_per_round) + " steps.")
                 if self.error_max_rounds:
                     raise RuntimeError(msg)
-                else:
+                else: # pragma: no-cover
                     logger.warning(msg)
                 break
             n_filled = len(bootstrap.globalstate)

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -30,7 +30,7 @@ class testFullBootstrapping(object):
         self.stateB = paths.CVRangeVolume(self.cv, 1.0, 2.0)
         self.stateC = paths.CVRangeVolume(self.cv, 3.0, 4.0)
         interfacesAB = paths.VolumeFactory.CVRangeVolumeSet(
-            self.cv, 0.0, [0.0, 0.1, 0.2]
+            self.cv, -1.0, [0.0, 0.1, 0.2]
         )
         interfacesBC = paths.VolumeFactory.CVRangeVolumeSet(
             self.cv, 1.0, [2.0, 2.1, 2.2]
@@ -55,23 +55,40 @@ class testFullBootstrapping(object):
             snapshot=self.snapA
         )
 
+    @raises(RuntimeError)
     def test_initial_max_length(self):
-        pass
+        engine = CalvinistDynamics([-0.5, -0.4, -0.3, -0.2, -0.1, 0.1, -0.1])
+        bootstrap_AB_maxlength = paths.FullBootstrapping(
+            transition=self.tisAB,
+            snapshot=self.snapA,
+            initial_max_length = 3,
+            engine=engine
+        )
+        gs = bootstrap_AB_maxlength.run(build_attempts=1)
 
     def test_first_traj_ensemble(self):
-        pass
+        traj_starts_in = make_1d_traj([-0.2, -0.1, 0.1, -0.1])
+        traj_starts_out = make_1d_traj([0.1, -0.1, 0.1, -0.1])
+        traj_not_good = make_1d_traj([0.1, -0.1, 0.1])
+        first_traj_ens = self.noforbid_noextra_AB.first_traj_ensemble
+        assert_equal(first_traj_ens(traj_starts_in), True)
+        assert_equal(first_traj_ens(traj_starts_out), True)
+        assert_equal(first_traj_ens(traj_not_good), False)
 
     def test_sampling_ensembles(self):
-        pass
+        raise SkipTest
 
     def test_run_already_satisfied(self):
-        pass
+        raise SkipTest
 
-    def test_build_attempts_fail(self):
-        pass
+    def test_run_extra_ensembles(self):
+        raise SkipTest
+
+    def test_run_forbidden_ensembles(self):
+        raise SkipTest
 
     def test_too_much_bootstrapping(self):
-        pass
+        raise SkipTest
 
 class testCommittorSimulation(object):
     def setup(self):

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -118,7 +118,30 @@ class testFullBootstrapping(object):
         assert_equal(len(gs), 4)
 
     def test_run_forbidden_states(self):
-        raise SkipTest
+        engine = CalvinistDynamics([-0.5, 0.3, 3.2, -0.1, 0.8, -0.1])
+        # first, without setting forbidden_states
+        bootstrap1 = FullBootstrapping(
+            transition=self.tisAB,
+            snapshot=self.snapA,
+            engine=engine
+        )
+        bootstrap1.output_stream = open(os.devnull, "w")
+        gs1 = bootstrap1.run()
+        assert_equal(len(gs1), 3)
+        assert_items_equal(self.cv(gs1[0]), [-0.5, 0.3, 3.2, -0.1])
+        # now with setting forbidden_states
+        bootstrap2 = FullBootstrapping(
+            transition=self.tisAB,
+            snapshot=self.snapA,
+            engine=engine,
+            forbidden_states=[self.stateC]
+        )
+        bootstrap2.output_stream = open(os.devnull, "w")
+        # make sure this is where we get the error
+        try:
+            gs2 = bootstrap2.run()
+        except RuntimeError:
+            pass
 
     @raises(RuntimeError)
     def test_too_much_bootstrapping(self):

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -95,16 +95,41 @@ class testFullBootstrapping(object):
         assert_equal(all_ensembles[2](traj3), False)
 
     def test_run_already_satisfied(self):
-        raise SkipTest
+        engine = CalvinistDynamics([-0.5, 0.8, -0.1])
+        bootstrap = FullBootstrapping(
+            transition=self.tisAB,
+            snapshot=self.snapA,
+            engine=engine
+        )
+        bootstrap.output_stream = open(os.devnull, "w")
+        gs = bootstrap.run()
+        assert_equal(len(gs), 3)
 
     def test_run_extra_interfaces(self):
-        raise SkipTest
+        engine = CalvinistDynamics([-0.5, 0.8, -0.1])
+        bootstrap = FullBootstrapping(
+            transition=self.tisAB,
+            snapshot=self.snapA,
+            engine=engine,
+            extra_interfaces=[paths.CVRangeVolume(self.cv, -1.0, 0.6)]
+        )
+        bootstrap.output_stream = open(os.devnull, "w")
+        gs = bootstrap.run()
+        assert_equal(len(gs), 4)
 
     def test_run_forbidden_states(self):
         raise SkipTest
 
+    @raises(RuntimeError)
     def test_too_much_bootstrapping(self):
-        raise SkipTest
+        engine = CalvinistDynamics([-0.5, 0.2, -0.1])
+        bootstrap = FullBootstrapping(
+            transition=self.tisAB,
+            snapshot=self.snapA,
+            engine=engine,
+        )
+        bootstrap.output_stream = open(os.devnull, "w")
+        gs = bootstrap.run(max_ensemble_rounds=1)
 
 class testCommittorSimulation(object):
     def setup(self):

--- a/openpathsampling/tools.py
+++ b/openpathsampling/tools.py
@@ -3,14 +3,17 @@ import sys
 __author__ = 'Jan-Hendrik Prinz'
 
 
-def refresh_output(output_str, print_anyway=True, refresh=True):
+def refresh_output(output_str, print_anyway=True, refresh=True,
+                   output_stream=None):
+    if output_stream is None:
+        output_stream = sys.stdout
     try:
         import IPython.display
     except ImportError:
         if print_anyway:
-            print(output_str)
+            output_stream.write(output_str)
     else:
         if refresh:
             IPython.display.clear_output(wait=True)
-        print(output_str)
+        output_stream.write(output_str)
     sys.stdout.flush()


### PR DESCRIPTION
When I started writing the section of the paper on the toy model MISTIS and the bootstrapping, I found that a few details that were a bit confusing. I think this may have led to some confusion in the stuff that Abel was doing. To make sure that the behavior in the code matches what I write in the paper, I’m writing tests for the bootstrapping.

This may also lead to some changes in the behavior of the `FullBoostrapping`, and possibly in the `MISTISNetwork`. I think I’ve occasionally seen bad initial conditions in the MISTIS ipynb test, causing annoying failures. I’m hoping that this PR might fix that. At the very least, it will give a nice bump to our test coverage, and ensure that our paper matches our code!

- [x] Tests for the `first_traj_ensemble`
- [x] Tests for the sampling ensembles
- [x] Change output of `FullBootstrap` & `Bootstrap` to file/stream based (so we can write to `/dev/null` or `stdout` depending on what we want)
- [x] Tests when extra interfaces exist
- [x] Tests when forbidden states exist
- [x] Tests when bootstrapping fails from too many attempts
- [x] Add numpydoc docstrings to FullBootstrapping