### PR TITLE
Path density histogram

### DIFF
--- a/examples/ipython/tutorial_path_histogram.ipynb
+++ b/examples/ipython/tutorial_path_histogram.ipynb
@@ -1,0 +1,415 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial: Path Histogram\n",
+    "\n",
+    "This gives a little overview of the option and behavior of the `PathHistogram` object. The `PathHistogram` is used for path density plots and free energy plots. It extends the basic `SparseHistogram` code by allowing for interpolation between bins, and by allowing one to normalize on a per-trajectory basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import openpathsampling as paths\n",
+    "from openpathsampling.analysis.path_histogram import PathHistogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import scipy\n",
+    "import pandas as pd\n",
+    "\n",
+    "def dataframe_from_counter(counter, ndim):\n",
+    "    mtx = scipy.sparse.dok_matrix(ndim)\n",
+    "    for k in counter.keys():\n",
+    "        mtx[k[0],k[1]] = counter[k]\n",
+    "    df = pd.DataFrame(mtx.todense())\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trajectory = [(0.1, 0.3), (2.1, 3.1), (1.7, 1.4), (1.6, 0.6), (0.1, 1.4), (2.2, 3.3)]\n",
+    "x, y = zip(*trajectory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's our trajectory. The grid happens to correspond with the bins I'll use for the histograms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x11b409f90>]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAEACAYAAABWLgY0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xl8VNX9//HXBxRwq6laRbACgrao1SjWFSWofFusCO5a\nUaK/hwtWsF9LW2tNEdBa/GorQQRtoWFxwx0rLiiMCxVEILKvhoAguAAqmyI5vz8+M94wJGQyuTP3\nzp3P8/HIw7mZ68zh5M6ZM+8593PFOYcxxphoahR0A4wxxmSODfLGGBNhNsgbY0yE2SBvjDERZoO8\nMcZEmA3yxhgTYXUO8iLSVESmi8hsEZkrIv1r2KeXiHwqIrPiP9dlprnGGGPqY4+6dnDOfSMinZ1z\nW0SkMTBVRF5xzr2ftOuTzrm+mWmmMcaYdKQU1zjntsRvNkXfGGo6g0r8apQxxhh/pDTIi0gjEZkN\nrAUmOedm1LDbRSJSLiLjReQwX1tpjDEmLanO5KuccycAhwGniMjRSbtMAFo75wqBN4HR/jbTGGNM\nOqS+tWtE5C/AJufc32u5vxGw3jlXUMN9VijHGGPS4JxLKxJPZXXNQSKyf/z2XsC5wKKkfZpX2+wO\nLNhNQ+3HOfr37x94G8LyY31hfWF9sfufhqhzdQ1wKDA6PkNvBDzlnJsoIgOAGc65/wB9ReQCYDuw\nHihuUKvywIoVK4JuQmhYX3isLzzWF/5IZQnlXODEGn7fv9rtO4A7/G2aMcaYhrIzXgNSXFwcdBNC\nw/rCY33hsb7wR72/eG3Qk4m4bD6fMcZEgYjgMvXFq8mMWCwWdBNCw/rCY33hsb7whw3yxhgTYRbX\nGGNMyDUkrkllCaUxxkRSRUUlJSVlrF5dRcuWjRg0qJg2bVoF3SxfWVwTEMsbPdYXHusLT6b7oqKi\nki5dhvLYY/2IxQbw2GP96NJlKBUVlRl93myzQd4Yk5dKSspYvnwAsE/8N/uwfPkASkrKAmyV/2yQ\nD0hRUVHQTQgN6wuP9YUn032xaFEV3gCfsA9r1lRl9HmzzQZ5Y0ze+O47ePppOPNMWLCgEbA5aY/N\ntGgRrWExWv+aHGLZq8f6wmN94fGzLz7/HP72N2jTBkpLoW9f+PDDYtq27Y830G+mbdv+DBpU7Nvz\nhoGtrjHGRNacOTqoP/ss9OgBL74IJ35fiasVkyb1oaTkftasqaJFi0YMGtQncqtrbJ28MSZSduyA\nCRN0cF+yBHr3hhtugIMPDrpl6bN18saYvLdhA4wcCQ89BIceCrfeChddBE2aBN2yYFkmHxDLXj3W\nFx7rC0+qfTF/Ptx0ExxxBHz4IYwfD++9B1dcYQM82EzeGJODduyAiRM1kpk7Vwf5BQt0Bm92Zpm8\nMSZnfPkl/PvfMHQo/PCHGslcdhk0bRp0yzLLMnljTKQtXqwD++OPwy9+AePGwamngqQ17OUXy+QD\nYtmrx/rCY33hmTw5xiuvQNeuevJSQYFGM088AaedtvMAX1FRSc+eA+jcuT89ew6IXP2ZhrCZvDEm\nVL7+GkaPhsGD4cADNZJ5/nlo1qzm/ROFxrw6NJuZNq0/kyZFb817OiyTN8aEwrJluvxxzBg4+2wd\n3Dt2rDuS6dlTK0juXIdmM1dddT/jxvXPZJOzxi7/Z4zJSc7BpEnQrZtGMM2aQXk5PPOMRjSpZO6r\nV+dHobF02SAfEMtePdYXnnzpi82bYcQIOOYYuO02uOACqKzU+jKHH677pNIXW7fCunX5UWgsXXX2\ngog0FZHpIjJbROaKyC6ff0SkiYg8KSJLReQ9ETk8M801xuSyFSvg97+HVq3g1Vdh2DCtL3P99bD3\n3vV7rGnT4IQToE2bYn70o+gXGktXSpm8iOztnNsiIo2BqUBf59z71e7vDfzMOXeziFwOXOicu6KG\nx7FM3pg84xy89RYMGQJvvw3XXgu/+Y1WhEzH1q3wl7/oMsqhQ+Hii+HYYys56KAyGjdOFBqL1mX8\nMr5O3jm3JX6zafz/SR6puwOJGf4zwEPpNMYYEx1btui69tJS2L5dy/uOHQv77pv+Y06bBsXFcPzx\n+gngRz+Cl16CPfdsRSzW39bN1yCl0EpEGonIbGAtMMk5NyNpl5bAKgDn3A5go4gc4GtLIyZfstdU\nWF94otAXq1bB7bdrJPPCC/DAA1pyoHfv+g3w1fti61aNeS68EO6+G556Sgd452DgQCgpsROjapPq\nTL4KOEFEfgC8ICJHO+cWVNsluXuFXWf7ABQXF9O6dWsACgoKKCws/P4yX4k/qm3n13ZCWNoT5HZ5\neXmo2pPqtnMwdGiMZ5+FuXOLuOYa+Mc/Yhx2WPqPX15eDkCzZkUUF8Ohh8YYPhx69PD2nzYNtm0r\n4sILw9UfDd2OxWKUlZUBfD9epqve6+RF5C/AJufc36v97hXgLufc9Hhu/4lzbpfqzZbJGxMt27bB\nk09qJLNpE/Tpo3HKfvs1/LGTs/dLLtn5fud02eVtt2n9mijLaCYvIgcB251zX4rIXsC5wN+SdnsJ\n6AVMBy4FJqfTGGNMblizBoYPh0cf1RUu99yjNWUa+bRqsabsPdnrr+vZscmDv9lZKn+SQ4EpIlKO\nDuKvOecmisgAETk/vs9I4CARWQr8Frg9M82NjuSoIp9ZX3jC3BfO6eB75ZW6vn3DBl018+qrWl/G\njwG+evZ+5ZWx77P3mtoyYADcead/byxRVedM3jk3Fzixht/3r3b7GyDiH5iMyU/ffANPP62RzOef\nayQzfLgWDPNT8ux9/vza933zTVi/PvoxjR+sdo0xpkZr18Ijj3hnpt56K5x3HjRu7O/z1JW9J3MO\nzjoLbrwRevb0ty1hZbVrjDG++eADuPpqaN8ePvkE3nhDf7p183+AT5y1unKlzt5TyddjMVi3Ti/v\nZ+pmg3xAwpy9Zpv1hSeovti+XVfJnH66nkF63HGwfLk3i/dbbeveq6utLwYOhD//GfawQukpsW4y\nJo999pmukBk+HNq1g379tFhYJgfQVFbO1Obtt/Vkq6uuyljzIscyeWPy0OzZmn8//zxcdJGWHDj+\n+Mw+Z32z95qcey78+tdw3XX+ty/M7Bqvxpg6ffedlhkoLYWPPtIiYUuXwkEHZf65GzJ7T5g6VSOk\nq6/2vXmRZpl8QCyH9lhfeDLRF198oZfSO+IIePBBuOUWqKiAP/0p8wN8Ktl7bZL7YuBAuOMO2HNP\n/9sZZTaTNyai5s7VWfszz0D37hrNdOiQvef3Y/Ze/bEWLYJevXxrXt6wTN6YCNmxQ0vvlpbqoNi7\nN9xwAxxySPba4Ef2nuy88/QL4Ztuavhj5SLL5I3Jcxs2wKhReiHsQw7RL1IvuQSaNMluO/ycvSe8\n/75+Knn++YY/Vj6yTD4glkN7rC889e2LhQvh5ps1b581S9e6T5umK1CyOcA3JHuvTaIvBg3S+vRN\nmza8nfnIZvLG5JiqKpg4USOZOXP09P7586FFi2Dak4nZe8LMmbrc8+mn/XvMfGOZvDE54quv4N//\n1px7//21lszllwc3w81E9p6sRw84+2yNn/KZZfLGRNiSJZq1jxsHXbrAmDF6sYwgL3eXydl7Qnm5\n5vFPPOH/Y+cTy+QDYjm0x/rCk+iLqip47TVdVdKxo15pac4czbpPPz24AT4T2Xtt+vaN8fvfw157\nZebx84XN5I0Jka1bYdgwjT+aNtVI5tlnwzHQZWP2njBnDsybpxckMQ1jmbwxIbB8uQ7uo0dDUZEO\n7meeGWwkk5CN7D3ZZZfBySdrwTRj9eSNyUnO6RWOLrgATjlFT9efNUtn7medFY4BPp167w01f75e\nVrB378w/Vz6wQT4glkN78q0vNm/WKy4de6zO2M8/XwfRwYOhoiIWdPOA7Gbvye6+G267DWbMiGXn\nCSPOMnljsqSyUiOZUaPgjDM0+ujcORwz9uqymb0nW7hQP9388596hSrTcJbJG5NBzumFLkpL9bJ1\nxcVa4veII4Ju2a6CyN6T9ewJRx+t1SaNx9bJGxMyW7fq+u7SUti2TU/mGT0a9t036JbVLMjZe8KS\nJbps9OGHs//cUWaZfEDyLYfenSj1xapVOgtt1Uq/QL3vPliwQOvLpDLAZ7svgszek91zj74Z/uAH\nuh2l4yJIdQ7yInKYiEwWkQUiMldEdjnBWEQ6ichGEZkV/7kzM801Jnyc06sWXXaZzoQ3b9btl1+G\n//kfaBTSqVQQK2dqs2yZ9le+ly/IhDozeRFpDjR3zpWLyL7ATKC7c25RtX06Ab9zzl1Qx2NZJm8i\n45tvtOpjaanWlenTRyOPxEw0rMKQvSe77jo4/HC4666gWxJOGc3knXNrgbXx25tEZCHQEliUtGvI\n1ggYkxlr1sCIEfDoozpzHzgQunYN74y9ujBk78k++ggmTNDrzRr/1euwFJHWQCEwvYa7TxWR2SLy\nsogc7UPbIs3yRk+u9MX06XDVVXDMMfD55zBlin5R+Ktf+TfAZ6ovwpS9J7v3Xj3x6Yc/3Pn3uXJc\nhF3Kq2viUc0zwK3OuU1Jd88EWjnntohIV+AF4KiaHqe4uJjWrVsDUFBQQGFhIUVFRYD3R7Xt/NpO\nCEt7qm9v3w6ffVbEkCGwcmWMCy+EiooiCgr0/nXr/H2+8vJy3/89zZoVUVwMhx4aY/hw6NEjc/1V\n3+21a+G554pYsmTX+8vLywNvX1DbsViMsrIygO/Hy3SltE5eRPYA/gO84pwbksL+FUAH59z6pN9b\nJm9ywrp1elbqiBHQvr1+IXj++dC4cdAtS10Ys/dkN90EBxwAf/1r0C0Jt2yskx8FLKhtgBeRQ5xz\n6+K3T0bfPNbXtK8xYTZzpn6ROmECXHopvP66lh/INWHM3pOtXAnjx+v6eJM5qSyhPAO4Cjg7nrnP\nEpFfisiNInJDfLdLRGSeiMwGHgQuz2CbIyE5qshnQffF9u062JxxBlx0kWbuy5bpF6vZHuAb2hdh\nzt6TDR4M118PBx1U8/1BHxdRkcrqmqnAbj+kOueGAcP8apQx2fD55zqQP/wwtG2rRbG6d4c9cvQ8\n8FyYvSd8/LGeEbwoeY2e8Z3VrjF558MPNZJ57jmduffpA4WFQbcqfbmQvSfr2xeaNIH77w+6JbnB\natcYU4fvvtOcvbRUo5ibb9YsOMyz3VTk0uw9Yc0afUNasCDoluSHHDh9I5osb/Rksi/Wr9f6MW3b\nwgMP6HrsigqtLxPGATHVvsil7D3Z//0f9OoFzZvvfj97jfjDZvImkubN0+hi/Hjo1k2LhZ10UtCt\n8kcuzt4T1q7Vapzz5gXdkvxhmbyJjB07tMjVkCEaBfTuDTfcUPeMMVfkYvaerF8/+PZbjc1M6iyT\nN3lt40a92tJDD+lyvFtv1TXuTZoE3TL/5PLsPeHTT/XvNGdO0C3JL5bJB8TyRk+6fbFokV5lqU0b\nvVTcE0/A++9rfZlcHeCT+yKXs/dkDzwAV14Jhx2W2v72GvGHzeRNTqmqgldf1Y/7s2fDjTfC/PnQ\nokXQLfNfFGbvCZ9/rtdtjZejMVlkmbzJCV99BWVlmkXvt59GMpdfDs2aBd0y/0Uhe092xx260mnE\niKBbkpsskzeRtXSpZu1jx8K558K//63lBySiVy+I0uw94YsvtNjbzJlBtyQ/WSYfEMsbPcl94ZwW\nBjv/fDj9dNh7bz1Ldfx46NgxmgN8Ins/77xYzmfvyR58UM8srm/FXHuN+MNm8iY0Nm3SGXtpqX5x\n2rcvPP007LVX0C3LrOqz91GjoEePoFvknw0btDbQjBlBtyR/WSZvAldRoZFMWRl06qR5+1lnRXPG\nXl0Us/dkd92lJYVHjQq6JbnNMnmTc5zTy+eVlsK77+qFnGfOrP9H+lwVxew92caN+uY9bVrQLclv\nlskHJF/zxi1btLzvz36m1R+7doWxY2Pcd19+DPB1rXuP0nExdKhe/7Zdu/T+/yj1RZBsJm+yorJS\ns9lRo+C00/TLuHPO0UgmX17L+TB7T/jqK/2UNnVq0C0xlsmbjHEO3nlHX+xTpmjlwd/8RitC5pN8\nyN6T/fWvWj9o3LigWxINlsmbUNm2TUsMlJZqPNO3r65v32+/oFuWffk0e0/4+mv9pPbWW0G3xIBl\n8oGJYt64ejX8+c9w+OG69PHee2HhQp29726Aj2JfpFtzJgp98fDDGsW1b9+wx4lCX4SBzeRNgzgH\n772ns/bXX9fiYO++C0cdFXTLgpOPs/eETZvg73+HyZODbolJsEzepOWbb/QM1CFDdKlcnz46sO2/\nf9AtC04+Zu/J7r9fK4GOHx90S6LFMnmTNZ98okWmHnkEjjtOT3bp2hUaNw66ZcHK59l7wpYtOshP\nmhR0S0x1lskHJNfyxvffh5494eij9eIPkyd79WUaOsDnWl9U53e991zui0ce0eJxP/uZP4+Xy30R\nJnUO8iJymIhMFpEFIjJXRPrWsl+piCwVkXIRKfS/qSbbvv1WV8mcdpqW9T3hBPjoIxg+XAf7fDdt\nmvbJypU6e8/HeCZh61a9QHdJSdAtMcnqzORFpDnQ3DlXLiL7AjOB7s65RdX26Qrc4pz7lYicAgxx\nzp1aw2NZJp8DPv1Uz0odPhx+8hNdAtmtm0UyCZa976q0VD/dvfBC0C2Jpoxm8s65tcDa+O1NIrIQ\naAksqrZbd2BMfJ/pIrK/iBzinFuXTqNMMGbN0hfriy/qwPXqq/599I4Ky953tW0bDB4MEyYE3RJT\nk3pl8iLSGigEpifd1RJYVW17dfx3phZhyRu/+07XtJ95ppa4bd8eli3TS7Vla4APS1/sTrautZoL\nfZFs5Eg48UTo0MHfx83FvgijlFfXxKOaZ4BbnXObku+u4X+pMZcpLi6mdbwSVUFBAYWFhRQVFQHe\nH9W2M7/9+edwxx0xnn8e2rcv4tZb4Yc/jNG4MRx4YHbbkxCm/qm+3axZEcXFcOihMYYPhx49Mvd8\n5eXlgf9767P97bfwt78V8dxz/j9+efyCsGH692ZrOxaLUVZWBvD9eJmulNbJi8gewH+AV5xzQ2q4\nfwQwxTn3VHx7EdApOa6xTD54c+ZoJPPsszpz79tXvzw0u7LsvW4jRmhMM3Fi0C2Jtmyskx8FLKhp\ngI+bAPwGeEpETgU2Wh4fHjt26AuxtBSWLIGbb4bFi+Hgg4NuWXhZ9l63b7/V0hVPPRV0S8zupLKE\n8gzgKuBsEZktIrNE5JcicqOI3ADgnJsIVIjIMuAR4OaMtjoCkqOKTNiwQU9OadtWl7fdeCOsWKH1\nZcI0wGejL1KVrey9NmHqi7qMHg0//Smcuss6On/kUl+EWSqra6YCdS6ec87d4kuLTIPNn6/xwlNP\n6clKTz8NP/950K0KP5u9p277di0nbKWEw89q10TEjh2ai5aWwrx5cNNNOnNv3jzoloWfZe/1N2oU\nPPYYvPlm0C3JD1a7Jo99+aXWah86FA44QC+Cfeml0LRp0C3LDTZ7r7/t2+Gee/S4M+FntWsC0tC8\ncfFiuOUWaNMGpk/XWWiivkyuDfBBZK9BZ++1yYUc+vHH4cc/hrPOyuzz5EJf5AKbyeeQqip47TWN\nZGbNguuvh7lzoaWddlYvNntP33ff6Zvio48G3RKTKsvkc8DXX+tKhqFDYe+9NZK54gpo1izoluUW\ny94bbtw4rTb59tt6EXaTHZbJR9SyZfDQQzBmjF5O7V//go4d7cWVDpu9N9yOHTqLf+ghOwZziWXy\nAaktb3ROL7rQrZuW+N1rLygv9+rLRPHFlcnsNazZe23CnEOPH69f7p9zTnaeL8x9kUtsJh8SmzfD\n2LGatzdurJHMU09pPGPSY7N3/+zYAYMGwT/+Ec2JRpRZJh+wFStg2DBdjnbmmVpLpqjIXkgNYdm7\n/8aPhwce0DdOOzazryGZvMU1AXAOYjGNEDp00O0ZM+D556FzZ3sRNYRdrcl/VVUwcCD072/HZi6y\nQT6LtmzRL0+PPx569Yrxi19AZaXWl2nTJujWBceP7DXXsvfahDGHfv55/W6oa9fsPm8Y+yIXWSaf\nBatWaSQzcqQWc3rgAdhjD521m4az7D1zErP4u++2WXyuskw+Q5yDd9/VL1LffBOuuUbPUG3XLuiW\nRYdl75n3wgs6yM+caYN8kGydfIhs2wZPPqmD+6ZN+kXqqFGw335BtyxabPaeec7pAP+Xv9gAn8ss\nk/fJmjVQUgKtWmkefM89sGiRzt5rGuAtb/TUpy+ikr3XJkzHxX/+o0snL7ggmOcPU1/kMhvkG8A5\nnVFeeSUce6xepOPtt+GVV/RLqkbWu75KrJyprLSVM5nmHAwYoLN4O45zm2XyafjmGz0DtbQUvvgC\n+vSBa6+F/fcPumXRlMjex47V7P3SS4NuUfRNnAh//CN8+KEN8mFgmXyWrF2rxZlGjNCZe0kJnHee\nnqFqMiORvR93nFbcjFI0E1aJWXxJiQ3wUWB/whR88AFcfTW0bw+ffAJvvOHVl0l3gLe80VNTXySy\n9x499HT68ePzY4APw3Hx+uta+fTii4NtRxj6IgpsJl+L7dvh2Wc1klmzRr9AHTJECzSZzLLZe3Cq\nz+LtE2o0WCaf5LPP9IIIw4fDkUfqEshu3fTkJZNZlr0H7403dEIzf74N8mFitWt8UF4O110HRx0F\nFRXw8sswZYou1bMBPvOqr5yZO9cG+CAkZvF33mkDfJTk9SD/3XfwzDN6rcpu3XSAX7rUqy+TSZY3\nqq1b4fLLY3mXvdcmyOMiFtPFBVdcEVgTdmKvEX/UOUcVkZHA+cA659xxNdzfCXgR+Cj+q+ecc3f7\n2kqfffGFDuTDhunJS3376hd8e+4ZdMvySyJ7b97csvcwGDhQZ/H2yTVa6szkRaQjsAkYs5tB/nfO\nuTrPiws6k587V79IfeYZ6N5d17d36BBYc/KWZe/h8/bbeq7H4sU2yIdRRtfJO+feFZFWdbUhnSfP\nhh074KWXdHBftAh699YD+eCDg25ZfrKVM+E0cCD8+c82wEeRX5n8qSIyW0ReFpGjfXrMBtmwQUv6\ntmsHgwfD9dfrVZhKSsIxwOdb3ri7de/51he7E0RfTJ0Ky5fruSBhYseFP/x4354JtHLObRGRrsAL\nwFG17VxcXEzr1q0BKCgooLCwkKKiIsD7ozZku7ISpk8v4okn4KSTYvzhD9C7t3+Pb9v1327WrCie\nvccYMQJ69Nj5/oSwtDfI7fLy8qw//733FnHHHTB1avD//urb5eXloWpPNrdjsRhlZWUA34+X6Upp\nnXw8rnmppky+hn0rgA7OufU13JeRTL6qSmttlJZq4aobb4SbboJDD/X9qUw9WPYeftOmweWX66qy\nJk2Cbo2pTTZq1wi15O4icohzbl389snoG8cuA3wmfPWVXgB76FAoKIBbb4XLLoOmTbPx7GZ3LHvP\nDQMHwp/+ZAN8lNWZyYvI48B/gaNEZKWIXCsiN4rIDfFdLhGReSIyG3gQuDyD7QVgyRJd9ti6Nbz3\nHowZoxfCvvrq3Bngk6OKqEin5kxU+yId2eyL99/XN+Brr83aU9aLHRf+SGV1za/ruH8YMMy3FlVT\nUVFJSUkZq1dX0aJFI7p0KWb8+FZ88IF+kTpnDhx2WCae2aTDZu+5IfG6evXVKtq0acSaNcW0aVPX\nAjqTs5xzWfvRp0vNRx+tcG3b/s7BJqcnXG9yTZr8zg0evMJt2ZLyw5gs2LLFuX79nDvkEOfGjw+6\nNWZ3anpdtW37O/fRRyuCbprZjfjYmda4G9qyBiUlZSxfPgDYJ/6bffj22wHMmlXGXnsF2TJTndWc\nyS01va6WLx9ASUlZgK0ymRTaQX716iq8AzFhH55+uoqiIi2k9PbbepWmXJTreaOf9d5zvS/8lOm+\nqO11tWZNVUafNx12XPgjtIN8y5aNgM1Jv93MJZc04vbbYcsW6NcPDjoIzj1XL5z93/9qHXiTWTZ7\nz121va5atAjtUGAaKLT15CsqKunSZWi1j5abadu2P5Mm9dnpS6Ivv4R33tGywFOmwLJlcPrp0Lmz\n/px4op2q7Rdb9577Kioq+fnPh/LFF7t/XZlwacg6+dAO8uCtAlizRlfXDBpU9yqA9evhrbe8QX/V\nKujY0Rv0jz/eamWno/rKmWHDbOVMLjv77Eq2by9jzz1Tf12ZYEV2kPfDZ59pnezEoL9undaPTwz6\nxx4bzMWKY7HY96czh1k2Zu+50hfZkOm+2L5dI85ly8L/Rm3HhScbZ7zmrB/9SAemxOD0ySfeoP/Q\nQ7BxI3Tq5A367duDhLamZnbZuvfomTED2rSxv2U+ifxMvi4ff+zN8qdM0ZlrUZE36B95ZP4N+pa9\nR9egQTqxeeCBoFti6sPiGh+tWLHzoF9V5Q34nTvrLCjKg75l79HWqRPcfjt07Rp0S0x92IW8fdS6\ntdbyGDMGVq7UL3E7dYI334QzztD7i4th9Gi9P11hWwPs57r3+gpbXwQpk32xeTPMnAlnnpmxp/CV\nHRf+iHwm3xAietGRdu20Vo5zelWpKVPg5Zd1UNxvv51n+i1aBN3q+rPsPT+8+66e37DvvkG3xGST\nxTUN4BzMn+9FO2+9pSsXEgN+UREcckjQraydZe/55Q9/gL33hrvuCrolpr4skw+JqiqtjJkY9N95\nR2f21Qf9Aw8MupXKsvf806EDPPhg7sQ1xmODfEjt2AGzZ3uD/tSpmul37gwHHRTjlluKKCjIbpvC\nOHu39dCeTPXFF1/oooHPP8+dC4TYceGxL15DqnFjOOkkze4nTtQX2COPaITzwgvw4x/r7KpfP834\nv/oqs+2xmjP5a8oUPfM7VwZ44x+byQfo22/16jyJmf7778Mxx3jxTseOsE9ywcA0hHH2brKrd29d\nQPC73wXdEpMOi2siYts2nW0nBv1Zs7TWTmLQP/106l1L37J3A3DUUbostrAw6JaYdFhck4NqWgPc\nrBk71cr/9FO97RyUlOgAnWot/SDXvdeXrYf2ZKIvVq6EDRv0jT6X2HHhD1snH2J776218s89V7c3\nbdK1zlOmaI6/cCGccoo30//5z2HPPW3du9nZm2/C2WcHU4jPBM/imhyWXEt/3jzvoin9+sG991ot\nfQM9e2oqXAVlAAANc0lEQVTl1RtuCLolJl2WyRumTYPu3fVj+cUX64BvtfSNc3quxrvvQtu2QbfG\npMsy+RzkV95YPXt/6CFdsfPEExrTLF0KvXrB8uVw1VUa2/ToAUOG6ElbVSG5rKdlrx6/+2LhQmja\nFI44wteHzQo7LvxR5yAvIiNFZJ2IzNnNPqUislREykXEvr/PkrrWvSdq6T/8sL7Y58+Hyy/X/158\nMRx8MFxyia66WbBAZ30mWt58E845J9qVU83u1RnXiEhHYBMwxjm3y/fzItIVuMU59ysROQUY4pw7\ntZbHsrjGB36te7da+tHXvTtccQVceWXQLTENkfFMXkRaAS/VMsiPAKY4556Kby8Eipxz62rY1wb5\nBsrkuvd8r6UfNd99pwXzFi8Od6E8U7egM/mWwKpq26vjvzO7Ud+8MRvr3rNVSz+ZZa8eP/ti5kwt\nnZGrA7wdF/7wY4FdTe8utU7Xi4uLad26NQAFBQUUFhZ+X4Qo8Ue17Z23mzUrorgYmjePMWIE9OiR\n+ecXgY8/jnHkkXD99UU4B2PHxpg9G15+uYjf/x722CPGCSfAr39dROfOsGRJes+XEJb+DnK7vLzc\nt8f75z9j/OQnAOH599Vnu7y8PFTtyeZ2LBajrKwM4PvxMl2ZiGsWAZ0srmm4MNecyfVa+vngnHPg\nt7+Fbt2CbolpqGxk8q3RQf5nNdx3HvCb+BevpwIP2hevDZdrNWeSa+m//Ta0bOkN+p066ZuAyY6t\nW/WYWbMGfvCDoFtjGiqjmbyIPA78FzhKRFaKyLUicqOI3ADgnJsIVIjIMuAR4OZ0GpJvkqOKhFyq\nOVNdo0Za/Op//xcmTND65aNHQ6tWMHKknohz/PE6s3zxRT1pK6G2vshHfvXF1Kk6QcjlAd6OC3/U\nmck7536dwj63+NOc/BalmjOJWvqJevrbt+sXgVOm6CeTnj21MmLnznq1rBNPzO0BKWwS6+ONsbIG\nIRDm7D1TslVLP1+dfDLcd59+N2Jyn9WuyWG5lr1nyrZt8N573qA/e3bDa+nnqw0b4PDD9UpkTZsG\n3Rrjh6DXyZs0vPZaLCez90yIxWI0a6aD+cCBWlnz00/hrrv0C90779S+6dRJf/fWW7uvpZ/L/Mih\nYzF9U8z1Ad4yeX9YIdoATJsG118Pp56a+9l7puy9N3Tpoj8AX3+9cy39RYs0kqheS7+JXb8UsDze\n7MzimizKx+w9U778UpdpJuKd5cvhtNO8Qb9Dh/ytpd++PYwbp31gosEy+Rxg2XtmrV+vMU5i0F+5\ncuda+oWF+VFLf/VqPcY+/TQ//r35wjL5EKtt3bvljR4/+uKAA+DCC6G0VCOwZcv0TfWjj3S5Zlhr\n6SdraF9MnqwraqIwwNtrxB95+oE2O6K07j3XJGrpJyKxTz7RLySnTNGLq2zYsHNZ5fbto1Fh8403\nLI83O7O4JgMsew+/KNbSd06rTk6erCeameiwTD5ELHvPTVGopb94MZx7rn4fEfa2mvqxTD4E6ltz\nxvJGTxj6Iqha+ska0hdRu9RfGI6LKLBM3geWvUeLCLRrpz/XX68xyOLFOsN/+WV9M99vv51n+i1a\nBN1qHeR79Ai6FSZsLK5pAMve81NVlV74PEy19Hfs0MnFvHnheMMx/rJMPgCWvZuEqir48ENv0H/n\nnezX0v/gA7jmGn3zMdFjmXwW+VXv3fJGT673RaNGcMIJcNtt8NJLWhisrEyLhP3rX3DEEbXX0k+W\nbl9EsZRBrh8XYWGDfD1Mm6Yv5spKzd4tnjE12WMPraXzhz/AK6/oBVRGjICDD9Y1+ocfriUH+vXT\njP+rrxr+nFEc5I0/LK5JgWXvxk/ffLNzLf0ZMxpWS3/bNv00uWoVFBRkrt0mOJbJZ5Bl7ybTGlpL\nf8oU+OMf9Y3DRJNl8hmQ6WutWt7oyfe+qF5Lf9CgGOvWpVZLv6Kikp49B3Dttf3ZvHkAFRWVQf4z\nfJfvx4VfbJ18DWzduwnSPvvsvpb+woVw3HGVLF48lPXrBwD7AJvp0qU/kyb1oU2bVkE234SMxTXV\nWPZucsHGjdCjxwDeeqsfOsAnbOaqq+5n3Lj+QTXNZEhD4hqbycfZ7N3kioICEKli5wEeYB/WrAlp\nDWUTmLzP5DOdvdfG8kaP9YUn1b5o2bIRsDnpt5tp0SI6L2k7LvyR0hEhIr8UkUUiskRE/ljD/b1E\n5FMRmRX/uc7/pvrP1r2bXDVoUDFt2/bHG+g307ZtfwYNKg6sTSac6szkRaQRsAQ4B1gDzACucM4t\nqrZPL6CDc65vHY8VikzesncTBRUVlZSUlLFmTRUtWjRi0KBi+9I1ojKdyZ8MLHXOVcaf7EmgO7Ao\nab+cKHBq2buJijZtWtmXrKZOqcQ1LYFV1bY/jv8u2UUiUi4i40XkMF9a56OgsvfaWN7osb7wWF94\nrC/8kcpMvqYZenLmMgF43Dm3XURuBEaj8c4uiouLad26NQAFBQUUFhZSVFQEeH9Uv7ebNSuiuBia\nN48xYgT06JHZ57Pt+m0nhKU9QW6Xl5eHqj1BbpeXl4eqPdncjsVilJWVAXw/XqYrlUz+VOAu59wv\n49u3A845N7iW/RsB651zu1TRyHYmb9m7MSYKMl3WYAbQTkRaiUgT4Ap05l69Ac2rbXYHAq9qbStn\njDEmhUHeObcDuAV4HZgPPOmcWygiA0Tk/PhufUVknojMju9bnKkG1yVs2XttkqOKfGZ94bG+8Fhf\n+COlM16dc68CP0n6Xf9qt+8A7vC3afVnK2eMMWZnkahdY9m7MSbK8rp2jc3ejTGmdjlb6CJXsvfa\nWN7osb7wWF94rC/8kZMzeZu9G2NManIqk7fs3RiTjyKbyScKMK1eXUWTJo1YurSYk05qZbN3Y4xJ\nUWgz+YqKSrp0Gcpjj/UjFhvA66/3Y8uWoQweXBmJAd7yRo/1hcf6wmN94Y/QDvIlJWUsX564fiXA\nPqxbN4CSkrIAW2WMMbkltIP86tXRvrxZoiiRsb6ozvrCY33hj9AO8vlweTNjjMm00I6YUb+8meWN\nHusLj/WFx/rCH6FdXdOmTSsmTepDScn91S5v1scub2aMMfWQU+vkjTEmH2W6nrwxxpgcZYN8QCxv\n9FhfeKwvPNYX/rBB3hhjIswyeWOMCTnL5I0xxtTIBvmAWN7osb7wWF94rC/8YYO8McZEmGXyxhgT\ncpbJG2OMqVFKg7yI/FJEFonIEhH5Yw33NxGRJ0VkqYi8JyKH+9/UaLG80WN94bG+8Fhf+KPOQV5E\nGgEPAb8AjgGuFJGfJu32/4D1zrkjgQeB+/xuaNSUl5cH3YTQsL7wWF94rC/8kcpM/mRgqXOu0jm3\nHXgS6J60T3dgdPz2M8A5/jUxmjZu3Bh0E0LD+sJjfeGxvvBHKoN8S2BVte2P47+rcR/n3A5go4gc\n4EsLjTHGpC2VQb6mb3STl8gk7yM17GOqWbFiRdBNCA3rC4/1hcf6wh91LqEUkVOBu5xzv4xv3w44\n59zgavu8Et9nuog0Bj5xzh1cw2PZwG+MMWlIdwllKhcNmQG0E5FWwCfAFcCVSfu8BPQCpgOXApP9\nbKQxxpj01DnIO+d2iMgtwOtovDPSObdQRAYAM5xz/wFGAmNFZCnwBfpGYIwxJmBZPePVGGNMdmXk\njFc7ecqTQl/0EpFPRWRW/Oe6INqZaSIyUkTWicic3exTGj8mykWkMJvty6a6+kJEOonIxmrHxJ3Z\nbmO2iMhhIjJZRBaIyFwR6VvLfpE/NlLpi7SODeecrz/oG8cyoBWwJ1AO/DRpn97Aw/HblwNP+t2O\nMPyk2Be9gNKg25qFvugIFAJzarm/K/By/PYpwLSg2xxgX3QCJgTdziz1RXOgMH57X2BxDa+RvDg2\nUuyLeh8bmZjJ28lTnlT6Ampephopzrl3gQ272aU7MCa+73RgfxE5JBtty7YU+gLy4JgAcM6tdc6V\nx29vAhay63k4eXFspNgXUM9jIxODvJ085UmlLwAuin8MHS8ih2WnaaGT3Ferqbmv8sWpIjJbRF4W\nkaODbkw2iEhr9BPO9KS78u7Y2E1fQD2PjUwM8nbylCeVvpgAtHbOFQJv4n3CyTep9FW+mAm0cs6d\ngNaNeiHg9mSciOyLfqq/NT6L3enuGv6XyB4bdfRFvY+NTAzyHwPVv0g9DFiTtM8q4McA8ZOnfuCc\nq+vjay6qsy+ccxviUQ7AP4EOWWpb2HxM/JiIq+m4yQvOuU3OuS3x268Ae0b0ky4AIrIHOqiNdc69\nWMMueXNs1NUX6RwbmRjkvz95SkSaoGvmJyTtkzh5CnZz8lQE1NkXItK82mZ3YEEW25dtQu154gTg\nGvj+LOuNzrl12WpYAGrti+p5s4icjC51Xp+thgVgFLDAOTeklvvz6djYbV+kc2ykcsZrvTg7eep7\nKfZFXxG5ANgOrAeKA2twBonI40ARcKCIrAT6A03QEhmPOucmish5IrIM2AxcG1xrM6uuvgAuEZHe\n6DGxFV2BFkkicgZwFTBXRGajMcwd6Iq0vDo2UukL0jg27GQoY4yJMLv8nzHGRJgN8sYYE2E2yBtj\nTITZIG+MMRFmg7wxxkSYDfLGGBNhNsgbY0yE2SBvjDER9v8BSuDT3P54Y10AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b409f50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.grid(True)\n",
+    "plt.plot(x, y, 'o-')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first type of histogram is what you'd get from just histogramming the frames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PolyCollection at 0x11b409fd0>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEACAYAAACatzzfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADBFJREFUeJzt3W+IZXUdx/HPZ51VxkyfFLq4VEhIuBDm31htZirJTc0e\nRVkh+qBHykpFWBG6LUsQRCUEQWSR0V+lPyaGCjYzaLVu7k6Zu2YkpqK7FEgmLrHqpwf37M7uODP3\nXGfunO/uvF8ge+b6u5cvh5n3nvnde9RJBACoa03XAwAAFkeoAaA4Qg0AxRFqACiOUANAcYQaAIrr\nG2rbZ9reZXtn8+d/bG9eieEAAJIH+Ry17TWSnpF0YZKnhzYVAOCQQbc+LpH0DyINACtn0FB/VNJP\nhjEIAGB+rbc+bK+V9Kyks5L8a6hTAQAOGRlg7QclPbxQpG3zHw0BgAElcb81g4T6KvXZ9th/gFZL\n0ratW/Slm7Z0PUbnOA+zOBez3r7pGq2/5Nquxyhh+xcmWq1rtUdte1S9NxJ/8fpHAgC8Hq2uqJPs\nl/TmIc8CAJgHdyYOwdj4RNcjlMB5mMW5mHXyGWd3PcJRZ6AbXhZ9ITvsUQPoZ+JrU12PUMb2L0y0\nejORK2oAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByh\nBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOJahdr2KbZvt73H9qO2Lxz2YACA\nnpGW626RdHeSj9gekXTiEGcCABymb6htv1HSe5JcI0lJXpb0wpDnAgA02mx9nCHp37a/b3un7e/Y\nHh32YACAnjZbHyOSzpF0XZI/2f6mpM9Lunnuwm1btxw6Hhuf0Nj4xPJMCQDHgBee2KUXnpgZ+HlO\nsvgC+1RJf0hyRvP1xZJuTPKhOeuy/8DirwUAmDW61krifuv6bn0k2SfpadtnNg+9X9LuJc4HAGip\n7ac+Nkv6ke21kp6QdO3wRgIAHK7v1kfrF2LrAwAGsmxbHwCAbhFqACiOUANAcYQaAIoj1ABQHKEG\ngOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlAD\nQHGEGgCKI9QAUByhBoDiCDUAFDfSZpHtJyX9R9Krkg4kuWCYQwEAZrUKtXqBnkjy/DCHAQC8Vtut\nDw+wFgCwjNrGN5Lusb3D9qeGORAA4Ehttz42Jtlr+82S7rO9J8kDcxdt27rl0PHY+ITGxieWZUgA\nOBZMT01qempy4Oc5yWBPsG+W9N8kX5/zePYfGOy1AGA1G11rJXG/dX23PmyfaPuk5vgNkj4g6a9L\nHxEA0EabrY9TJf3Sdpr1P0py73DHAgAcNPDWx4IvxNYHAAxk2bY+AADdItQAUByhBoDiCDUAFEeo\nAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPU\nAFAcoQaA4gg1ABRHqAGgOEINAMURagAornWoba+xvdP2ncMcCABwpEGuqG+QtHtYgwAA5tcq1LbX\nS7pM0neHOw4AYK62V9TfkPQ5SRniLACAeYz0W2D7ckn7kszYnpDkhdZu27rl0PHY+ITGxieWPiEA\nHCOmpyY1PTU58POcLH6RbPsrkj4p6WVJo5LeKOkXSa6esy77D3DBDQBtja61kix48XtQ31Afsdge\nl/TZJFfO8+8INQAMoG2o+Rw1ABQ30BX1oi/EFTUADIQragA4RhBqACiOUANAcYQaAIoj1ABQHKEG\ngOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlAD\nQHGEGgCKI9QAUByhBoDiCDUAFDfSb4HtEyRNSzq+WX9Hki8PezAAQE/fUCf5n+33JnnJ9nGSHrT9\n2yQPrcB8ALDqtdr6SPJSc3iCenHP0CYCAByhVahtr7G9S9JeSfcl2THcsQAAB/Xd+pCkJK9Kepft\nkyX9yvZZSXbPXbdt65ZDx2PjExobn1imMQHg6Dc9NanpqcmBn+dksF0M2zdJejHJ1+c8nttnnh14\ngGPNFRvWdT0CCrrr0ee6HqEMfkZmja61krjfur5bH7bfZPuU5nhU0iWSHlv6iACANtpsfayT9APb\na9QL+8+S3D3csQAAB7X5eN4jks5ZgVkAAPPgzkQAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGg\nOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQ\nHKEGgOIINQAUR6gBoLi+oba93vb9tnfbfsT25pUYDADQM9JizcuSPpNkxvZJkh62fW+Sx4Y8GwBA\nLa6ok+xNMtMcvyhpj6TThz0YAKBnoD1q22+TdLak7cMYBgDwWm22PiRJzbbHHZJuaK6sX+Pn3/7a\noeMN523UhvM3LnlAADhWTE9NanpqcuDnOUn/RfaIpLsk/TbJLQusyf4D/V8LWI3uevS5rkco44oN\n67oeoYzRtVYS91vXduvje5J2LxRpAMDwtPl43kWSPiHpfbZ32d5pe9PwRwMASC32qJM8KOm4FZgF\nADAP7kwEgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMUR\nagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIrrG2rbt9reZ/sv\nKzEQAOBIba6ovy/p0mEPAgCYX99QJ3lA0vMrMAsAYB7sUQNAcSPL+WJXX//ZQ8cbztuoDedvXM6X\nPypcsWFd1yOgIL4vIEnTU5Oanpoc+HlO0n+R/VZJv0nyzkXW5PaZZwce4FjDDySAtkbXWkncb13b\nrQ83/wAAVlibj+f9WNLvJZ1p+ynb1w5/LADAQX33qJN8fCUGAQDMj099AEBxhBoAiiPUAFAcoQaA\n4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANA\ncYQaAIoj1ABQHKEGgOIINQAUR6gBoLhWoba9yfZjth+3feOwhwIAzOobattrJH1L0qWSNki6yvY7\nhj3Y0Wx6arLrEUrgPMziXMziXAyuzRX1BZL+nuSfSQ5I+qmkDw93rKMb34g9nIdZnItZnIvBtQn1\n6ZKePuzrZ5rHAAAroE2oPc9jWe5BAADzc7J4c22/W9KWJJuarz8vKUm+Omcd8QaAASWZ72L4CG1C\nfZykv0l6v6TnJD0k6aoke5ZjSADA4kb6LUjyiu3rJd2r3lbJrUQaAFZO3ytqAEC3lnxnIjfD9Ni+\n1fY+23/pepau2V5v+37bu20/Yntz1zN1xfYJtrfb3tWci5u7nqlrttfY3mn7zq5n6ZLtJ23/ufne\neGjRtUu5om5uhnlcvf3rZyXtkPSxJI+97hc9Stm+WNKLkm5L8s6u5+mS7dMknZZkxvZJkh6W9OHV\n+H0hSbZPTPJS837Pg5I2J1n0B/NYZvvTks6VdHKSK7uepyu2n5B0bpLn+61d6hU1N8M0kjwgqe8J\nXw2S7E0y0xy/KGmPVvFn75O81ByeoN77Qqt2v9H2ekmXSfpu17MUYLVs8FJDzc0wWJTtt0k6W9L2\nbifpTvOr/i5JeyXdl2RH1zN16BuSPqdV/JfVYSLpHts7bH9qsYVLDTU3w2BBzbbHHZJuaK6sV6Uk\nryZ5l6T1ki60fVbXM3XB9uWS9jW/bVnz92M12ZjkPPV+w7iu2T6d11JD/Yyktxz29Xr19qqxytke\nUS/SP0zy667nqSDJC5ImJW3qeJSuXCTpymZv9ieS3mv7to5n6kySvc2f/5L0S/W2kue11FDvkPR2\n22+1fbykj0laze/kcpUw63uSdie5petBumT7TbZPaY5HJV0iaVW+qZrki0nekuQM9Vpxf5Kru56r\nC7ZPbH7jlO03SPqApL8utH5JoU7yiqSDN8M8Kumnq/VmGNs/lvR7SWfafsr2tV3P1BXbF0n6hKT3\nNR892ml7tV5FrpP0O9sz6u3T35Pk7o5nQvdOlfRA897FHyX9Jsm9Cy3mhhcAKI7/FRcAFEeoAaA4\nQg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOL+DzPr3EU8VpO1AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b4c0590>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hist = PathHistogram(left_bin_edges=(0.0,0.0), bin_widths=(0.5,0.5), interpolate=False, per_traj=False)\n",
+    "\n",
+    "hist.add_trajectory(trajectory)\n",
+    "plt.pcolor(dataframe_from_counter(hist._histogram, ndim=(5, 7)).transpose(), cmap='Blues', vmin=0, vmax=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next type of histogram uses that fact that we know this is a trajectory, so we do linear interpolation between the frames. This gives us a count of every time the trajectory enters a given bin. We can use this kind of histogram for free energy plots based on the reweighted path ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PolyCollection at 0x11b4d9e50>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEACAYAAACatzzfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADIVJREFUeJzt3X+s3XV9x/HXq9xKLiL8o8HGBk2zNAs3caCtLMX1XpUo\nKNO/nDAnkT/8Y9GUbdYoZpGOsCVLGh3JEpJFNHPxxyjRTQkNkLB7b0BXOtqr2JZ1WeeElDYuIXYE\nshR57Y9z2tteTu/5Hm6/9/vuvc9HQvq9N59z8s43lyff+znfb3ESAQDqWtP1AACAxRFqACiOUANA\ncYQaAIoj1ABQHKEGgOKGhtr2Rtv7be/r//lr29uWYzgAgORR7qO2vUbSc5KuTfJsa1MBAE4bdevj\nekn/SaQBYPmMGupPSPpuG4MAAAZrvPVhe62ko5KuSvKrVqcCAJw2NsLaGyU9da5I2+YvDQGAESXx\nsDWjhPoWDdn2ePkkrZaku+/aoT//yo6ux+gc52HerZ/7vP7gj7d3PUYJf/L5O7T++tu6HqOEPXdM\nNVrXaI/a9rh6HyR+//WPBAB4PRpdUSd5WdJbWp4FADAATya2YOvkVNcjlMB5mDexaUvXI5Rx2Yar\nux7hgkOoW0CgejgP8yY2E+pTLttwTdcjXHAINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAc\noQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiO\nUANAcY1Cbfty27tsH7J9wPa1bQ8GAOgZa7juHkkPJfm47TFJl7Q4EwDgDENDbftNkn4vyaclKckr\nkk60PBcAoK/J1scGSf9j+5u299n+O9vjbQ8GAOhpsvUxJuldkj6b5N9s/42kL0m6c+HCu+/acfp4\n6+SUtk5OnZ8pAWAFOHFkv04cmRv5dU6y+AL7Ckk/SbKh//V7JX0xye8vWJeXTy7+XlhdHjzwfNcj\nlPGpT/9l1yOU8Tuf+HjXI5Sx544pJfGwdUO3PpIcl/Ss7Y39b31A0sElzgcAaKjpXR/bJH3b9lpJ\nRyTd1t5IAIAzNQp1kp9K2tzyLACAAXgyEQCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANA\ncYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGg\nOEINAMURagAobqzJItu/kPRrSa9KOpnkPW0OBQCY1yjU6gV6KskLbQ4DAHitplsfHmEtAOA8ahrf\nSHrY9l7bn2lzIADA2ZpufWxJcsz2WyQ9avtQkscXLrr7rh2nj7dOTmnr5NR5GRIAVoITR/brxJG5\nkV/nJKO9wL5T0v8m+eqC7+flk6O910r04IHnux6hjJ27D3c9Agqa3j7Z9QhljK+1knjYuqFbH7Yv\nsX1p//iNkj4o6edLHxEA0ESTrY8rJP3Advrrv53kkXbHAgCcMjTUSf5L0tXLMAsAYABuuQOA4gg1\nABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQa\nAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAimscattrbO+z/cM2BwIAnG2UK+rb\nJR1saxAAwGCNQm17vaQPS/p6u+MAABZqekX9NUlfkJQWZwEADDA2bIHtj0g6nmTO9pQkn2vt3Xft\nOH28dXJKWyenlj4hAKwQszPTmp2ZHvl1Tha/SLb9V5L+SNIrksYlvUnS95PcumBdds0dHXmAlWbn\n7sNdj1DG9hs3dj0CCrppYl3XI5QxvtZKcs6L31OGbn0k+XKSK5NskHSzpMcWRhoA0B7uowaA4obu\nUZ8pyYykmZZmAQAMwBU1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4\nQg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFDc\n2LAFti+WNCvpDf31DyT5i7YHAwD0DA11kv+z/b4kL9m+SNITtncneXIZ5gOAVa/R1keSl/qHF6sX\n97Q2EQDgLI1CbXuN7f2Sjkl6NMnedscCAJwydOtDkpK8Kuka25dJ+ifbVyU5uHDd/ffuPH08sWmL\nJjZvOW+DAsCFbnZmWrMz0yO/zslouxi2vyLpxSRfXfD97Jo7OvIAK83O3Ye7HqGM6e2TXY9QxoMH\nnu96hDJumljX9QhljK+1knjYuqFbH7bfbPvy/vG4pOslPbP0EQEATTTZ+lgn6e9tr1Ev7P+Y5KF2\nxwIAnNLk9rynJb1rGWYBAAzAk4kAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQ\nHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAo\njlADQHFDQ217ve3HbB+0/bTtbcsxGACgZ6zBmlck/VmSOduXSnrK9iNJnml5NgCAGlxRJzmWZK5/\n/KKkQ5Le1vZgAICekfaobb9D0tWS9rQxDADgtZpsfUiS+tseD0i6vX9l/Rr337vz9PHEpi2a2Lxl\nyQMCwEoxOzOt2ZnpkV/nJMMX2WOSHpS0O8k951iTXXNHRx5gpdm5+3DXI5Sx/caNXY+Agm6aWNf1\nCGWMr7WSeNi6plsf35B08FyRBgC0p8nteddJ+qSk99veb3uf7RvaHw0AIDXYo07yhKSLlmEWAMAA\nPJkIAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQ\nHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABQ3NNS277N93PbPlmMg\nAMDZmlxRf1PSh9oeBAAw2NBQJ3lc0gvLMAsAYAD2qAGguLHz+Wb337vz9PHEpi2a2LzlfL79BWF6\n+2TXIwAoanZmWrMz0yO/zkmGL7LfLulHSd65yJrsmjs68gArzU0T67oeAcAFYnytlcTD1jXd+nD/\nHwDAMmtye953JP1Y0kbbv7R9W/tjAQBOGbpHneQPl2MQAMBg3PUBAMURagAojlADQHGEGgCKI9QA\nUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoA\nKI5QA0BxhBoAiiPUAFAcoQaA4hqF2vYNtp+xfdj2F9seCgAwb2ioba+R9LeSPiRpQtIttn+77cEu\nZLMz012PUALnYR7nYh7nYnRNrqjfI+k/kvx3kpOSvifpY+2OdWHjB7GH8zCPczGPczG6JqF+m6Rn\nz/j6uf73AADLoEmoPeB7Od+DAAAGc7J4c23/rqQdSW7of/0lSUny1wvWEW8AGFGSQRfDZ2kS6osk\n/bukD0h6XtKTkm5Jcuh8DAkAWNzYsAVJfmP7c5IeUW+r5D4iDQDLZ+gVNQCgW0t+MpGHYXps32f7\nuO2fdT1L12yvt/2Y7YO2n7a9reuZumL7Ytt7bO/vn4s7u56pa7bX2N5n+4ddz9Il27+w/dP+z8aT\ni65dyhV1/2GYw+rtXx+VtFfSzUmeed1veoGy/V5JL0r6VpJ3dj1Pl2y/VdJbk8zZvlTSU5I+thp/\nLiTJ9iVJXup/3vOEpG1JFv0XcyWz/aeS3i3psiQf7Xqertg+IundSV4YtnapV9Q8DNOX5HFJQ0/4\napDkWJK5/vGLkg5pFd97n+Sl/uHF6n0utGr3G22vl/RhSV/vepYCrIYNXmqoeRgGi7L9DklXS9rT\n7STd6f+qv1/SMUmPJtnb9Uwd+pqkL2gV/8fqDJH0sO29tj+z2MKlhpqHYXBO/W2PByTd3r+yXpWS\nvJrkGknrJV1r+6quZ+qC7Y9IOt7/bcsa3I/VZEuSTer9hvHZ/vbpQEsN9XOSrjzj6/Xq7VVjlbM9\npl6k/yHJP3c9TwVJTkialnRDx6N05TpJH+3vzX5X0vtsf6vjmTqT5Fj/z19J+oF6W8kDLTXUeyX9\nlu23236DpJslreZPcrlKmPcNSQeT3NP1IF2y/Wbbl/ePxyVdL2lVfqia5MtJrkyyQb1WPJbk1q7n\n6oLtS/q/ccr2GyV9UNLPz7V+SaFO8htJpx6GOSDpe6v1YRjb35H0Y0kbbf/S9m1dz9QV29dJ+qSk\n9/dvPdpne7VeRa6T9C+259Tbp384yUMdz4TuXSHp8f5nF/8q6UdJHjnXYh54AYDi+F9xAUBxhBoA\niiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAo7v8Bw6nT/O1DNvkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b3ddc10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hist = PathHistogram(left_bin_edges=(0.0,0.0), bin_widths=(0.5,0.5), interpolate=True, per_traj=False)\n",
+    "\n",
+    "hist.add_trajectory(trajectory)\n",
+    "plt.pcolor(dataframe_from_counter(hist._histogram, ndim=(5, 7)).transpose(), cmap='Blues', vmin=0, vmax=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next type of histogram uses the interpolation, but also normalizes so that each trajectory only contributes once per bin. This is what we use for a path density plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PolyCollection at 0x11b4ccf50>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEACAYAAACatzzfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADDtJREFUeJzt3W+IXXedx/HPJ51Yplb7RKmpoUpZytIBiZraZarJqEW7\nmtVH3W3XpWwf+GBRUtxdUWSxsRRBKLqFhcJilXXxzzZFdzVU2kJ3ZmijbdpktE7SdVl1bckfXCi6\npUVS+/HBPckk05u55zo5c77JvF9Qcmb43cuXw/TdM797TuokAgDUtaHvAQAAKyPUAFAcoQaA4gg1\nABRHqAGgOEINAMWNDLXtK20fsL2/+fPXtneuxXAAAMnj3Edte4OkZyVdk+SZzqYCAJw07tbHdZL+\nh0gDwNoZN9R/IembXQwCABiu9daH7Y2SDku6KsmvOp0KAHDSxBhr/1TSk2eKtG3+0hAAGFMSj1oz\nTqhv0ohtjxeP02pJuuP2XfqHz+7qe4zecR6W3Pzxv9Of/83f9z1GCffefSfnonHDlstarWu1R217\nUoMPEr+9ipkAAH+AVlfUSV6U9PqOZwEADMGTiR3Ytn2m7xFK4Dwsmdo63fcIZXAuxjfWAy8rvpEd\n9qiB4fYsHul7BBR0w5bLWn2YyBU1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUA\nFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxrUJt\n+xLbu20fsr1o+5quBwMADEy0XHeXpPuT3GB7QtJFHc4EADjFyFDbfo2kdyX5a0lK8pKk33Q8FwCg\n0Wbr4wpJ/2f7q7b32/5n25NdDwYAGGiz9TEh6W2SPpbkCdv/KOnTkm5bvvCO23edPN62fUbbts+c\nnSkB4DywuG+vFp/YO/brnGTlBfalkn6Q5Irm63dK+lSSP1u2Li8eX/m9sL7sWTzS9whAaTdsuUxJ\nPGrdyK2PJMckPWP7yuZb75V0cJXzAQBaanvXx05JX7e9UdLPJN3S3UgAgFO1CnWSH0m6uuNZAABD\n8GQiABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANA\ncYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFDcRJtFtn8h6deSXpZ0\nPMk7uhwKALCkVag1CPRMkue6HAYA8Epttz48xloAwFnUNr6R9IDtfbY/2uVAAIDTtd36mE5y1Pbr\nJT1k+1CSR5YvuuP2XSePt22f0bbtM2dlSAA4Hyzu26vFJ/aO/TonGe8F9m2S/j/JF5d9Py8eH++9\nzkd7Fo/0PQJQ2o6pTX2PUMbkRiuJR60bufVh+yLbFzfHr5b0Pkk/Wf2IAIA22mx9XCrpO7bTrP96\nkge7HQsAcMLIUCf5uaQtazALAGAIbrkDgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAc\noQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiO\nUANAcYQaAIprHWrbG2zvt/3dLgcCAJxunCvqWyUd7GoQAMBwrUJte7OkD0j6crfjAACWa3tF/SVJ\nn5SUDmcBAAwxMWqB7Q9KOpZkwfaMJJ9p7R237zp5vG37jLZtn1n9hABwnpifm9X83OzYr3Oy8kWy\n7c9L+itJL0malPQaSd9OcvOyddm9cHjsAQCsLzumNvU9QhmTG60kZ7z4PWHk1keSzyS5PMkVkm6U\n9PDySAMAusN91ABQ3Mg96lMlmZM019EsAIAhuKIGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoA\niiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0A\nxRFqACiOUANAcYQaAIqbGLXA9oWS5iW9qll/X5LPdT0YAGBgZKiT/Nb2u5O8YPsCSY/a/n6Sx9dg\nPgBY91ptfSR5oTm8UIO4p7OJAACnaRVq2xtsH5B0VNJDSfZ1OxYA4ISRWx+SlORlSW+1/VpJ/277\nqiQHl6+79+47Tx5PbZ3W1NXTZ21QADjXzc/Nan5uduzXORlvF8P2ZyU9n+SLy76f3QuHxx4A568d\nU5v6HqGMPYtH+h6hDH4ulkxutJJ41LqRWx+2X2f7kuZ4UtJ1kp5e/YgAgDbabH1skvQvtjdoEPZ/\nS3J/t2MBAE5oc3veU5LetgazAACG4MlEACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDF\nEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDi\nCDUAFEeoAaC4kaG2vdn2w7YP2n7K9s61GAwAMDDRYs1Lkv42yYLtiyU9afvBJE93PBsAQC2uqJMc\nTbLQHD8v6ZCkN3Y9GABgYKw9attvlrRF0mNdDAMAeKU2Wx+SpGbb4z5JtzZX1q9w7913njye2jqt\nqaunVz0gAJwv5udmNT83O/brnGT0IntC0h5J309y1xnWZPfC4bEHALC+7Jja1PcIZUxutJJ41Lq2\nWx9fkXTwTJEGAHSnze1510r6iKT32D5ge7/t67sfDQAgtdijTvKopAvWYBYAwBA8mQgAxRFqACiO\nUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRH\nqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFDcy1LbvsX3M9o/XYiAAwOnaXFF/VdL7\nux4EADDcyFAneUTSc2swCwBgCPaoAaC4ibP5ZvfefefJ46mt05q6evpsvv05YcfUpr5HAFDU/Nys\n5udmx36dk4xeZL9J0veSvGWFNdm9cHjsAc43hBpAW5MbrSQeta7t1oebfwAAa6zN7XnfkLRX0pW2\nf2n7lu7HAgCcMHKPOslfrsUgAIDhuOsDAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0Bx\nhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4\nQg0AxbUKte3rbT9t+6e2P9X1UACAJSNDbXuDpH+S9H5JU5Jusv3HXQ92Lpufm+17hBI4D0s4F0s4\nF+Nrc0X9Dkn/neR/kxyX9C1JH+52rHMbP4gDnIclnIslnIvxtQn1GyU9c8rXzzbfAwCsgTah9pDv\n5WwPAgAYzsnKzbX9J5J2Jbm++frTkpLkC8vWEW8AGFOSYRfDp2kT6gsk/Zek90o6IulxSTclOXQ2\nhgQArGxi1IIkv7P9cUkParBVcg+RBoC1M/KKGgDQr1U/mcjDMAO277F9zPaP+56lb7Y3237Y9kHb\nT9ne2fdMfbF9oe3HbB9ozsVtfc/UN9sbbO+3/d2+Z+mT7V/Y/lHzs/H4imtXc0XdPAzzUw32rw9L\n2ifpxiRP/8Fveo6y/U5Jz0v6WpK39D1Pn2y/QdIbkizYvljSk5I+vB5/LiTJ9kVJXmg+73lU0s4k\nK/6LeT6z/QlJb5f02iQf6nuevtj+maS3J3lu1NrVXlHzMEwjySOSRp7w9SDJ0SQLzfHzkg5pHd97\nn+SF5vBCDT4XWrf7jbY3S/qApC/3PUsBVssGrzbUPAyDFdl+s6Qtkh7rd5L+NL/qH5B0VNJDSfb1\nPVOPviTpk1rH/7E6RSQ9YHuf7Y+utHC1oeZhGJxRs+1xn6RbmyvrdSnJy0neKmmzpGtsX9X3TH2w\n/UFJx5rftqzh/VhPppNs1eA3jI8126dDrTbUz0q6/JSvN2uwV411zvaEBpH+1yT/0fc8FST5jaRZ\nSdf3PEpfrpX0oWZv9puS3m37az3P1JskR5s/fyXpOxpsJQ+12lDvk/RHtt9k+1WSbpS0nj/J5Sph\nyVckHUxyV9+D9Mn262xf0hxPSrpO0rr8UDXJZ5JcnuQKDVrxcJKb+56rD7Yvan7jlO1XS3qfpJ+c\naf2qQp3kd5JOPAyzKOlb6/VhGNvfkLRX0pW2f2n7lr5n6ovtayV9RNJ7mluP9tter1eRmyT9p+0F\nDfbpH0hyf88zoX+XSnqk+ezih5K+l+TBMy3mgRcAKI7/FRcAFEeoAaA4Qg0AxRFqACiOUANAcYQa\nAIoj1ABQHKEGgOJ+D3hFzfU1kQYBAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b4c0e10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hist = PathHistogram(left_bin_edges=(0.0,0.0), bin_widths=(0.5,0.5), interpolate=True, per_traj=True)\n",
+    "\n",
+    "hist.add_trajectory(trajectory)\n",
+    "plt.pcolor(dataframe_from_counter(hist._histogram, ndim=(5, 7)).transpose(), cmap='Blues', vmin=0, vmax=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course, we can normalize to one contribution per path while *not* interpolating. I don't think this is actually useful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PolyCollection at 0x11b409e50>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEACAYAAACatzzfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADBNJREFUeJzt3W+IZXUdx/HPZ51NxiyfFLa2pEhIOCBWmrHWzFRSVmaP\nrMyQfNCDUFbKpIjQbVmCICohCCKLitJS+qOiqGAzg1q6ubupu2tFYSq6i4Fo4hJrfnpwz+7sjjNz\nz23mzvnuzvsFsmeuv3v5cph575nfvUedRACAutZ0PQAAYHGEGgCKI9QAUByhBoDiCDUAFEeoAaC4\nvqG2fZrt7ba3NX8+b3vjSgwHAJA8yOeoba+R9JSkc5I8ObSpAAAHDbr1cZ6kvxNpAFg5g4b6k5Ju\nGMYgAID5td76sL1W0tOSTk/y7FCnAgAcNDLA2g9LemihSNvmPxoCAANK4n5rBgn1xeqz7bFvP62W\npC2bN+lr12zqeozOcR5mcS5mXXrFVfrE57/U9RglXHTmSa3Wtdqjtj2q3huJv17CTACA/0OrK+ok\n+yS9ccizAADmwZ2JQzA+Mdn1CCVwHmZxLmaNnbWh6xGOOAPd8LLoC9lhjxpAP7ftfKbrEcq46MyT\nWr2ZyBU1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiO\nUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxrUJt+wTbN9nebXun7XOGPRgA\noGek5brrJN2e5CLbI5KOG+JMAIBD9A217ddJem+Sz0pSkpclvTDkuQAAjTZbH6dK+pftH9veZvsH\ntkeHPRgAoKfN1seIpHdIujzJn2x/V9JXJF07d+GWzZsOHo9PTGp8YnJ5pgSAo8DOrfdr55/uH/h5\nTrL4AvtESX9Icmrz9XskfTnJx+asy779i78WAGDW6Forifut67v1kWSvpCdtn9Y89AFJu5Y4HwCg\npbaf+tgo6ee210r6h6TLhjcSAOBQfbc+Wr8QWx8AMJBl2/oAAHSLUANAcYQaAIoj1ABQHKEGgOII\nNQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGE\nGgCKI9QAUByhBoDiCDUAFEeoAaC4kTaLbD8u6XlJr0jan+RdwxwKADCrVajVC/RkkueGOQwA4NXa\nbn14gLUAgGXUNr6RdKftrbY/N8yBAACHa7v1sSHJHttvlHS37d1J7p27aMvmTQePxycmNT4xuSxD\nAsDRYGZ6SjPTUwM/z0kGe4J9raR/J/n2nMezb/9grwUAq9noWiuJ+63ru/Vh+zjbxzfHr5X0QUmP\nLn1EAEAbbbY+TpT0G9tp1v88yV3DHQsAcMDAWx8LvhBbHwAwkGXb+gAAdItQA0BxhBoAiiPUAFAc\noQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiO\nUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoLjWoba9xvY227cMcyAAwOEGuaK+UtKuYQ0CAJhfq1Db\nXi/pI5J+ONxxAABztb2i/o6kqyVliLMAAOYx0m+B7Y9K2ptkh+1JSV5o7ZbNmw4ej09ManxicukT\nAsBRYmZ6SjPTUwM/z8niF8m2vyHpM5JeljQq6XWSfp3k0jnrsm8/F9wA0NboWivJghe/B/QN9WGL\n7QlJVyW5cJ5/R6gBYABtQ83nqAGguIGuqBd9Ia6oAWAgXFEDwFGCUANAcYQaAIoj1ABQHKEGgOII\nNQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGE\nGgCKI9QAUByhBoDiCDUAFEeoAaC4kX4LbB8raUbSa5r1Nyf5+rAHAwD09A11kv/Yfl+Sl2wfI+k+\n23ckeXAF5gOAVa/V1keSl5rDY9WLe4Y2EQDgMK1CbXuN7e2S9ki6O8nW4Y4FADig79aHJCV5RdLb\nbb9e0m9tn55k19x1WzZvOng8PjGp8YnJZRoTAI58M9NTmpmeGvh5TgbbxbB9jaQXk3x7zuO5acfT\nAw9wtLlgbF3XI6Cg23Y+0/UIZfAzMmt0rZXE/db13fqw/QbbJzTHo5LOk/TY0kcEALTRZutjnaSf\n2F6jXth/meT24Y4FADigzcfzHpH0jhWYBQAwD+5MBIDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQa\nAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEIN\nAMURagAojlADQHGEGgCK6xtq2+tt32N7l+1HbG9cicEAAD0jLda8LOmLSXbYPl7SQ7bvSvLYkGcD\nAKjFFXWSPUl2NMcvStot6c3DHgwA0DPQHrXtUySdKemBYQwDAHi1NlsfkqRm2+NmSVc2V9av8qvv\nf+vg8dhZGzR29oYlDwgAR4uZ6SnNTE8N/Dwn6b/IHpF0m6Q7kly3wJrs29//tYDV6Ladz3Q9QhkX\njK3reoQyRtdaSdxvXdutjx9J2rVQpAEAw9Pm43nnSrpE0vttb7e9zfb5wx8NACC12KNOcp+kY1Zg\nFgDAPLgzEQCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAU\nR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAorm+obV9ve6/t\nh1diIADA4dpcUf9Y0oeGPQgAYH59Q53kXknPrcAsAIB5sEcNAMWNLOeLXXrFVQePx87aoLGzNyzn\nyx8RLhhb1/UIKIjvC0jSzPSUZqanBn6ek/RfZJ8s6dYkZyyyJjfteHrgAY42/EACaGt0rZXE/da1\n3fpw8w8AYIW1+XjeLyTdL+k020/Yvmz4YwEADui7R53k0ysxCABgfnzqAwCKI9QAUByhBoDiCDUA\nFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoA\niiPUAFAcoQaA4gg1ABRHqAGgOEINAMW1CrXt820/Zvuvtr887KEAALP6htr2Gknfk/QhSWOSLrb9\ntmEPdiSbmZ7qeoQSOA+zOBezOBeDa3NF/S5Jf0vyzyT7Jd0o6ePDHevIxjdiD+dhFudiFudicG1C\n/WZJTx7y9VPNYwCAFdAm1J7nsSz3IACA+TlZvLm23y1pU5Lzm6+/IilJvjlnHfEGgAElme9i+DBt\nQn2MpL9I+oCkZyQ9KOniJLuXY0gAwOJG+i1I8l/bV0i6S72tkuuJNACsnL5X1ACAbi35zkRuhumx\nfb3tvbYf7nqWrtleb/se27tsP2J7Y9czdcX2sbYfsL29ORfXdj1T12yvsb3N9i1dz9Il24/b/nPz\nvfHgomuXckXd3AzzV/X2r5+WtFXSp5I89n+/6BHK9nskvSjpp0nO6HqeLtl+k6Q3Jdlh+3hJD0n6\n+Gr8vpAk28cleal5v+c+SRuTLPqDeTSz/QVJ75T0+iQXdj1PV2z/Q9I7kzzXb+1Sr6i5GaaR5F5J\nfU/4apBkT5IdzfGLknZrFX/2PslLzeGx6r0vtGr3G22vl/QRST/sepYCrJYNXmqouRkGi7J9iqQz\nJT3Q7STdaX7V3y5pj6S7k2zteqYOfUfS1VrFf1kdIpLutL3V9ucWW7jUUHMzDBbUbHvcLOnK5sp6\nVUrySpK3S1ov6Rzbp3c9Uxdsf1TS3ua3LWv+fqwmG5Kcpd5vGJc326fzWmqon5L0lkO+Xq/eXjVW\nOdsj6kX6Z0l+1/U8FSR5QdKUpPM7HqUr50q6sNmbvUHS+2z/tOOZOpNkT/Pns5J+o95W8ryWGuqt\nkt5q+2Tbr5H0KUmr+Z1crhJm/UjSriTXdT1Il2y/wfYJzfGopPMkrco3VZN8NclbkpyqXivuSXJp\n13N1wfZxzW+csv1aSR+U9OhC65cU6iT/lXTgZpidkm5crTfD2P6FpPslnWb7CduXdT1TV2yfK+kS\nSe9vPnq0zfZqvYpcJ+n3tneot09/Z5LbO54J3TtR0r3Nexd/lHRrkrsWWswNLwBQHP8rLgAojlAD\nQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0Axf0PBjbcDMGNNNkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b700890>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hist = PathHistogram(left_bin_edges=(0.0,0.0), bin_widths=(0.5,0.5), interpolate=False, per_traj=True)\n",
+    "\n",
+    "hist.add_trajectory(trajectory)\n",
+    "plt.pcolor(dataframe_from_counter(hist._histogram, ndim=(5, 7)).transpose(), cmap='Blues', vmin=0, vmax=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Hypothetically, it is possible for a path to cut exactly through a corner. It won't happen in the real world, but we would like our interpolation algorithm to get even the unlikely cases right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x11b9604d0>]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAEACAYAAABWLgY0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAFJ5JREFUeJzt3W+MZXV9x/H3d0ViAqkbSQphsTtkizW0kjEmsNY2O8QQ\nwBJIG4k1JjLYBwaqLDEaDbouG/qgNH3AHzUGg44IBIlpBFEaSGFibOpKYCcSAUG6IOzKblLgASsP\nkP32wdzd3zDeu3Nn5tx7zj3n/Uomzpl7WH75cPztdz5z7pnITCRJ7bSh7gVIkkbHTV6SWsxNXpJa\nzE1eklrMTV6SWsxNXpJabMVNPiJOi4iHIuKJiHg8Iq7qc862iHg1Ih7rfXxlNMuVJK3GcUOc8wfg\nc5m5EBEnAo9GxAOZ+dSy836amRdXv0RJ0lqtOMln5kuZudD7/DXgSWBTn1Oj4rVJktZpVZ18REwB\n08DuPi9vjYg9EfHjiDizgrVJktZpmLoGgF5V8wNge2+iX+pRYHNm/j4iLgR+CLynumVKktYihnl2\nTUQcB9wH3J+ZNw5x/l7gA5n58rKv+6AcSVqDzFxTJT5sXfNt4IlBG3xEnLzk87NZ/Mvj5X7nZqYf\nmezcubP2NTTlwyzMwiyO/bEeK9Y1EfEh4BPA4xGxB0jgGmDz4p6dtwAfjYgrgDeA14GPrWtVHfDc\nc8/VvYTGMIvCLAqzqMaKm3xm/jfwthXO+Trw9aoWJUmqhu94rcns7GzdS2gMsyjMojCLagz1g9fK\n/mUROc5/nyS1QUSQI/7Bqyo2Pz9f9xIawywKsyjMohpu8pLUYtY1ktRw1jWSpL7c5Gti31iYRWEW\nhVlUw01eklrMTl6SGs5OXpLUl5t8TewbC7MozKIwi2q4yUtSi9nJS1LD2clLkvpyk6+JfWNhFoVZ\nFGZRjaF/x6skdcnevc+zY8cc+/YdZtOmDVx33Synn7657mWtmp28JC2zd+/znHfezTz77C7gBOAQ\nW7bs5MEHP1vLRm8nL0kV2rFjbskGD3ACzz67ix075mpc1dq4ydfEvrEwi8IsirqyyIQ9ew5TNvgj\nTmD//sN1LGld3OQlqefgQbj0UnjxxQ3AoWWvHuLUUydvy7STl9R5mXD33bB9O1x2GVx++fNcdFE7\nOnk3eUmddvAgXHkl/OpXMDcH55yz+PUjd9fs33+YU0+t9+4af/A6gexeC7MozKIYdRaZ8P3vw1ln\nwZYtsGdP2eABTj99M7ffvpOHHtrF7bfvnMjbJ8H75CV10NLp/Z573rq5t411jaTOWN6979oF73hH\n3ata2XrqGid5SZ3Qpel9KTv5mti9FmZRmEVRVRYrde9t5yQvqbW6Or0vZScvqXUmtXsfxE5eknqc\n3t/KTr4mdq+FWRRmUaw2i65374M4yUuaeE7vg9nJS5pYbeveB7GTl9Q5Tu/DsZOvid1rYRaFWRSD\nsrB7Xx0neUkTw+l99Vbs5CPiNOA24BTgTeBbmXlTn/NuAi5k8Un7s5m50OccO3lJq9aV7n2QUXfy\nfwA+l5kLEXEi8GhEPJCZTy1ZwIXAlsw8IyLOAb4JbF3LgiRpKaf39Vmxk8/Ml45M5Zn5GvAksGnZ\naZewOO2TmbuBd0bEyRWvtVXsXguzKMyiePjhebv3Cqyqk4+IKWAa2L3spU3AC0uO9/W+dmAda5PU\nUQcPwrXXLv6v0/v6DL3J96qaHwDbexP9W17u84/0Ld9nZ2eZmpoCYOPGjUxPTzMzMwOUKaYLxzMz\nM41aj8fNOT6iKesZ53EmHDw4w/btcO658OUvz3POOc1Z37iO5+fnmZubAzi6X67VUG+GiojjgPuA\n+zPzxj6vfxN4ODO/3zt+CtiWmQeWnecPXiX1Neh3rWo8v+P128AT/Tb4nnuBT/YWsxV4dfkGr7da\nPrV1mVkUXcxi0H3vXcxiFFasayLiQ8AngMcjYg+LNcw1wGYgM/OWzPxJRHwkIn7D4i2Ul49y0ZLa\nwTtnRs9n10gau67f975aPrtG0sRweh8vn11TE/vGwiyKNmex2mfOtDmLcXKSlzRyTu/1sZOXNDJ2\n79Wwk5fUOE7vzWAnXxP7xsIsijZkUdXz3tuQRRM4yUuqjNN789jJS1o3u/fRspOXVBun92azk6+J\nfWNhFsUkZTHq37U6SVk0mZO8pFVzep8cdvKShmb3Xg87eUkj5/Q+mezka2LfWJhF0cQsRt29D9LE\nLCaRk7ykgZzeJ5+dvKQ/YvfeLHbykirj9N4udvI1sW8szKKoM4u6uvdBvC6q4SQvyem9xezkpQ6z\ne58MdvKSVs3pvRvs5Gti31iYRTGOLJrWvQ/idVENJ3mpQ5zeu8dOXuoAu/fJZicvaSCn926zk6+J\nfWNhFkWVWUxK9z6I10U1nOSlFnJ61xF28lKL2L23k528JKd39WUnXxP7xsIsirVkMend+yBeF9Vw\nkpcmmNO7VmInL00gu/dusZOXOsTpXathJ18T+8bCLIpjZdHW7n0Qr4tqOMlLE8DpXWu1YicfEbcC\nFwEHMvOsPq9vA+4B/rf3pf/IzH8Z8GfZyUurYPcuGH0n/x3gZuC2Y5zz08y8eC0LkNSf07uqsGIn\nn5k/A15Z4bQ1/Q3TZfaNhVkU8/PzneveB/G6qEZVnfzWiNgD7Ae+kJlPVPTnSp3yyitw6aVO76rO\nUPfJR8Rm4EcDOvkTgcOZ+fuIuBC4MTPfM+DPsZOX+rB717HUep98Zr625PP7I+IbEfGuzHy53/mz\ns7NMTU0BsHHjRqanp5mZmQHKt2cee9yl4zPPnOHKK+EXv5jnq1+FK69s1vo8Hv/x/Pw8c3NzAEf3\ny7UadpKfYnGSf1+f107OzAO9z88G7s7Mvqtyki/m5+eP/sftuq5m0W96//nPu5lFP129LvoZ6SQf\nEXcCM8BJEfFbYCdwPJCZeQvw0Yi4AngDeB342FoWInWJd85oXHx2jTRGdu9aC59dI00Ap3fVwWfX\n1OTID1nU/ixWc99727NYDbOohpO8NEJO76qbnbw0AnbvqpKdvNQgTu9qEjv5mtg3Fm3JoopnzrQl\niyqYRTWc5KUKOL2rqezkpXWwe9c42MlLNXB61ySwk6+JfWMxaVmM8nnvk5bFKJlFNZzkpVVwetek\nsZOXhmD3rjrZyUsj5PSuSWYnXxP7xqKpWdTxu1abmkUdzKIaTvJSH07vags7eWkJu3c1kZ28VAGn\nd7WRnXxN7BuLurOoo3sfpO4smsQsquEkr05zelfb2cmrk+zeNUns5KVVcHpXl9jJ18S+sRhXFk3q\n3gfxuijMohpO8uoEp3d1lZ28Ws3uXW1gJy/14fQu2cnXxr6xqDqLSejeB/G6KMyiGk7yahWnd+mt\n7OTVCnbvajM7eXWa07s0mJ18Tewbi7VmMcnd+yBeF4VZVMNJXhPJ6V0ajp28Jordu7rITl6d4PQu\nrZ6dfE3sG4uVsmhj9z6I10VhFtVwklejOb1L62Mnr0aye5eKkXbyEXErcBFwIDPPGnDOTcCFwCFg\nNjMX1rIYCZzepSoN08l/Bzh/0IsRcSGwJTPPAD4NfLOitbWafWNxJIsude+DeF0UZlGNFSf5zPxZ\nRGw+ximXALf1zt0dEe+MiJMz80BVi1T7Ob1Lo1HF3TWbgBeWHO/rfU3HMDMzU/cSGiETDhyY6fT0\nvpTXRWEW1aji7pp+Pwzwp6takdO7NHpVbPIvAu9ecnwasH/QybOzs0xNTQGwceNGpqenj/6NfaSD\n68Lx0r6xCesZ5/G2bTPcfTdcccU8558PN94I55wz05j11Xm8sLDA1Vdf3Zj11Hl8ww03dHp/mJub\nAzi6X67VULdQRsQU8KPMfF+f1z4C/HNm/l1EbAVuyMytA/4cb6HsmZ+fP/oft0uWTu9zc4vTe1ez\n6McsCrMo1nML5YqbfETcCcwAJwEHgJ3A8UBm5i29c74GXMDiLZSXZ+ZjA/4sN/mO8r53ae1GuslX\nyU2+m/pN75KGt55N3mfX1ORI/9Zmw9733oUshmUWhVlUw2fXaCS8c0ZqBusaVcruXaqez5NXIzi9\nS81jJ1+TNvWN633mTJuyWC+zKMyiGk7yWhend6nZ7OS1Jnbv0vjYyWusnN6lyWEnX5NJ7BtH9bz3\nScxiVMyiMItqOMlrKE7v0mSyk9cx2b1L9bOT10g4vUuTz06+Jk3uG8f9u1abnMW4mUVhFtVwktdb\nOL1L7WInL8DuXWoyO3mti9O71F528jVpQt847u59kCZk0RRmUZhFNZzkO8rpXeoGO/mOsXuXJo+d\nvIbi9C51j518TcbZNzalex/E7rUwi8IsquEk33JO71K32cm3lN271B528noLp3dJR9jJ12QUfWPT\nu/dB7F4LsyjMohpO8i3h9C6pHzv5CWf3LrWfnXxHOb1LWomdfE3W0zdOavc+iN1rYRaFWVTDSX7C\nOL1LWg07+Qlh9y51l518yzm9S1orO/maDNM3tq17H8TutTCLwiyq4STfUE7vkqpgJ98wdu+SlrOT\nbwmnd0lVG6qTj4gLIuKpiHg6Ir7Y5/XLIuJgRDzW+/hU9Uttl6V9Y1e690HsXguzKMyiGitO8hGx\nAfga8GFgP/BIRNyTmU8tO/WuzLxqBGtsNad3SaM0zCR/NvBMZj6fmW8AdwGX9DlvTX1RV23bNtPp\n6X2pmZmZupfQGGZRmEU1hunkNwEvLDl+kcWNf7l/iIi/BZ4GPpeZL1awvlZyepc0LsNs8v0m9OW3\nyNwL3JmZb0TEp4Hvsljv/JHZ2VmmpqYA2LhxI9PT00f/xj7SwbX1+OGH53n4YbjllhnOPXeeG2+E\n118HaMb66jo+8rWmrKfO44WFBa6++urGrKfO4xtuuKFT+8PS4/n5eebm5gCO7pdrteItlBGxFbg2\nMy/oHX8JyMy8fsD5G4CXM3Njn9c6ewvl0ul9bg5ef33+6H/crpufN4sjzKIwi2I9t1AOs8m/Dfg1\ni5P574BfAB/PzCeXnHNKZr7U+/zvgS9k5l/3+bM6t8l737uk9RrpffKZ+WZEfAZ4gMUf1N6amU9G\nxC7gkcy8D7gqIi4G3gBeBmbXspi2sXuXVLeh7pPPzP/MzL/IzDMy8197X9vZ2+DJzGsy868y8/2Z\n+eHMfHqUi266Ye57X9pHd51ZFGZRmEU1fMdrxZzeJTWJz66piN27pFHx2TU1c3qX1FQ+T34d1vPM\nGfvGwiwKsyjMohpO8mvk9C5pEtjJr5Ldu6Rxs5MfE6d3SZPGTn4Io3jeu31jYRaFWRRmUQ0n+RU4\nvUuaZHbyA9i9S2oKO/mKOb1Lags7+SXG+btW7RsLsyjMojCLajjJ9zi9S2qjznfydu+Sms5Ofkh7\n9z7Pjh1z7Nt3mE2bNrB9+yzXX7/Z6V1Sa3Wmk9+793nOO+9m7rjj88zP7+KOOz7PBz94Myed9PxI\nu/dB7BsLsyjMojCLanRmk9+xY45nn90FnND7ygm8+eYuDh2as56R1Fqd2eT37TtM2eCPOIH9+w/X\nsRx/QfESZlGYRWEW1ejMJr9p0wbg0LKvHuLUUzsTgaQO6swOd911s2zZspOy0R9iy5adXHfdbC3r\nsW8szKIwi8IsqtGZu2tOP30zDz74WXbs+Hf27z/Mqadu4LrrPsvpp2+ue2mSNDKdv09ekppuPffJ\nd6aukaQucpOviX1jYRaFWRRmUQ03eUlqMTt5SWo4O3lJUl9u8jWxbyzMojCLwiyq4SYvSS1mJy9J\nDWcnL0nqy02+JvaNhVkUZlGYRTXc5CWpxezkJanh7OQlSX0NtclHxAUR8VREPB0RX+zz+vERcVdE\nPBMR/xMRf1b9UtvFvrEwi8IsCrOoxoqbfERsAL4GnA/8JfDxiHjvstP+CXg5M88AbgD+reqFts3C\nwkLdS2gMsyjMojCLagwzyZ8NPJOZz2fmG8BdwCXLzrkE+G7v8x8AH65uie306quv1r2ExjCLwiwK\ns6jGMJv8JuCFJccv9r7W95zMfBN4NSLeVckKJUlrNswm3+8nustvkVl+TvQ5R0s899xzdS+hMcyi\nMIvCLKqx4i2UEbEVuDYzL+gdfwnIzLx+yTn3987ZHRFvA36XmX/a589y45ekNVjrLZTD/CLvR4A/\nj4jNwO+AfwQ+vuycHwGXAbuBS4GHqlykJGltVtzkM/PNiPgM8ACL9c6tmflkROwCHsnM+4Bbge9F\nxDPA/7H4F4EkqWZjfcerJGm8RvKOV988VQyRxWURcTAiHut9fKqOdY5aRNwaEQci4pfHOOem3jWx\nEBHT41zfOK2URURsi4hXl1wTXxn3GsclIk6LiIci4omIeDwirhpwXuuvjWGyWNO1kZmVfrD4F8dv\ngM3A24EF4L3LzrkC+Ebv848Bd1W9jiZ8DJnFZcBNda91DFn8DTAN/HLA6xcCP+59fg7w87rXXGMW\n24B7617nmLI4BZjufX4i8Os+/x/pxLUxZBarvjZGMcn75qlimCyg/22qrZKZPwNeOcYplwC39c7d\nDbwzIk4ex9rGbYgsoAPXBEBmvpSZC73PXwOe5I/fh9OJa2PILGCV18YoNnnfPFUMkwXAP/S+Db07\nIk4bz9IaZ3lW++ifVVdsjYg9EfHjiDiz7sWMQ0RMsfgdzu5lL3Xu2jhGFrDKa2MUm7xvniqGyeJe\nYCozp4H/onyH0zXDZNUVjwKbM/P9LD436oc1r2fkIuJEFr+r396bYt/ycp9/pLXXxgpZrPraGMUm\n/yKw9AeppwH7l53zAvBugN6bp/4kM1f69nUSrZhFZr7Sq3IAvgV8YExra5oX6V0TPf2um07IzNcy\n8/e9z+8H3t7S73QBiIjjWNzUvpeZ9/Q5pTPXxkpZrOXaGMUmf/TNUxFxPIv3zN+77Jwjb56CY7x5\nqgVWzCIiTllyeAnwxBjXN27B4D7xXuCTcPRd1q9m5oFxLawGA7NY2jdHxNks3ur88rgWVoNvA09k\n5o0DXu/StXHMLNZybQzzjtdVSd88ddSQWVwVERcDbwAvA7O1LXiEIuJOYAY4KSJ+C+wEjmfxERm3\nZOZPIuIjEfEb4BBweX2rHa2VsgA+GhFXsHhNvM7iHWitFBEfAj4BPB4Re1isYa5h8Y60Tl0bw2TB\nGq4N3wwlSS3mr/+TpBZzk5ekFnOTl6QWc5OXpBZzk5ekFnOTl6QWc5OXpBZzk5ekFvt/x8YFpjXm\nWhkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b960550>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "diag = [(0.25, 0.25), (2.25, 2.25)]\n",
+    "diag_x, diag_y = zip(*diag)\n",
+    "plt.grid(True)\n",
+    "plt.plot(diag_x, diag_y, 'o-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PolyCollection at 0x11b84a690>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEACAYAAACatzzfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADAVJREFUeJzt3V+IpXUdx/HPZ51Rxr83iW4tFhYSLoT/0tCYGUvSyvQq\n0gzBC6+UlQpRJHRblqAbTegqtKjoH4r2Z1FUsJlhtXRzd1N314zMVNxdDMQSl9jy08U5u7M7np3z\nHGfOPN/deb9A9pnhdw5fHsa3z/zO86xOIgBAXSvaHgAAMD9CDQDFEWoAKI5QA0BxhBoAiiPUAFBc\n31DbPsP2Ftubu3++ZXvNUgwHAJA8yH3UtldIek3SBUleHdpUAID9Bt36uETS34g0ACydQUP9FUm/\nGMYgAIDeGm992B6V9LqkM5O8MdSpAAD7jQyw9vOSnjlUpG3zl4YAwICSuN+aQUJ9tfpse+zZS6sl\naf26tfrW7WvbHqN1nIdZnItZnItZY6N9Gy2p4R617TF1Pkh8YAEzAQDeh0ZX1En2SDp5yLMAAHrg\nycQhGJ+YbHuEEjgPszgXszgXgxvogZd538gOe9QA0NzYqBt9mMgVNQAUR6gBoDhCDQDFEWoAKI5Q\nA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeo\nAaA4Qg0AxRFqACiOUANAcY1Cbfsk2/fZ3mF7m+0Lhj0YAKBjpOG6uyU9lOTLtkckHTvEmQAAB3CS\n+RfYJ0jamuSjfdZlz9753wsAMGts1ErifuuabH2cLumftn9ke7PtH9geW/iIAIAmmmx9jEg6R9IN\nSf5k+3uSbpV0x9yF69et3X88PjGp8YnJxZkSAI4AM9NTmpmeGvh1TbY+TpH0hySnd7/+tKRbknxp\nzjq2PgBgAIu29ZFkt6RXbZ/R/dZnJW1f4HwAgIaa3vWxRtLPbI9KeknSdcMbCQBwoL5bH43fiK0P\nABjIYt71AQBoEaEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGg\nOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcSNNFtl+WdJb\nkt6VtDfJ+cMcCgAwq1Go1Qn0ZJI3hzkMAOC9mm59eIC1AIBF1DS+kfSI7U22rx/mQACAgzXd+rgw\nyS7bJ0t6zPaOJBvnLlq/bu3+4/GJSY1PTC7KkABwJJiZntLM9NTAr3OSwV5g3yHp30nunPP97Nk7\n2HsBWH42bNvZ9ghlfPmsDyqJ+63ru/Vh+1jbx3ePj5P0OUnPL3xEAEATTbY+TpH0oO101/8syaPD\nHQsAsE/fUCf5u6SzlmAWAEAP3HIHAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0A\nxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA\n4gg1ABTXONS2V9jebPu3wxwIAHCwQa6ob5K0fViDAAB6axRq26skfUHSPcMdBwAwV9Mr6rsk3Swp\nQ5wFANDDSL8Ftr8oaXeSrbYnJflQa9evW7v/eHxiUuMTkwufEACOENs2Paltf3py4Nc5mf8i2fZ3\nJH1N0n8ljUk6QdIDSa6dsy579nLBDfSyYdvOtkco4/LVK9seoYyxUSvJIS9+9+m79ZHktiSnJTld\n0lWSHp8baQDA8HAfNQAU13eP+kBJpiVND2kWAEAPXFEDQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4\nQg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAc\noQaA4gg1ABRHqAGgOEINAMWN9Ftg+xhJM5KO7q6/P8m3hz0YAKCjb6iT/Mf2xUnesX2UpCdsP5zk\n6SWYDwCWvUZbH0ne6R4eo07cM7SJAAAHaRRq2ytsb5G0S9JjSTYNdywAwD59tz4kKcm7ks62faKk\nX9s+M8n2uevWr1u7/3h8YlLjE5OLNCYAHP5mpqc0Mz018OucDLaLYft2SW8nuXPO97NnLzsimLVh\n2862Ryjj8tUr2x4BBY2NWkncb13frQ/bH7B9Uvd4TNIlkl5Y+IgAgCaabH2slPRj2yvUCfuvkjw0\n3LEAAPs0uT3vOUnnLMEsAIAeeDIRAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoA\niiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0A\nxRFqACiub6htr7L9uO3ttp+zvWYpBgMAdIw0WPNfSd9IstX28ZKesf1okheGPBsAQA2uqJPsSrK1\ne/y2pB2SPjTswQAAHQPtUdv+iKSzJD01jGEAAO/VZOtDktTd9rhf0k3dK+v3WL9u7f7j8YlJjU9M\nLnA8ADhyzExPaWZ6auDXOUn/RfaIpA2SHk5y9yHWZM/e/u91pNuwbWfbI5Rx+eqVbY8AlDY2aiVx\nv3VNtz5+KGn7oSINABieJrfnXSTpGkmfsb3F9mbblw1/NACA1GCPOskTko5aglkAAD3wZCIAFEeo\nAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPU\nAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUFzfUNu+1/Zu288uxUAAgIM1uaL+\nkaRLhz0IAKC3vqFOslHSm0swCwCgB/aoAaC4kcV8s2tv/Ob+49XnXajVn7xwMd/+sHD56pVtjwCg\nqJnpKc1MTw38Oifpv8j+sKTfJfnEPGty39bXBx7gSEOoATQ1Nmolcb91Tbc+3P0HALDEmtye93NJ\nT0o6w/Yrtq8b/lgAgH367lEn+epSDAIA6I27PgCgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDi\nCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0Bx\nhBoAiiPUAFBco1Dbvsz2C7ZftH3LsIcCAMzqG2rbKyR9X9KlklZLutr2x4c92OFsZnqq7RFK4DzM\n4lzM4lwMrskV9fmS/prkH0n2SvqlpCuHO9bhjR/EDs7DLM7FLM7F4JqE+kOSXj3g69e63wMALIEm\noXaP72WxBwEA9OZk/uba/pSktUku6359q6Qk+e6cdcQbAAaUpNfF8EGahPooSX+R9FlJOyU9Lenq\nJDsWY0gAwPxG+i1I8j/bN0p6VJ2tknuJNAAsnb5X1ACAdi34yUQehumwfa/t3bafbXuWttleZftx\n29ttP2d7TdsztcX2Mbafsr2ley7uaHumttleYXuz7d+2PUubbL9s+8/dn42n5127kCvq7sMwL6qz\nf/26pE2Srkrywvt+08OU7U9LelvST5J8ou152mT7VEmnJtlq+3hJz0i6cjn+XEiS7WOTvNP9vOcJ\nSWuSzPsv5pHM9tclnSvpxCRXtD1PW2y/JOncJG/2W7vQK2oehulKslFS3xO+HCTZlWRr9/htSTu0\njO+9T/JO9/AYdT4XWrb7jbZXSfqCpHvanqUAq2GDFxpqHobBvGx/RNJZkp5qd5L2dH/V3yJpl6TH\nkmxqe6YW3SXpZi3j/1gdIJIesb3J9vXzLVxoqHkYBofU3fa4X9JN3SvrZSnJu0nOlrRK0gW2z2x7\npjbY/qKk3d3ftqze/VhOLkxynjq/YdzQ3T7taaGhfk3SaQd8vUqdvWosc7ZH1In0T5P8pu15Kkjy\nL0lTki5reZS2XCTpiu7e7C8kXWz7Jy3P1Joku7p/viHpQXW2kntaaKg3SfqY7Q/bPlrSVZKW8ye5\nXCXM+qGk7UnubnuQNtn+gO2Tusdjki6RtCw/VE1yW5LTkpyuTiseT3Jt23O1wfax3d84Zfs4SZ+T\n9Pyh1i8o1En+J2nfwzDbJP1yuT4MY/vnkp6UdIbtV2xf1/ZMbbF9kaRrJH2me+vRZtvL9SpypaTf\n296qzj79I0keankmtO8USRu7n138UdLvkjx6qMU88AIAxfG/4gKA4gg1ABRHqAGgOEINAMURagAo\njlADQHGEGgCKI9QAUNz/AXsx2MJUU047AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11b82d290>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hist = PathHistogram(left_bin_edges=(0.0,0.0), bin_widths=(0.5,0.5), interpolate=True, per_traj=True)\n",
+    "\n",
+    "hist.add_trajectory(diag)\n",
+    "plt.pcolor(dataframe_from_counter(hist._histogram, ndim=(5, 7)).transpose(), cmap='Blues', vmin=0, vmax=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How would we make this into an actual path density plot? Add the trajectories on top of each other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PolyCollection at 0x11bb3b310>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEACAYAAACatzzfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADF1JREFUeJzt3X+sX3V9x/HXq9yKF0H+0SDQoCFLs9DEVAVZimuvSgR/\nTP5igzkJ/OEfBlOyqdG5RTqCS5Y0OhISkkV00/hjQNQpgQAJ622gG1xor+JtGcuYCiltXNLICGQp\n8tof39Pe9vLt/Z6vt+eed+99PhLSc28+32/eObk8OffzPac4iQAAda3pewAAwOIINQAUR6gBoDhC\nDQDFEWoAKI5QA0BxI0Nte73tPbZ3N3/+xvbW5RgOACB5nPuoba+R9LykS5M819lUAICjxt36uFzS\nfxFpAFg+44b6TyR9r4tBAADDtd76sL1W0n5JFyX5dadTAQCOmhhj7YclPXmiSNvmLw0BgDEl8ag1\n44T6Wo3Y9njlMK2WpFtv2aa//vK2vsfoHedh3nWf+az++NOf63uMEu66YzvnonH1xvNarWu1R217\nUoMPEn+whJkAAL+DVlfUSV6R9NaOZwEADMGTiR3YvGWq7xFK4DzM23Dxpr5HKINzMb6xHnhZ9I3s\nsEcNDHfv3At9j4CCrt54XqsPE7miBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEG\ngOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAorlWo\nbZ9t+27b+2zP2b6068EAAAMTLdfdJum+JFfbnpB0RoczAQCOMTLUts+S9IdJrpekJK9KerHjuQAA\njTZbHxdK+h/b37S92/Y/2J7sejAAwECbrY8JSe+WdGOSJ2z/vaQvSrp54cJbb9l29Hjzlilt3jJ1\ncqYEgBVgbmaX5p7YNfbrnGTxBfY5kv4tyYXN1++T9IUkf7RgXV45vPh7YXW5d+6FvkcASrt643lK\n4lHrRm59JDko6Tnb65tvfVDS3iXOBwBoqe1dH1slfcf2WknPSrqhu5EAAMdqFeokP5V0ScezAACG\n4MlEACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA\n4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaC4iTaLbP9C0m8kvSbp\ncJL3djkUAGBeq1BrEOipJIe6HAYA8Hpttz48xloAwEnUNr6R9IDtGduf6nIgAMDx2m59bEpywPZb\nJT1ke1+SRxYuuvWWbUePN2+Z0uYtUydlSABYCeZmdmnuiV1jv85JxnuBfbOk/03y1QXfzyuHx3uv\nlejeuRf6HgEobfv9z/Q9QhmP/eWUknjUupFbH7bPsH1mc/wmSR+S9POljwgAaKPN1sc5kn5oO836\n7yR5sNuxAABHjAx1kv+WtHEZZgEADMEtdwBQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoA\niiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0A\nxRFqACiOUANAca1DbXuN7d22f9zlQACA441zRX2TpL1dDQIAGK5VqG2vk/QRSV/vdhwAwEJtr6i/\nJunzktLhLACAISZGLbD9UUkHk8zanpLkE6299ZZtR483b5nS5i1TS58QAFaIF5/doxefnR37dU4W\nv0i2/beS/kzSq5ImJZ0l6QdJrluwLnfP7h97AGA1+OT1X+l7hDIOzdze9whlTK61kpzw4veIkVsf\nSb6U5IIkF0q6RtLDCyMNAOgO91EDQHEj96iPlWRa0nRHswAAhuCKGgCKI9QAUByhBoDiCDUAFEeo\nAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPU\nAFAcoQaA4gg1ABRHqAGgOEINAMURagAobmLUAtunS9op6Q3N+nuS/E3XgwEABkaGOsn/2X5/kpdt\nnybpUdv3J3l8GeYDgFWv1dZHkpebw9M1iHs6mwgAcJxWoba9xvYeSQckPZRkptuxAABHjNz6kKQk\nr0l6l+03S/qR7YuS7F247q47th893nDxJm24ZNNJGxQATnU7p3do5/SOsV/nZLxdDNtflvRSkq8u\n+H7unt0/9gBYubbf/0zfI5TxuQ+v73uEMj624dy+Ryhjcq2VxKPWjdz6sP0W22c3x5OSLpf09NJH\nBAC00Wbr41xJ/2R7jQZh/+ck93U7FgDgiDa35z0l6d3LMAsAYAieTASA4gg1ABRHqAGgOEINAMUR\nagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACiOUANAcYQaAIoj1ABQHKEGgOII\nNQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAihsZatvrbD9se6/tp2xvXY7BAAADEy3WvCrpL5LM2j5T\n0pO2H0zydMezAQDU4oo6yYEks83xS5L2STq/68EAAANj7VHbfoekjZIe62IYAMDrtdn6kCQ12x73\nSLqpubJ+nbvu2H70eMPFm7Thkk1LHhAAVoqd0zu0c3rH2K9zktGL7AlJ90q6P8ltJ1iTu2f3jz3A\nSvPJ67/S9whlfPsf/6rvEVDQxzac2/cIZUyutZJ41Lq2Wx/fkLT3RJEGAHSnze15l0n6hKQP2N5j\ne7ftK7sfDQAgtdijTvKopNOWYRYAwBA8mQgAxRFqACiOUANAcYQaAIoj1ABQHKEGgOIINQAUR6gB\noDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRHqAGgOEINAMURagAojlADQHGEGgCKI9QA\nUByhBoDiCDUAFDcy1LbvtH3Q9s+WYyAAwPHaXFF/U9IVXQ8CABhuZKiTPCLp0DLMAgAYgj1qAChu\n4mS+2TVXXHX0eM2Z5+u0s84/mW9/Sjg0c3vfIwAoauf0Du2c3jH265xk9CL77ZJ+kuSdi6zJGzfe\nOPYAKw2hBtDW5ForiUeta7v14eYfAMAya3N73ncl7ZK03vavbN/Q/VgAgCNG7lEn+dPlGAQAMBx3\nfQBAcYQaAIoj1ABQHKEGgOIINQAUR6gBoDhCDQDFEWoAKI5QA0BxhBoAiiPUAFAcoQaA4gg1ABRH\nqAGgOEINAMURagAojlADQHGEGgCKI9QAUByhBoDiCDUAFEeoAaC4VqG2faXtp20/Y/sLXQ8FAJg3\nMtS210i6XdIVkjZIutb273c92Kls5/SOvkcogfMwj3Mxj3MxvjZX1O+V9J9JfpnksKTvS7qq27FO\nbfwgDnAe5nEu5nEuxtcm1OdLeu6Yr59vvgcAWAZtQu0h38vJHgQAMJyTxZtr+w8kbUtyZfP1FyUl\nyd8tWEe8AWBMSYZdDB+nTahPk/Qfkj4o6QVJj0u6Nsm+kzEkAGBxE6MWJPmt7c9IelCDrZI7iTQA\nLJ+RV9QAgH4t+clEHoYZsH2n7YO2f9b3LH2zvc72w7b32n7K9ta+Z+qL7dNtP2Z7T3Mubu57pr7Z\nXmN7t+0f9z1Ln2z/wvZPm5+Nxxddu5Qr6uZhmGc02L/eL2lG0jVJnv6d3/QUZft9kl6S9K0k7+x7\nnj7ZfpuktyWZtX2mpCclXbUafy4kyfYZSV5uPu95VNLWJIv+i7mS2f5zSe+R9OYkH+97nr7YflbS\ne5IcGrV2qVfUPAzTSPKIpJEnfDVIciDJbHP8kqR9WsX33id5uTk8XYPPhVbtfqPtdZI+Iunrfc9S\ngNWywUsNNQ/DYFG23yFpo6TH+p2kP82v+nskHZD0UJKZvmfq0dckfV6r+D9Wx4ikB2zP2P7UYguX\nGmoehsEJNdse90i6qbmyXpWSvJbkXZLWSbrU9kV9z9QH2x+VdLD5bcsa3o/VZFOSizX4DePGZvt0\nqKWG+nlJFxzz9ToN9qqxytme0CDS307yL33PU0GSFyXtkHRlz6P05TJJH2/2Zr8n6f22v9XzTL1J\ncqD589eSfqjBVvJQSw31jKTfs/1222+QdI2k1fxJLlcJ874haW+S2/oepE+232L77OZ4UtLlklbl\nh6pJvpTkgiQXatCKh5Nc1/dcfbB9RvMbp2y/SdKHJP38ROuXFOokv5V05GGYOUnfX60Pw9j+rqRd\nktbb/pXtG/qeqS+2L5P0CUkfaG492m17tV5FnivpX23ParBP/0CS+3qeCf07R9IjzWcX/y7pJ0ke\nPNFiHngBgOL4X3EBQHGEGgCKI9QAUByhBoDiCDUAFEeoAaA4Qg0AxRFqACju/wEPDNeuLKZoWgAA\nAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11bc4cdd0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hist = PathHistogram(left_bin_edges=(0.0,0.0), bin_widths=(0.5,0.5), interpolate=True, per_traj=True)\n",
+    "hist.add_trajectory(diag, weight=2) # each trajectory can be assigned a weight (useful for RPE)\n",
+    "hist.add_trajectory(trajectory)\n",
+    "plt.pcolor(dataframe_from_counter(hist._histogram, ndim=(5, 7)).transpose(), cmap='Blues', vmin=0, vmax=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The actual `PathDensity` object also contains information about the collective variables we map this into, and has a convenience function to take a list of regular OPS trajectories and make the whole path histogram out of them."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -11,6 +11,8 @@ from analysis.network import (
     FixedLengthTPSNetwork
 )
 
