### PR TITLE
Retire alanine.ipynb

### DIFF
--- a/devtools/ci/ipythontests.sh
+++ b/devtools/ci/ipythontests.sh
@@ -19,8 +19,8 @@ ipynbtest.py "mistis_analysis.ipynb" || testfail=1
 date
 ipynbtest.py --strict "test_openmm_integration.ipynb" || testfail=1
 date
-ipynbtest.py "alanine.ipynb" || testfail=1
-date
+#ipynbtest.py "alanine.ipynb" || testfail=1
+#date
 ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
 
 # needs to run after alanine since it need the trajectory.nc file
@@ -32,6 +32,7 @@ date
 ipynbtest.py --strict "test_cv.ipynb" || testfail=1
 date
 ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
+
 
 # python ipynbtest.py "visualization.ipynb" || testfail=1
 cd ../..

--- a/examples/ipython/test_openmm_integration.ipynb
+++ b/examples/ipython/test_openmm_integration.ipynb
@@ -242,20 +242,20 @@
       " [ 0.14886747  0.25747473 -0.08926164]\n",
       " [ 0.33994537  0.26638274  0.00609843]\n",
       " [ 0.42709578  0.1897011   0.04380051]\n",
-      " [ 0.36886493  0.38998331 -0.03181561]\n",
+      " [ 0.36886493  0.38998331 -0.03181562]\n",
       " [ 0.293367    0.452431   -0.05633815]\n",
       " [ 0.49859312  0.4565761  -0.02400124]\n",
       " [ 0.5581438   0.41515287  0.0573552 ]\n",
       " [ 0.5732535   0.43391328 -0.15561179]\n",
       " [ 0.5191127   0.48312774 -0.23640657]\n",
-      " [ 0.67427683  0.47320502 -0.14414124]\n",
+      " [ 0.67427683  0.47320502 -0.14414125]\n",
       " [ 0.58423055  0.32728151 -0.17536463]\n",
       " [ 0.4749522   0.60669039 -0.00127668]\n",
-      " [ 0.359584    0.64924202  0.00474684]\n",
+      " [ 0.35958399  0.64924202  0.00474684]\n",
       " [ 0.5835927   0.68379167  0.00902624]\n",
       " [ 0.6747424   0.64066121  0.00332412]\n",
       " [ 0.57127444  0.82897221  0.01853087]\n",
-      " [ 0.46718868  0.86095438  0.02347778]\n",
+      " [ 0.46718868  0.86095438  0.02347777]\n",
       " [ 0.62214258  0.86301533  0.10872177]\n",
       " [ 0.61715852  0.87434251 -0.06931573]] nm\n"
      ]
@@ -343,7 +343,7 @@
     {
      "data": {
       "text/plain": [
-       "u'{\"_cls\": \"OpenMMEngine\", \"_dict\": {\"integrator_xml\": \"<?xml version=\\\\\"1.0\\\\\" ?>\\\\n<Integrator constraintTolerance=\\\\\"1e-05\\\\\" stepSize=\\\\\".002\\\\\" type=\\\\\"VerletIntegrator\\\\\" version=\\\\\"1\\\\\"/>\\\\n\", \"options\": {\"timestep\": null, \"n_frames_max\": 5000, \"platform\": \"CPU\",...'"
+       "u'{\"_cls\": \"OpenMMEngine\", \"_dict\": {\"integrator_xml\": \"<?xml version=\\\\\"1.0\\\\\" ?>\\\\n<Integrator constraintTolerance=\\\\\"1e-05\\\\\" stepSize=\\\\\".002\\\\\" type=\\\\\"VerletIntegrator\\\\\" version=\\\\\"1\\\\\"/>\\\\n\", \"system_xml\": \"<?xml version=\\\\\"1.0\\\\\" ?>\\\\n<System openmmVersion=\\\\\"7.0\\\\\"...'"
       ]
      },
      "execution_count": 15,
@@ -359,6 +359,28 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(store.trajectories[Trajectory], 0, 0)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "st.save(traj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -376,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -387,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -405,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -416,7 +438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -435,12 +457,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
+    "st.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And save the trajectory for future use (other tests)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "st = paths.Storage('engine_store_test.nc', \"a\")\n",
+    "st.save(traj)\n",
     "st.close()"
    ]
   },

