### PR TITLE
New DynamicsEngine.__getattr__ 

### DIFF
--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -173,7 +173,8 @@ class DynamicsEngine(StorableNamedObject):
                     # return result  # miraculously fixed
                     raise AttributeError(
                         "Unknown problem occurred in property" + 
-                        str(p.fget.func_name)
+                        str(p.fget.func_name) + ": Second attempt returned"
+                        + str(result)
                     )
             # for now, items in dict that fail with AttributeError will just
             # give the default message; to change, add something here like:

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -75,10 +75,6 @@ class DynamicsEngine(StorableNamedObject):
         # Better would be a link to the topology directly. This is needed to create
         # mdtraj.Trajectory() objects
 
-        # TODO: Remove this and put the logic outside of the engine. The engine in trajectory is only
-        # used to get the solute indices which should depend on the topology anyway
-        # Trajectory.engine = self
-
         self._check_options(options)
 
         # as default set a newly generated engine as the default engine
@@ -173,7 +169,12 @@ class DynamicsEngine(StorableNamedObject):
                 except:
                     raise
                 else:
-                    return result  # miraculously fixed
+                    # alternately, trust the fixed result with
+                    # return result  # miraculously fixed
+                    raise AttributeError(
+                        "Unknown problem occurred in property" + 
+                        str(p.fget.func_name)
+                    )
             # for now, items in dict that fail with AttributeError will just
             # give the default message; to change, add something here like:
             # raise AttributeError("Something went wrong with " + str(item))

--- a/openpathsampling/tests/testdynamicsengine.py
+++ b/openpathsampling/tests/testdynamicsengine.py
@@ -1,0 +1,46 @@
+import openpathsampling as paths
+
+from nose.tools import (assert_equal, assert_not_equal, raises)
+from nose.plugins.skip import SkipTest
+from test_helpers import make_1d_traj, raises_with_message_like
+
+class StupidEngine(paths.engines.DynamicsEngine):
+    _default_options = {'random_option': False}
+
+    @property
+    def bad_property(self):
+        obj = object()
+        return obj.b
+
+    @property
+    def property_recovers(self):
+        if not hasattr(self, 'attempted'):
+            self.attempted = True
+            raise AttributeError("Internal error")
+        return self.attempted
+
+class testDynamicsEngine(object):
+    def setup(self):
+        options = {'n_frames_max' : 100, 'random_option' : True}
+        template = make_1d_traj([1.0])[0]
+        self.engine = paths.engines.DynamicsEngine(options, template)
+        self.stupid = StupidEngine(options, template)
+
+    def test_getattr_from_options(self):
+        assert_equal(self.stupid.random_option, True)
+
+    @raises_with_message_like(AttributeError, 
+                              "'object' object has no attribute 'b'")
+    def test_getattr_property_fails(self):
+        self.stupid.bad_property
+
+    @raises_with_message_like(AttributeError, 
+                              "Unknown problem occurred in property")
+    def test_getattr_property_recovers(self):
+        self.stupid.property_recovers
+
+    @raises_with_message_like(AttributeError,
+                              "'StupidEngine' has no attribute 'foo'" +  
+                              ", nor does its options dictionary")
+    def test_getattr_does_not_exist(self):
+        self.stupid.foo


### PR DESCRIPTION
See discussion in #507. This will not solve that issue, but it should make it easier to debug.

A few questions:

* In the event that the re-run works, do we `return result` or raise the `AttributeError`. Currently, I'm raising the error under the assumption that if something went bad, we can't trust the results.
* Do we give a special message for non-property, in-dictionary errors? I'm not entirely sure how to create a test for that scenario; currently it would give the same as an actual does-not-exist.