+from analysis.path_histogram import PathDensityHistogram
+
 from analysis.replica_network import (
     ReplicaNetwork, trace_ensembles_for_replica,
     trace_replicas_for_ensemble, condense_repeats,

--- a/openpathsampling/analysis/__init__.py
+++ b/openpathsampling/analysis/__init__.py
@@ -1,4 +1,5 @@
 from histogram import Histogram, SparseHistogram
+from path_histogram import PathHistogram
 from lookup_function import (LookupFunction, LookupFunctionGroup,
                              VoxelLookupFunction)
 from tis_analysis import Transition, TISTransition

--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -157,3 +157,5 @@ class PathDensityHistogram(PathHistogram):
             cv_traj = [cv(traj) for cv in self.cvs]
             self.add_trajectory(zip(*cv_traj), w)
 
+        return self._histogram.copy()
+

--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -5,9 +5,14 @@ from collections import Counter
 import numpy as np
 
 class PathHistogram(SparseHistogram):
-    def __init__(self, left_bin_edges, bin_widths):
+    def __init__(self, left_bin_edges, bin_widths, interpolate=True,
+                 per_traj=True):
         super(PathHistogram, self).__init__(left_bin_edges=left_bin_edges, 
                                             bin_widths=bin_widths)
+        if interpolate is True:
+            interpolate = "subdivide"
+        self.interpolate = interpolate
+        self.per_traj = per_traj
 
     def interpolated_bins(self, old_pt, new_pt):
         # bins for this do not include the bin of the old point
@@ -24,20 +29,69 @@ class PathHistogram(SparseHistogram):
         if np.all(abs_dx == abs_dx[0]):
             pass # test that we aren't on diag
 
-        # otherwise, subdivide until adjacent
-        return bin_list
+        # otherwise, use one of the interpolation algos to find bins
+        if self.interpolate == "subdivide":
+            bin_list = self.subdivide_interpolation(start_pt=old_pt,
+                                                    end_pt=new_pt,
+                                                    start_bin=old_bin,
+                                                    end_bin=new_bin)
+        return list(set(bin_list) - set([old_bin]))
 
-    def add_trajectory(self, traj, interpolate=True, per_traj=True):
+    def subdivide_interpolation(self, start_pt, end_pt, start_bin, end_bin):
+        mid_pt = start_pt + 0.5*(np.asarray(end_pt) - np.asarray(start_pt))
+        mid_bin = self.map_to_bins(mid_pt)
+        if mid_bin == start_bin:
+            return self.subdivide_interpolation(start_pt=mid_pt,
+                                                end_pt=end_pt,
+                                                start_bin=mid_bin,
+                                                end_bin=end_bin)
+        elif mid_bin == end_bin:
+            return self.subdivide_interpolation(start_pt=start_pt,
+                                                end_pt=mid_pt,
+                                                start_bin=start_bin,
+                                                end_bin=mid_bin)
+
+        manhattan_dist_start = sum(abs(np.asarray(mid_bin) - 
+                                       np.asarray(start_bin)))
+        manhattan_dist_end = sum(abs(np.asarray(end_bin) - 
+                                     np.asarray(mid_bin)))
+        if manhattan_dist_start == 1 and manhattan_dist_end == 1:
+            return [start_bin, mid_bin, end_bin]
+        elif manhattan_dist_start == 1:
+            return ([start_bin] + 
+                    self.subdivide_interpolation(start_pt=mid_pt,
+                                                 end_pt=end_pt,
+                                                 start_bin=mid_bin,
+                                                 end_bin=end_bin))
+        elif manhattan_dist_end == 1:
+            return ([end_bin] +
+                    self.subdivide_interpolation(start_pt=start_pt,
+                                                 end_pt=mid_pt,
+                                                 start_bin=start_bin,
+                                                 end_bin=mid_bin))
+        else:
+            start_side = self.subdivide_interpolation(start_pt=start_pt,
+                                                      end_pt=mid_pt,
+                                                      start_bin=start_bin,
+                                                      end_bin=mid_bin)
+            end_side = self.subdivide_interpolation(start_pt=mid_pt,
+                                                    end_pt=end_pt,
+                                                    start_bin=mid_bin,
+                                                    end_bin=end_bin)
+            return start_side + end_side
+
+
+    def add_trajectory(self, traj):
         # make a list of every bin visited, possibly interpolating gaps
         bin_list = [self.map_to_bins(traj[0])]
         for fnum in range(len(traj)-1):
-            if interpolate:
+            if self.interpolate:
                 bin_list += self.interpolated_bins(traj[fnum], traj[fnum+1])
             else:
                 bin_list += [self.map_to_bins(traj[fnum+1])]
 
         local_hist = Counter(bin_list)
-        if per_traj:
+        if self.per_traj:
             # keys only exist once, so the counter gives 1 if key present
             local_hist = Counter(local_hist.keys())
         if self._histogram is None:

--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -105,23 +105,29 @@ class PathHistogram(SparseHistogram):
                                                     end_bin=end_bin)
             return start_side + end_side
 