--- a/examples/ipython/test_pyemma.ipynb
+++ b/examples/ipython/test_pyemma.ipynb
@@ -36,18 +36,10 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "04-03-16 12:01:10 openpathsampling.netcdfplus.netcdfplus INFO     Open existing netCDF file 'trajectory.nc' for appending - appending existing file\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#! lazy\n",
-    "storage = paths.Storage('trajectory.nc', mode='a')"
+    "storage = paths.Storage('engine_store_test.nc', mode='a')"
    ]
   },
   {
@@ -123,7 +115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(store.cvs[CollectiveVariable], 6, 6)\n"
+      "(store.cvs[CollectiveVariable], 6, 0)\n"
      ]
     }
    ],
@@ -146,7 +138,7 @@
    },
    "outputs": [],
    "source": [
-    "cv(storage.trajectories[2]);"
+    "cv(storage.trajectories[1]);"
    ]
   },
   {
@@ -273,13 +265,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ u'{\"_cls\": \"CV_Function\", \"_dict\": {\"name\": \"psi2\", \"f\": {\"_marshal\": \"YwMAAAADAAAAAwAAAEMAAABzHAAAAHwBAHwAAIMBAGQBABN8AgB8AACDAQBkAQATF1MoAgAAAE5pAgAAACgAAAAAKAMAAAB0BAAAAGl0ZW10AwAAAHBzaXQDAAAAcGhpKAAAAAAoAAAAAHMeAAAAPGlweXRob24taW5wdXQtOC00NGFmZmMyZGY1MzU+dAcAAABwcDJfZm5jAQAAAHMCAAAAAAE=\", \"_module_vars\": [], \"_global_vars\": []}, \"cv_store_cache\": true, \"cv_time_reversible\": false, \"cv_wrap_numpy_array\": false, \"cv_requires_lists\": false, \"cv_scalarize_numpy_singletons\": false, \"kwargs\": {\"phi\": {\"_obj\": \"cvs\", \"_idx\": 1}, \"psi\": {\"_obj\": \"cvs\", \"_idx\": 2}}}}'\n",
-      " u'{\"_cls\": \"CV_MDTraj_Function\", \"_dict\": {\"name\": \"phi\", \"f\": {\"_module\": \"mdtraj.geometry.dihedral\", \"_name\": \"compute_dihedrals\"}, \"cv_store_cache\": true, \"cv_time_reversible\": true, \"cv_wrap_numpy_array\": true, \"cv_requires_lists\": true, \"cv_scalarize_numpy_singletons\": true, \"kwargs\": {\"indices\": [[4, 6, 8, 14]]}}}'\n",
-      " u'{\"_cls\": \"CV_MDTraj_Function\", \"_dict\": {\"name\": \"psi\", \"f\": {\"_module\": \"mdtraj.geometry.dihedral\", \"_name\": \"compute_dihedrals\"}, \"cv_store_cache\": true, \"cv_time_reversible\": true, \"cv_wrap_numpy_array\": true, \"cv_requires_lists\": true, \"cv_scalarize_numpy_singletons\": true, \"kwargs\": {\"indices\": [[6, 8, 14, 16]]}}}'\n",
-      " u'{\"_cls\": \"CV_Volume\", \"_dict\": {\"cv_store_cache\": true, \"volume\": {\"_obj\": \"volumes\", \"_idx\": 0}, \"name\": \"StateA\"}}'\n",
-      " u'{\"_cls\": \"CV_Volume\", \"_dict\": {\"cv_store_cache\": true, \"volume\": {\"_obj\": \"volumes\", \"_idx\": 1}, \"name\": \"StateB\"}}'\n",
-      " u'{\"_cls\": \"CV_Volume\", \"_dict\": {\"cv_store_cache\": true, \"volume\": {\"_obj\": \"volumes\", \"_idx\": 26}, \"name\": \"StateX\"}}'\n",
-      " u'{\"_cls\": \"CV_PyEMMA_Featurizer\", \"_dict\": {\"cv_store_cache\": true, \"topology\": {\"_obj\": \"topologies\", \"_idx\": 0}, \"name\": \"pyemma\", \"featurizer\": {\"_marshal\": \"YwEAAAABAAAAAwAAAEMAAABzIAAAAHwAAGoAAHwAAGoBAHwAAGoCAIMAAIMBAIMBAAFkAABTKAEAAABOKAMAAAB0FQAAAGFkZF9pbnZlcnNlX2Rpc3RhbmNlc3QFAAAAcGFpcnN0DwAAAHNlbGVjdF9CYWNrYm9uZSgBAAAAdAEAAABmKAAAAAAoAAAAAHMeAAAAPGlweXRob24taW5wdXQtNC00Nzc0ZDhlZGRkMDA+dBAAAABweWVtbWFfZ2VuZXJhdG9yAQAAAHMCAAAAAAE=\", \"_module_vars\": [], \"_global_vars\": []}, \"kwargs\": {}}}']\n"
+      "[ u'{\"_cls\": \"CV_PyEMMA_Featurizer\", \"_dict\": {\"cv_store_cache\": true, \"topology\": {\"_obj\": \"topologies\", \"_idx\": 0}, \"name\": \"pyemma\", \"featurizer\": {\"_marshal\": \"YwEAAAABAAAAAwAAAEMAAABzIAAAAHwAAGoAAHwAAGoBAHwAAGoCAIMAAIMBAIMBAAFkAABTKAEAAABOKAMAAAB0FQAAAGFkZF9pbnZlcnNlX2Rpc3RhbmNlc3QFAAAAcGFpcnN0DwAAAHNlbGVjdF9CYWNrYm9uZSgBAAAAdAEAAABmKAAAAAAoAAAAAHMeAAAAPGlweXRob24taW5wdXQtNC00Nzc0ZDhlZGRkMDA+dBAAAABweWVtbWFfZ2VuZXJhdG9yAQAAAHMCAAAAAAE=\", \"_module_vars\": [], \"_global_vars\": []}, \"kwargs\": {}}}']\n"
      ]
     }
    ],
