### PR TITLE
DefaultScheme does not require MS-outer interface

### DIFF
--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -850,24 +850,28 @@ class DefaultScheme(MoveScheme):
         global_strategy = strategies.OrganizeByMoveGroupStrategy()
         self.append(global_strategy)
 
-        msouters = self.network.special_ensembles['ms_outer']
-        for ms in msouters.keys():
-            self.append(strategies.OneWayShootingStrategy(
-                ensembles=[ms],
-                group="ms_outer_shooting",
-                engine=engine
-            ))
-            self.append(strategies.PathReversalStrategy(
-                ensembles=[ms],
-                replace=False
-            ))
-            ms_neighbors = [t.ensembles[-1] for t in msouters[ms]]
-            pairs = [[ms, neighb] for neighb in ms_neighbors]
-            self.append(strategies.SelectedPairsRepExStrategy(
-                ensembles=pairs
-            ))
-        #ms_outer_shoot_w = float(len(msouters)) / n_ensembles
-        #global_strategy.group_weights['ms_outer_shooting'] = ms_outer_shoot_w
+        try:
+            msouters = self.network.special_ensembles['ms_outer']
+        except KeyError:
+            # if no ms_outer, ignore the ms_outer setup for now; later we
+            # might default to a state swap
+            pass
+        else:
+            for ms in msouters.keys():
+                self.append(strategies.OneWayShootingStrategy(
+                    ensembles=[ms],
+                    group="ms_outer_shooting",
+                    engine=engine
+                ))
+                self.append(strategies.PathReversalStrategy(
+                    ensembles=[ms],
+                    replace=False
+                ))
+                ms_neighbors = [t.ensembles[-1] for t in msouters[ms]]
+                pairs = [[ms, neighb] for neighb in ms_neighbors]
+                self.append(strategies.SelectedPairsRepExStrategy(
+                    ensembles=pairs
+                ))
 
 class LockedMoveScheme(MoveScheme):
     def __init__(self, root_mover, network=None, root_accepted=None):

--- a/openpathsampling/tests/testmovescheme.py
+++ b/openpathsampling/tests/testmovescheme.py
@@ -374,6 +374,9 @@ class testDefaultScheme(object):
                 {interfacesA: 0.0, interfacesB: 0.0}
             )
         )
+        self.no_ms_outer = paths.MSTISNetwork(
+            [(self.stateA, interfacesA), (self.stateB, interfacesB)]
+        )
     
     def test_default_scheme(self):
         scheme = DefaultScheme(self.network)
@@ -386,7 +389,6 @@ class testDefaultScheme(object):
             'Ms_outer_shootingChooser' : paths.OneWayShootingMover
         }
         names = chooser_type_dict.keys()
-
         assert_equal(len(root.movers), len(names))
 
         name_dict = {root.movers[i].name : i for i in range(len(root.movers))}
@@ -416,6 +418,39 @@ class testDefaultScheme(object):
         for choosername in names:
             for mover in root.movers[name_dict[choosername]].movers:
                 assert_equal(type(mover), chooser_type_dict[choosername])
+
+    def test_default_scheme_no_ms_outer(self):
+        scheme = DefaultScheme(self.no_ms_outer)
+        root = scheme.move_decision_tree()
+        chooser_type_dict = {
+            'ShootingChooser' : paths.OneWayShootingMover,
+            'PathreversalChooser' : paths.PathReversalMover,
+            'RepexChooser' : paths.ReplicaExchangeMover,
+            'MinusChooser' : paths.MinusMover
+        }
+        names = chooser_type_dict.keys()
+        assert_equal(len(root.movers), len(names))
+
+        name_dict = {root.movers[i].name : i for i in range(len(root.movers))}
+        for name in names:
+            assert_in(name, name_dict.keys())
+
+        n_normal_repex = 4
+        n_msouter_repex = 0
+        n_repex = n_normal_repex + n_msouter_repex
+
+        assert_equal(
+            len(root.movers[name_dict['ShootingChooser']].movers), 6
+        )
+        assert_equal(
+            len(root.movers[name_dict['PathreversalChooser']].movers), 6
+        )
+        assert_equal(
+            len(root.movers[name_dict['RepexChooser']].movers), n_repex
+        )
+        assert_equal(
+            len(root.movers[name_dict['MinusChooser']].movers), 2
+        )
 
 
     def test_default_sanity(self):


### PR DESCRIPTION
Resolves #536.

Debated which should be the default behavior. I think this makes more sense. It also makes it easier to later switch to defaulting to state-swap based things.