-
-    def add_trajectory(self, traj, trajectory_weight=1.0):
+    def single_trajectory_counter(self, trajectory):
         # make a list of every bin visited, possibly interpolating gaps
-        bin_list = [self.map_to_bins(traj[0])]
-        for fnum in range(len(traj)-1):
+        bin_list = [self.map_to_bins(trajectory[0])]
+        for fnum in range(len(trajectory)-1):
             if self.interpolate:
-                bin_list += self.interpolated_bins(traj[fnum], traj[fnum+1])
+                bin_list += self.interpolated_bins(trajectory[fnum],
+                                                   trajectory[fnum+1])
             else:
-                bin_list += [self.map_to_bins(traj[fnum+1])]
+                bin_list += [self.map_to_bins(trajectory[fnum+1])]
 
         local_hist = Counter(bin_list)
         if self.per_traj:
             # keys only exist once, so the counter gives 1 if key present
             local_hist = Counter(local_hist.keys())
+        return local_hist
+
+    def add_trajectory(self, trajectory, weight=1.0):
+        local_hist = self.single_trajectory_counter(trajectory)
+        local_hist = Counter({k : local_hist[k] * weight
+                              for k in local_hist.keys()})
         if self._histogram is None:
             self._histogram = Counter({})
-        self._histogram += local_hist * trajectory_weight
+        self._histogram += local_hist
 
 
 class PathDensityHistogram(PathHistogram):