@@ -299,7 +285,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6\n"
+      "0\n"
      ]
     }
    ],
@@ -331,10 +317,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[ 3.03981256  2.99009299]\n",
-      " [ 3.18913245  3.10045004]\n",
-      " [ 3.00194454  2.95937991]\n",
-      " [ 3.0536685   2.96377301]]\n"
+      "[[ 2.68972969  2.06547379]\n",
+      " [ 2.61396813  2.00944018]]\n"
      ]
     }
    ],
@@ -342,15 +326,6 @@
     "#! lazy\n",
     "print erg[0::25,2:4]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/examples/ipython/tutorial_storage.ipynb
+++ b/examples/ipython/tutorial_storage.ipynb
@@ -63,7 +63,7 @@
     {
      "data": {
       "text/plain": [
-       "Storage @ 'trajectory.nc'"
+       "Storage @ 'mstis.nc'"
       ]
      },
      "execution_count": 2,
@@ -72,7 +72,7 @@
     }
    ],
    "source": [
-    "storage = paths.Storage('trajectory.nc')\n",
+    "storage = paths.Storage('mstis.nc')\n",
     "storage"
    ]
   },
@@ -94,7 +94,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'schemes', 'stores', u'snapshots', u'tag', u'transitions', u'networks', u'ensembles', u'engines', u'topologies', u'pathmovers', u'details', u'samples', u'statics', u'trajectories', u'pathmovechanges', u'shootingpointselectors', u'pathsimulators', u'kinetics', u'cvs', u'steps', u'volumes', u'samplesets']\n"
+      "[u'transitions', 'stores', u'samples', u'engines', u'topologies', u'pathsimulators', u'trajectories', u'tag', u'cvs', u'snapshots', u'pathmovers', u'schemes', u'steps', u'details', u'pathmovechanges', u'shootingpointselectors', u'volumes', u'samplesets', u'networks', u'ensembles']\n"
      ]
     }
    ],
