### PR TITLE
Fix bug in storage string in `netcdfplus`

### DIFF
--- a/openpathsampling/netcdfplus/netcdfplus.py
+++ b/openpathsampling/netcdfplus/netcdfplus.py
@@ -310,7 +310,7 @@ class NetCDFPlus(netCDF4.Dataset):
             if current > 1024:
                 output_prefix = prefix
                 current /= 1024.0
-        return "{0:.2f}{1}B".format(current, prefix)
+        return "{0:.2f}{1}B".format(current, output_prefix)
 
     def _setup_class(self):
         """


### PR DESCRIPTION
Really stupid typo of mine. It always reported as "GB" even when it meant "MB", "kB" or even just "B".

7-character fix for a bug @bolhuis caught. This should be ready to merge as soon as it passes.