--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -1,0 +1,50 @@
+import openpathsampling as paths
+from openpathsampling.analysis import SparseHistogram
+
+from collections import Counter
+import numpy as np
+
+class PathHistogram(SparseHistogram):
+    def __init__(self, left_bin_edges, bin_widths):
+        super(PathHistogram, self).__init__(left_bin_edges=left_bin_edges, 
+                                            bin_widths=bin_widths)
+
+    def interpolated_bins(self, old_pt, new_pt):
+        # bins for this do not include the bin of the old point
+        old_bin = self.map_to_bins(old_pt)
+        new_bin = self.map_to_bins(new_pt)
+        abs_dx = abs(np.asarray(new_bin) - np.asarray(old_bin))
+        manhattan_distance = sum(abs_dx)
+        bin_list = [new_bin]
+        # if the manhattan_distance is 1, we're adjacent
+        if manhattan_distance == 1:
+            return bin_list
+        # if the abs_dx is the same for each, we should check if we're
+        # unluckily on the diagonal
+        if np.all(abs_dx == abs_dx[0]):
+            pass # test that we aren't on diag
+
+        # otherwise, subdivide until adjacent
+        return bin_list
+
+    def add_trajectory(self, traj, interpolate=True, per_traj=True):
+        # make a list of every bin visited, possibly interpolating gaps
+        bin_list = [self.map_to_bins(traj[0])]
+        for fnum in range(len(traj)-1):
+            if interpolate:
+                bin_list += self.interpolated_bins(traj[fnum], traj[fnum+1])
+            else:
+                bin_list += [self.map_to_bins(traj[fnum+1])]
+
+        local_hist = Counter(bin_list)
+        if per_traj:
+            # keys only exist once, so the counter gives 1 if key present
+            local_hist = Counter(local_hist.keys())
+        if self._histogram is None:
+            self._histogram = Counter({})
+        self._histogram += local_hist
+
+
+class PathDensityHistogram(SparseHistogram):
+    def __init__(self, cvs, left_bin_edges, bin_widths):
+        pass

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -61,6 +61,8 @@ class testPathHistogram(object):
         for val in [(1,1), (1,2), (1,3), (2,4), (3,4), (4,5), (4,6)]:
             assert_equal(hist._histogram[val], 1.0)
         assert_equal(hist._histogram[(3,5)], 1.0)