@@ -124,16 +124,16 @@
     {
      "data": {
       "text/plain": [
-       "[1.9918975,\n",
-       " 1.7917405,\n",
-       " 1.9266806,\n",
-       " 2.0645561,\n",
-       " 2.1895022,\n",
-       " 2.4010296,\n",
-       " 1.9002941,\n",
-       " 1.8658323,\n",
-       " 1.8267705,\n",
-       " 1.483196]"
+       "[0.033847045203725376,\n",
+       " 0.040653559359746509,\n",
+       " 0.047348446105937185,\n",
+       " 0.053970170061407426,\n",
+       " 0.060299940069028529,\n",
+       " 0.065879194781825551,\n",
+       " 0.071242734923218337,\n",
+       " 0.075907719416307654,\n",
+       " 0.080415425559051124,\n",
+       " 0.085336078351615219]"
       ]
      },
      "execution_count": 5,
@@ -190,7 +190,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We have 80 snapshots in our storage\n"
+      "We have 55746 snapshots in our storage\n"
      ]
     }
    ],
@@ -230,7 +230,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[<Sample @ 0x12987ae10>, <Sample @ 0x129b21490>]\n"
+      "[<Sample @ 0x113686a10>, <Sample @ 0x11372ff10>]\n"
      ]
     }
    ],
@@ -256,7 +256,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[<openpathsampling.ensemble.TISEnsemble object at 0x12987a050>, <openpathsampling.ensemble.IntersectionEnsemble object at 0x129b21a10>, <openpathsampling.ensemble.AllInXEnsemble object at 0x129b21a50>]\n"
+      "[<openpathsampling.ensemble.TISEnsemble object at 0x10711f550>, <openpathsampling.ensemble.IntersectionEnsemble object at 0x11372d790>, <openpathsampling.ensemble.AllInXEnsemble object at 0x10be702d0>]\n"
      ]
     }
    ],
@@ -360,7 +360,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"_cls\": \"CVRangeVolumePeriodic\", \"_dict\": {\"period_min\": -3.14159265, \"collectivevariable\": {\"_obj\": \"cvs\", \"_idx\": 2}, \"lambda_max\": -3.14159265, \"lambda_min\": 1.7453292500000006, \"period_max\": 3.14159265}}\n"
+      "{\"_cls\": \"CVRangeVolume\", \"_dict\": {\"collectivevariable\": {\"_obj\": \"cvs\", \"_idx\": 0}, \"lambda_max\": 0.04000000000000001, \"lambda_min\": 0.0}}\n"
      ]
     }
    ],
