### PR TITLE
Enable upload to Anaconda/Omnia after build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,22 @@
 language: python
-
 python:
-  # We don't actually use the Travis Python, but this keeps it organized.
-  - "2.7"
-
+- '2.7'
 install:
-  - deactivate
-  # Sets up a MINIConda enviroment in the name of the selected python version
-  - source devtools/ci/install.sh
-  # Do not buffer output of python outputs but flush them directly to the terminal
-  - export PYTHONUNBUFFERED=true
-
+- deactivate
+- source devtools/ci/install.sh
+- export PYTHONUNBUFFERED=true
 script:
-  - echo travis_fold:start:conda.build.package
-  - conda install --yes conda-build
-  - conda build devtools/conda-recipe
-  - echo travis_fold:end:conda.build.package
-
-  # Run tests in _test environment
-  - source activate _test
-  - source devtools/ci/git_hash.sh
-  - source devtools/ci/nosetests.sh
-  - source devtools/ci/ipythontests.sh
-
-  # Upload new docs
-  - bash -x devtools/ci/after_sucess.sh
-
+- echo travis_fold:start:conda.build.package
+- conda install --yes conda-build
+- conda build devtools/conda-recipe
+- echo travis_fold:end:conda.build.package
+- source activate _test
+- source devtools/ci/git_hash.sh
+- source devtools/ci/nosetests.sh
+- source devtools/ci/ipythontests.sh
+- bash -x devtools/ci/after_sucess.sh
 env:
   matrix:
-    - python=2.7  CONDA_PY=27  CONDA_NPY=110
-# - python=3.4  CONDA_PY=34  CONDA_NPY=110
-# - python=3.5  CONDA_PY=35  CONDA_NPY=110
-
+  - python=2.7  CONDA_PY=27  CONDA_NPY=110
   global:
-    # encrypted BINSTAR_TOKEN for push of dev package to binstar
-    - secure: "Ou9KukGxCOdNWvEpr+9YrWTlB0xezu1mNV1gXtFjJ0RDIvzPRGUkpU7AUAdKwn6fUcbzq5E1y6rU9aG/QQe9YZkRHhPo585ZzieTNa0UxsyINk7XuwxL7MpRZijHCHFBvRVNrXkIh3CtmXvZS2ksAa8+FuYiO/lBbOMZ0nNAJac="
-    - secure: "NJvoSrLNd2ZR3HluJjEqI36gD5lsucwIvgnYjNmM4cwnnA77aLV9FRYTwlLRZn3XY9FL8KOzL5l0amNzMD7sQrf7bWwWv7iCUBddH549q9RSgiuOugtodYJ6VaXi76hk1rOgcJpDoCj9wTCIlMtWibPUzr1QHmdihfdM2iA2kkE="
-    - secure: "l9NJkZDD0ALhkErUvhRrreLsrcWErd+CXpWv8dxHGtkjemNx6CwVtyL+a30jz/QwMANSZbKll/cPK5yJQvuwDaWxja6UPLLKVNGtma+CmwKcIC/wwTwbMoxcS62fyLJ3kS0qR8oCQz2nCPKiYyRGADtPLWVMZckY1SJfNYcKuCM="
+  - secure: kb37xmsSV3pEnESnINzwlW2Cju/UFzA/G+m+NsihAwO8RMPZwKCrZK/rptgkUDACXJxom5M690WEukQkHnOt+OTrWhu7WKZgYeVuWUs2++RohYv/m5npaOHMMn+uYmF328v4PvPmXxbD02zzg5Tgdn82x8oa6J8BKX8ohOQ6Xpg=

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     echo "This is a pull request. No deployment will be done."; exit 0
 fi
@@ -6,18 +7,22 @@ if [[ "$TRAVIS_BRANCH" != "master" ]]; then
     echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
 fi
 
-#echo travis_fold:start:binstar.upload
-#if [[ "2.7" =~ "$python" ]]; then
-#    conda install --yes anaconda-client jinja2
-#        conda convert -p all ~/miniconda2/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda2/conda-bld/
-#    anaconda -t ${BINSTAR_TOKEN}  upload  --force -u omnia -p openpathsampling-dev $HOME/miniconda2/conda-bld/*/openpathsampling-dev*.tar.bz2
-#fi
-#
-#if [[ "$python" != "2.7" ]]; then
-#    echo "No deploy on PYTHON_VERSION=${python}"; exit 0
-#fi
-#
-#echo travis_fold:end:binstar.upload
+PACKAGE_NAME=openpathsampling-dev
+GROUP_NAME=omnia
+BUILD_PATH=~/miniconda2/conda-bld
+
+echo travis_fold:start:binstar.upload
+if [[ "2.7" =~ "$python" ]]; then
+    conda install --yes anaconda-client jinja2
+    conda convert -p all ${BUILD_PATH}/linux-64/${PACKAGE_NAME}*.tar.bz2 -o ${BUILD_PATH}/
+    anaconda -t ${ANACONDA_TOKEN}  upload  --force -u ${GROUP_NAME} -p ${PACKAGE_NAME} ${BUILD_PATH}/*/${PACKAGE_NAME}*.tar.bz2
+fi
+
+if [[ "$python" != "2.7" ]]; then
+    echo "No deploy on PYTHON_VERSION=${python}"; exit 0
+fi
+
+echo travis_fold:end:binstar.upload
 
 echo travis_fold:start:build.docs
 # Create the docs and push them to S3

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # This script was taken from https://github.com/pandegroup/mdtraj/tree/master/devtools
 
-sudo apt-get update
+# sudo apt-get update
 
 ### Install Miniconda
 


### PR DESCRIPTION
Resolves #487.

This will reenable conda upload. Not sure if that is what we want, but I created a new TOKEN and updated the `after_success.py` script to upload a merge on master if it was successful.