+        assert_equal(hist._histogram[(2,2)], 0.0)
+
 
     def test_nointerp_pertraj(self):
         hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
@@ -73,8 +75,30 @@ class testPathHistogram(object):
             assert_equal(hist._histogram[val], 0.0)
 
     def test_diag_interp(self):
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=True, per_traj=True)
+        hist.add_trajectory(self.diag)
+        for val in [(0,0), (1,1), (2,2), (3,3), (4,4)]:
+            assert_equal(hist._histogram[val], 1.0)
+        for val in [(1,2), (1,6)]:
+            assert_equal(hist._histogram[val], 0.0)
         raise SkipTest
 
     def test_add_with_weight(self):
-        raise SkipTest
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=True, per_traj=True)
+        hist.add_trajectory(self.trajectory)
+        hist.add_trajectory(self.diag, weight=2)
+        for val in [(0,1), (0,2), (0,3), (1,2), (1,3), (1,4), (2,1), (2,3),
+                    (2,4), (2,5), (3,1), (3,2), (3,4), (3,5), (3,6), (4,5),
+                    (4,6)]:
+            assert_equal(hist._histogram[val], 1.0)
+        for val in [(2,2), (4,4)]:
+            assert_equal(hist._histogram[val], 2.0)
+        for val in [(0,0), (1,1), (3,3)]:
+            assert_equal(hist._histogram[val], 3.0)
+        for val in [(0,4), (0,5), (0.6), (0,7), (-1,0)]:
+            assert_equal(hist._histogram[val], 0.0)
 

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -102,3 +102,37 @@ class testPathHistogram(object):
         for val in [(0,4), (0,5), (0.6), (0,7), (-1,0)]:
             assert_equal(hist._histogram[val], 0.0)
 