@@ -394,12 +394,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Interface 1\n"
+      "A\n"
      ]
     }
    ],
    "source": [
-    "print storage.ensembles['Interface 1'].name"
+    "print storage.volumes['A'].name"
    ]
   },
   {
@@ -420,12 +420,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Interface 1\n"
+      "A\n"
      ]
     }
    ],
    "source": [
-    "print storage.ensembles.find('Interface 1').name"
+    "print storage.volumes.find('A').name"
    ]
   },
   {
@@ -446,12 +446,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[<openpathsampling.ensemble.TISEnsemble object at 0x10535a910>]\n"
+      "[<openpathsampling.volume.CVRangeVolume object at 0x11372f150>]\n"
      ]
     }
    ],
    "source": [
-    "print storage.ensembles.find_all('Interface 1')"
+    "print storage.volumes.find_all('A')"
    ]
   },
   {
@@ -472,12 +472,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[10]\n"
+      "[4]\n"
      ]
     }
    ],
    "source": [
-    "print storage.ensembles.find_indices('Interface 1')"
+    "print storage.volumes.find_indices('A')"
    ]
   },
   {
@@ -497,13 +497,13 @@
     {
      "data": {
       "text/plain": [
-       "{'Interface 0': {0},\n",
-       " 'Interface 1': {10},\n",
-       " 'Interface 2': {20},\n",
-       " 'Interface 3': {30},\n",
-       " 'Interface 4': {40},\n",
-       " 'Interface 5': {50},\n",
-       " 'Interface 6': {60}}"
+       "{'A': {4},\n",
+       " 'B': {5},\n",
+       " 'C': {0},\n",
+       " 'all states': {35},\n",
+       " 'all states except A': {15},\n",
+       " 'all states except B': {25},\n",
+       " 'all states except C': {3}}"
       ]
      },
      "execution_count": 18,
@@ -512,7 +512,7 @@
     }
    ],
    "source": [
-    "storage.ensembles.name_idx"
+    "storage.volumes.name_idx"
    ]
   },
   {
@@ -551,7 +551,7 @@
     {
      "data": {
       "text/plain": [
-       "70"
+       "157"
       ]
      },
      "execution_count": 20,
@@ -574,7 +574,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "70\n"
+      "157\n"
      ]
     }
    ],
@@ -593,7 +593,16 @@
     {
      "data": {
       "text/plain": [
-       "array([u'{\"_cls\": \"EmptyEnsemble\", \"_dict\": {}}'], dtype=object)"
+       "array([ u'{\"_cls\": \"TISEnsemble\", \"_dict\": {\"orderparameter\": {\"_obj\": \"cvs\", \"_idx\": 2}, \"ensembles\": [{\"_obj\": \"ensembles\", \"_idx\": 71}, {\"_obj\": \"ensembles\", \"_idx\": 74}, {\"_obj\": \"ensembles\", \"_idx\": 77}], \"min_overlap\": {\"_tuple\": [0, 0]}, \"max_overlap\": {\"_tuple\": [0, 0]}, \"greedy\": false, \"final_states\": [{\"_obj\": \"volumes\", \"_idx\": 25}], \"interface\": {\"_obj\": \"volumes\", \"_idx\": 27}, \"initial_states\": [{\"_obj\": \"volumes\", \"_idx\": 5}]}}',\n",
+       "       u'{\"_cls\": \"IntersectionEnsemble\", \"_dict\": {\"ensemble2\": {\"_obj\": \"ensembles\", \"_idx\": 72}, \"ensemble1\": {\"_obj\": \"ensembles\", \"_idx\": 73}}}',\n",
+       "       u'{\"_cls\": \"LengthEnsemble\", \"_dict\": {\"length\": 1}}',\n",
+       "       u'{\"_cls\": \"AllInXEnsemble\", \"_dict\": {\"volume\": {\"_obj\": \"volumes\", \"_idx\": 5}, \"trusted\": true}}',\n",
+       "       u'{\"_cls\": \"IntersectionEnsemble\", \"_dict\": {\"ensemble2\": {\"_obj\": \"ensembles\", \"_idx\": 75}, \"ensemble1\": {\"_obj\": \"ensembles\", \"_idx\": 76}}}',\n",
+       "       u'{\"_cls\": \"PartOutXEnsemble\", \"_dict\": {\"volume\": {\"_obj\": \"volumes\", \"_idx\": 27}, \"trusted\": true}}',\n",
+       "       u'{\"_cls\": \"AllOutXEnsemble\", \"_dict\": {\"volume\": {\"_obj\": \"volumes\", \"_idx\": 28}, \"trusted\": true}}',\n",
+       "       u'{\"_cls\": \"IntersectionEnsemble\", \"_dict\": {\"ensemble2\": {\"_obj\": \"ensembles\", \"_idx\": 78}, \"ensemble1\": {\"_obj\": \"ensembles\", \"_idx\": 79}}}',\n",
+       "       u'{\"_cls\": \"LengthEnsemble\", \"_dict\": {\"length\": 1}}',\n",
+       "       u'{\"_cls\": \"AllInXEnsemble\", \"_dict\": {\"volume\": {\"_obj\": \"volumes\", \"_idx\": 29}, \"trusted\": true}}'], dtype=object)"
       ]
      },
      "execution_count": 22,
@@ -622,7 +631,7 @@
     {
      "data": {
       "text/plain": [
-       "71"
+       "158"
       ]
      },
      "execution_count": 23,
@@ -687,7 +696,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5\n"
+      "1\n"
      ]
     }
    ],