+    def test_add_data_to_histograms(self):
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=True, per_traj=True)
+        counter = hist.add_data_to_histogram([self.trajectory, self.diag],
+                                             weights=[1.0, 2.0])
+        for val in [(0,1), (0,2), (0,3), (1,2), (1,3), (1,4), (2,1), (2,3),
+                    (2,4), (2,5), (3,1), (3,2), (3,4), (3,5), (3,6), (4,5),
+                    (4,6)]:
+            assert_equal(counter[val], 1.0)
+        for val in [(2,2), (4,4)]:
+            assert_equal(counter[val], 2.0)
+        for val in [(0,0), (1,1), (3,3)]:
+            assert_equal(counter[val], 3.0)
+        for val in [(0,4), (0,5), (0.6), (0,7), (-1,0)]:
+            assert_equal(counter[val], 0.0)
+
+    def test_add_data_to_histograms_no_weight(self):
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=True, per_traj=True)
+        counter = hist.add_data_to_histogram([self.trajectory, self.diag])
+        for val in [(0,1), (0,2), (0,3), (1,2), (1,3), (1,4), (2,1), (2,3),
+                    (2,4), (2,5), (3,1), (3,2), (3,4), (3,5), (3,6), (4,5),
+                    (4,6)]:
+            assert_equal(counter[val], 1.0)
+        for val in [(2,2), (4,4)]:
+            assert_equal(counter[val], 1.0)
+        for val in [(0,0), (1,1), (3,3)]:
+            assert_equal(counter[val], 2.0)
+        for val in [(0,4), (0,5), (0.6), (0,7), (-1,0)]:
+            assert_equal(counter[val], 0.0)
+
+

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -37,10 +37,30 @@ class testPathHistogram(object):
             assert_equal(hist._histogram[val], 0.0)
 
     def test_interp_nopertraj(self):
-        raise SkipTest
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=True, per_traj=False)
+        hist.add_trajectory(self.trajectory)
+        for val in [(0,0), (0,2), (3,1), (3,2)]:
+            assert_equal(hist._histogram[val], 1.0)
+        for val in [(0,1), (0,3), (1,4), (2,1), (2,3), (2,5), (3,1), (3,2),
+                    (3,3), (3,6)]:
+            assert_equal(hist._histogram[val], 1.0)
+        for val in [(1,1), (1,2), (1,3), (2,4), (3,4), (4,5), (4,6)]:
+            assert_equal(hist._histogram[val], 2.0)
+        assert_equal(hist._histogram[(3,5)], 3.0)
 
     def test_interp_pertraj(self):
-        raise SkipTest
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=True, per_traj=True)
+        hist.add_trajectory(self.trajectory)
+        for val in [(0,0), (0,2), (3,1), (3,2), (0,1), (0,3), (1,4), (2,1),
+                    (2,3), (2,5), (3,1), (3,2), (3,3), (3,6)]:
+            assert_equal(hist._histogram[val], 1.0)
+        for val in [(1,1), (1,2), (1,3), (2,4), (3,4), (4,5), (4,6)]:
+            assert_equal(hist._histogram[val], 1.0)
+        assert_equal(hist._histogram[(3,5)], 1.0)
 
     def test_nointerp_pertraj(self):
         hist = PathHistogram(left_bin_edges=(0.0, 0.0), 

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -1,0 +1,60 @@
+import os
+import numpy as np
+
+from nose.tools import (assert_equal, assert_not_equal, assert_items_equal,
+                        assert_almost_equal, raises)
+from nose.plugins.skip import Skip, SkipTest
+from test_helpers import (
+    true_func, assert_equal_array_array, make_1d_traj, data_filename
+)
+
+import openpathsampling as paths
+import logging
+
+logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
+from openpathsampling.analysis.path_histogram import *
+from collections import Counter
+
+class testPathHistogram(object):
+    def setup(self):
+        self.trajectory = [(0.1, 0.3), (2.1, 3.1), (1.7, 1.4), 
+                           (1.6, 0.6), (0.1, 1.4), (2.2, 3.3)]
+        self.diag = [(0.25, 0.25), (2.25, 2.25)]
+
+    def test_nointerp_nopertraj(self):
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=False, per_traj=False)
+        hist.add_trajectory(self.trajectory)
+        for val in [(0,0), (0,2), (3,1), (3,2)]:
+            assert_equal(hist._histogram[val], 1.0)
+        assert_equal(hist._histogram[(4,6)], 2.0)
+        for val in [(1,0), (1,1), (1,6)]:
+            assert_equal(hist._histogram[val], 0.0)
+
+    def test_interp_nopertraj(self):
+        raise SkipTest
+
+    def test_interp_pertraj(self):
+        raise SkipTest
+
+    def test_nointerp_pertraj(self):
+        hist = PathHistogram(left_bin_edges=(0.0, 0.0), 
+                             bin_widths=(0.5, 0.5),
+                             interpolate=False, per_traj=True)
+        hist.add_trajectory(self.trajectory)
+        for val in [(0,0), (0,2), (3,1), (3,2), (4,6)]:
+            assert_equal(hist._histogram[val], 1.0)
+        for val in [(1,0), (1,1), (1,6)]:
+            assert_equal(hist._histogram[val], 0.0)
+
+    def test_diag_interp(self):
+        raise SkipTest
+
+    def test_add_with_weight(self):
+        raise SkipTest
+

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -136,3 +136,37 @@ class testPathHistogram(object):
             assert_equal(counter[val], 0.0)
 
 