@@ -706,10 +715,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "states\n",
-      "stateB\n",
-      "stateA\n",
-      "first_path\n",
       "template\n"
      ]
     }
@@ -729,7 +734,7 @@
     {
      "data": {
       "text/plain": [
-       "['states', 'stateB', 'stateA', 'first_path', 'template']"
+       "['template']"
       ]
      },
      "execution_count": 27,
@@ -752,11 +757,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "states               : list                \n",
-      "stateB               : CVRangeVolumePeriodic\n",
-      "stateA               : CVRangeVolumePeriodic\n",
-      "first_path           : Trajectory          \n",
-      "template             : Snapshot            \n"
+      "template             : ToySnapshot         \n"
      ]
     }
    ],
@@ -775,12 +776,7 @@
     {
      "data": {
       "text/plain": [
-       "{'first_path': Trajectory[16],\n",
-       " 'stateA': <openpathsampling.volume.CVRangeVolumePeriodic at 0x125d8c0d0>,\n",
-       " 'stateB': <openpathsampling.volume.CVRangeVolumePeriodic at 0x129b21410>,\n",
-       " 'states': [<openpathsampling.volume.CVRangeVolumePeriodic at 0x125d8c0d0>,\n",
-       "  <openpathsampling.volume.CVRangeVolumePeriodic at 0x129b21410>],\n",
-       " 'template': <openpathsampling.dynamics.openmm.snapshot.Snapshot at 0x125d8cc90>}"
+       "{'template': <abc.ToySnapshot at 0x113679950>}"
       ]
      },
      "execution_count": 29,
@@ -899,14 +895,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We found 34 snapshots in StateA among 80 total ones\n"
+      "We found 222 snapshots in StateA among 5000 total snapshots\n"
      ]
     }
    ],
    "source": [
-    "stA = storage.cvs['StateA']\n",
-    "reversed_samples = [snapshot for snapshot in storage.snapshots if stA(snapshot)]\n",
-    "print 'We found %d snapshots in StateA among %d total ones' % (len(reversed_samples), len(storage.snapshots))"
+    "stA = storage.volumes['A']\n",
+    "first_5000_snaps = storage.snapshots[0:5000]\n",
+    "reversed_samples = [snapshot for snapshot in first_5000_snaps if stA(snapshot)]\n",
+    "print 'We found %d snapshots in StateA among %d total snapshots' % (len(reversed_samples), len(first_5000_snaps))"
    ]
   },
   {
@@ -929,7 +926,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<openpathsampling.sample.SampleSet object at 0x12987a2d0>\n"
+      "<openpathsampling.sample.SampleSet object at 0x11374b190>\n"
      ]
     }
    ],