+class testPathDensityHistogram(object):
+    def setup(self):
+        id_cv = paths.CV_Function("Id",
+                                  lambda snap : snap.xyz[0][0])
+        sin_cv = paths.CV_Function("sin",
+                                   lambda snap : np.sin(snap.xyz[0][0]))
+        square_cv = paths.CV_Function("x^2",
+                                      lambda snap : snap.xyz[0][0]**2)
+        self.cvs = [id_cv, sin_cv, square_cv]
+        self.left_bin_edges = (0,0,0)
+        self.bin_widths = (0.25, 0.5, 0.4)
+
+        self.traj1 = make_1d_traj([0.1, 0.51, 0.61])
+        # [(0, 0, 0), (2, 0, 0), (2, 1, 0)]
+        # interpolate: (1, 0, 0)
+        self.traj2 = make_1d_traj([0.6, 0.7])
+        # [(2, 1, 0), (2, 1, 1)]
+
+    def test_histogram_no_weights(self):
+        hist = PathDensityHistogram(self.cvs, self.left_bin_edges,
+                                    self.bin_widths)
+        counter = hist.histogram([self.traj1, self.traj2])
+        assert_equal(len(counter), 5)
+        for bin_label in [(0,0,0), (2,0,0), (1,0,0), (2,1,1)]:
+            assert_equal(counter[bin_label], 1.0)
+        assert_equal(counter[(2,1,0)], 2.0)
+        for bin_label in [(1,1,1), (2,2,2), (-1,0,0), (0,-1,0)]:
+            assert_equal(counter[bin_label], 0.0)
+
+    def test_histogram_with_weights(self):
+        raise SkipTest
+
+    def test_histogram_single_traj(self):
+        raise SkipTest

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -166,7 +166,24 @@ class testPathDensityHistogram(object):
             assert_equal(counter[bin_label], 0.0)
 
     def test_histogram_with_weights(self):
-        raise SkipTest
+        hist = PathDensityHistogram(self.cvs, self.left_bin_edges,
+                                    self.bin_widths)
+        counter = hist.histogram([self.traj1, self.traj2], 
+                                 weights=[1.0, 2.0])
+        assert_equal(len(counter), 5)
+        for bin_label in [(0,0,0), (2,0,0), (1,0,0)]:
+            assert_equal(counter[bin_label], 1.0)
+        assert_equal(counter[(2,1,1)], 2.0)
+        assert_equal(counter[(2,1,0)], 3.0)
+        for bin_label in [(1,1,1), (2,2,2), (-1,0,0), (0,-1,0)]:
+            assert_equal(counter[bin_label], 0.0)
 
     def test_histogram_single_traj(self):
-        raise SkipTest
+        hist = PathDensityHistogram(self.cvs, self.left_bin_edges,
+                                    self.bin_widths)
+        counter = hist.histogram(self.traj1)
+        assert_equal(len(counter), 4)
+        for bin_label in [(0,0,0), (2,0,0), (1,0,0), (2,1,0)]:
+            assert_equal(counter[bin_label], 1.0)
+        for bin_label in [(1,1,1), (2,2,2), (-1,0,0), (0,-1,0)]:
+            assert_equal(counter[bin_label], 0.0)


### PR DESCRIPTION
This PR will implement path density plots. The easiest way to think of path density plots is in terms of what a single path contributes to them: each bin that is traversed by the path adds a count of 1 to the (multidimensional) histogram. This means: (1) it doesn’t matter how long a single path stays in one bin, or how many times it enters that bin; or equivalently (2) important areas of the histogram don’t represent long staying times (stable states), rather, they mean that lots of paths go through there (possible bottlenecks). Path density plots also interpolate (linearly) to include any bins that are skipped between frames.

Historically, path densities have been calculated in a 2D projection. This implementation, based on the `SparseHistogram` code from #504, works in an arbitrary dimensional projection. 

This includes:
* `PathHistogram` : a variant of `SparseHistogram` designed to think in terms of trajectories (after they’ve been mapped to CVs). This allows you to interpolate to include cells between frames that were saved (linear interpolation, initialization keyword `interpolate`), to ignore the *number* of times a given histogram cell is visited and instead only count whether the cell was visited by a path (initialization keyword `per_traj`), and to assign a specific weight to the entire trajectory (keyword `weight` in `add_trajectory` method).
* `PathDensity`: a wrapper to create a path density plot. Basically a version of the `PathHistogram` that can take a list of normal OPS trajectories, map each to the “reduced” trajectory of CVs that the `PathHistogram` requires, and calculate the resulting histogram based on the `per_traj=True` version of the `PathHistogram`.

Note that the `PathHistogram` object will later be reused, with the `per_traj` normalization set to `False` and including the per-trajectory weights, in order to calculate free energy plots from the reweighted path ensemble.

An overview of the capabilities of the `PathHistogram` object are shown in `tutorial_path_histogram.ipynb`. It’s one of those “picture worth a thousand words” things. I think it is a lot easier to see what the options do by looking at that, than it is to explain them in words.

- [x] Implement `PathHistogram` as a `SparseHistogam`
- [x] Add interpolation to `PathHistogram`
- [x] Fix interpolation for the (literal) corner case
- [x] Add `per_traj` normalization to `PathHistogram`
- [x] `tutorial_path_histogram.ipynb`
- [x] nosetests for `PathHistogram`
- [x] `PathDensity`
- [x] nosetests for `PathDensity`
- [x] docstrings

Note: in the not-to-distant future, it might be nice to write a little function to simplify plotting of these. These use data structures that are very similar to the ones for my contact map code, and @sroet has written some matplotlib code to plot those very quickly (going through a pandas frame is fine for small systems, but really sucks once your grid is large). That code should be reusable for these.