@@ -948,12 +945,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8\n"
+      "501\n"
      ]
     }
    ],
    "source": [
-    "my_ensemble = storage.ensembles['Interface 0']\n",
+    "my_network = storage.networks[0]\n",
+    "my_ensemble = my_network.sampling_ensembles[0]\n",
     "relevant_samples = [\n",
     "    sample \n",
     "    for sample_set in storage.samplesets \n",
@@ -981,8 +979,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[6, 8, 8, 8, 8, 8, 8, 8]\n",
-      "7.75\n"
+      "[33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 65, 65, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 34, 34, 34, 34, 34, 34, 34, 35, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 63, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 24, 24, 24, 24, 12, 12, 12, 12, 12, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 118, 118, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 126, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 47, 56, 56, 56, 40, 40, 40, 40, 40, 40, 40, 43, 43, 43, 43, 43, 43, 43, 43, 43, 41, 41, 41, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 13, 13, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 17, 17, 17, 17, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27]\n",
+      "43.4431137725\n"
      ]
     }
    ],
@@ -1033,7 +1031,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "62.0\n"
+      "21765.0\n"
      ]
     }
    ],
@@ -1066,7 +1064,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7.75\n"
+      "43.4431137725\n"
      ]
     }
    ],
@@ -1125,13 +1123,16 @@
     {
      "data": {
       "text/plain": [
-       "[<openpathsampling.pathmover.ForwardShootMover at 0x125d80f90>,\n",
-       " <openpathsampling.pathmover.ForwardShootMover at 0x1298bd350>,\n",
-       " <openpathsampling.pathmover.ForwardShootMover at 0x1298dbb10>,\n",
-       " <openpathsampling.pathmover.ForwardShootMover at 0x129bc9fd0>,\n",
-       " <openpathsampling.pathmover.ForwardShootMover at 0x1298dbd90>,\n",
-       " <openpathsampling.pathmover.ForwardShootMover at 0x1298fdd10>,\n",
-       " <openpathsampling.pathmover.ForwardShootMover at 0x1298dbe50>]"
+       "[<openpathsampling.pathmover.ForwardShootMover at 0x114062790>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x11408ff10>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x114296610>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x114091a10>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x114091cd0>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x11408f550>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x114062ed0>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x11400fa50>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x114296290>,\n",
+       " <openpathsampling.pathmover.ForwardShootMover at 0x114062950>]"
       ]
      },
      "execution_count": 39,
@@ -1154,7 +1155,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Use a 'ForwardShootMover' for ensemble(s) 'Interface 2'\n"
+      "Use a 'ForwardShootMover' for ensemble(s) 'I'face 1'\n"
      ]
     }
    ],
@@ -1255,11 +1256,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LastAllowed :\n",
-      " +- PartialAcceptanceMove : True : 2 samples\n",
+      "RandomChoice :\n",
+      " +- RandomChoice :\n",
       " |   +- OneWayShooting :\n",
-      " |   |   +- SampleMove : BackwardShootMover : True : 1 samples [<Sample @ 0x129b21b50>]\n",
-      " |   +- SampleMove : EnsembleHopMover : True : 1 samples [<Sample @ 0x12987ae10>]\n"
+      " |   |   +- SampleMove : BackwardShootMover : True : 1 samples [<Sample @ 0x11406a910>]\n"
      ]
     }
    ],


### PR DESCRIPTION
`alanine.ipynb` has decided, after discussion with Jan-Hendrik and me, to retire from its role in the test suite, so that it can spend more time with its family. We wish to state that this has *nothing* to do with the rumors that `alanine.ipynb` has regularly been slow and causing Travis tests to fail due to time-outs.

Jan-Hendrik and I would like to thank `alanine.ipynb`, one of our first tests, for its fine service to OPS. We wish it all the best in its future. (At least, until we delete it when we reorganize the examples according to #490).

- [x] Switch dependence in `tutorial_storage.ipynb` to use `mstis.nc`
- [x] Switch dependence in `test_pyemma.ipynb` to use `test_openmm_integration.ipynb`
- [x] Remove `alanine.ipynb` from `ipynbtests.sh`
- [ ] Make sure tests pass.