### PR TITLE
[WIP] Enable simtk.units in CVDefinedVolume

### DIFF
--- a/examples/ipython/mistis_setup.ipynb
+++ b/examples/ipython/mistis_setup.ipynb
@@ -533,7 +533,7 @@
    "source": [
     "import logging.config\n",
     "logging.config.fileConfig(\"logging.conf\", disable_existing_loggers=False)\n",
-    "mistis_calc.run(400)\n"
+    "mistis_calc.run(800)\n"
    ]
   },
   {

--- a/examples/ipython/mstis.ipynb
+++ b/examples/ipython/mstis.ipynb
@@ -822,7 +822,7 @@
    },
    "outputs": [],
    "source": [
-    "mstis_calc.run(100)"
+    "mstis_calc.run(400)"
    ]
   },
   {

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -39,7 +39,10 @@ class ObjectJSON(object):
         'numpy',
         'math',
         'pandas',
-        'mdtraj'
+        'mdtraj',
+        'simtk',
+        'simtk.unit',
+        'simtk.openmm'
     ]
 
     def __init__(self, unit_system=None):

--- a/openpathsampling/tests/testvolume.py
+++ b/openpathsampling/tests/testvolume.py
@@ -159,6 +159,14 @@ class testCVRangeVolume(object):
         assert(vol(-0.25 * u.nanometers))
         assert(not vol(-0.75 * u.nanometers))
 
+        vol = volume.PeriodicCVDefinedVolume(
+            op_id,
+            -30 * u.nanometers, 90 * u.nanometers,
+            -180 * u.nanometers, 180 * u.nanometers)
+
+        assert (vol(50 * u.nanometers))
+        assert (not vol(-70 * u.nanometers))
+
 
 class testCVRangeVolumePeriodic(object):
     def setUp(self):

--- a/openpathsampling/tests/testvolume.py
+++ b/openpathsampling/tests/testvolume.py
@@ -150,6 +150,16 @@ class testCVRangeVolume(object):
         assert_equal(volA.__str__(), "{x|Id(x) in [-0.5, 0.5]}")
         assert_equal((~volA).__str__(), "(not {x|Id(x) in [-0.5, 0.5]})")
 
+    def test_unit_support(self):
+        import simtk.unit as u
+
+        vol = volume.CVDefinedVolume(
+            op_id, -0.5 * u.nanometers, 0.25 * u.nanometers)
+
+        assert(vol(-0.25 * u.nanometers))
+        assert(not vol(-0.75 * u.nanometers))
+
+
 class testCVRangeVolumePeriodic(object):
     def setUp(self):
         self.pvolA = volume.PeriodicCVDefinedVolume(op_id, -100, 75)

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -248,8 +248,8 @@ class CVDefinedVolume(Volume):
         '''
         super(CVDefinedVolume, self).__init__()
         self.collectivevariable = collectivevariable
-        self.lambda_min = float(lambda_min)
-        self.lambda_max = float(lambda_max)
+        self.lambda_min = lambda_min.__float__()
+        self.lambda_max = lambda_max.__float__()
 
     # Typically, the logical combinations are only done once. Because of
     # this, it is worth passing these through a check to speed up the logic.
@@ -359,7 +359,7 @@ class CVDefinedVolume(Volume):
             return super(CVDefinedVolume, self).__sub__(other)
 
     def __call__(self, snapshot):
-        l = float(self.collectivevariable(snapshot))
+        l = self.collectivevariable(snapshot).__float__()
         return l >= self.lambda_min and l <= self.lambda_max
 
     def __str__(self):

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -396,8 +396,10 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
     """
 
     _excluded_attr = ['wrap']
-    def __init__(self, collectivevariable, lambda_min = 0.0, lambda_max = 1.0,
-                                       period_min = None, period_max = None):
+
+    def __init__(
+            self, collectivevariable, lambda_min=0.0, lambda_max=1.0,
+            period_min=None, period_max=None):
         super(PeriodicCVDefinedVolume, self).__init__(collectivevariable,
                                                     lambda_min, lambda_max)        
         self.period_min = period_min
@@ -419,7 +421,16 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
 
     def do_wrap(self, value):
         """Wraps `value` into the periodic domain."""
+
+        # this looks strange and mimics the modulo operation `%` while
+        # being folly compatible for simtk numbers and plain python as well
+        # ints and floats. I think we usually have floats, but the tests
+        # from dwhswenson use ints and it should work with both
         val = value - self._period_shift
+
+        # little trick to check for positivity without knowing the the units
+        # or if it actually has units
+
         if val > val * 0:
             return value - int(val / self._period_len) * self._period_len
         else:

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -312,7 +312,7 @@ class CVDefinedVolume(Volume):
         ValueError
             if the input lrange is not an allowed value
         """
-        if lrange == None:
+        if lrange is None:
             return EmptyVolume()
         elif lrange == 1:
             return self
@@ -328,7 +328,7 @@ class CVDefinedVolume(Volume):
         else:
             raise ValueError(
                 "lrange value not understood: {0}".format(lrange)
-            ) # pragma: no cover
+            )  # pragma: no cover
 
     def __and__(self, other):
         if (type(other) is type(self) and 
@@ -367,16 +367,19 @@ class CVDefinedVolume(Volume):
 
     def __call__(self, snapshot):
         l = self.collectivevariable(snapshot).__float__()
-        if self.lambda_min != float('nan') and self.lambda_min > l:
+        if self.lambda_min != float('nan') and \
+                self.lambda_min != float('-inf') and self.lambda_min > l:
             return False
 
-        if self.lambda_max != float('nan') and self.lambda_max < l:
+        if self.lambda_max != float('nan') and \
+                self.lambda_min != float('inf') and self.lambda_max < l:
             return False
 
         return True
 
     def __str__(self):
-        return '{{x|{2}(x) in [{0}, {1}]}}'.format( self.lambda_min, self.lambda_max, self.collectivevariable.name)
+        return '{{x|{2}(x) in [{0}, {1}]}}'.format(
+            self.lambda_min, self.lambda_max, self.collectivevariable.name)
 
 
 class PeriodicCVDefinedVolume(CVDefinedVolume):
@@ -449,9 +452,11 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
     @staticmethod
     def range_and(amin, amax, bmin, bmax):
         return range_logic.periodic_range_and(amin, amax, bmin, bmax)
+
     @staticmethod
     def range_or(amin, amax, bmin, bmax):
         return range_logic.periodic_range_or(amin, amax, bmin, bmax)
+
     @staticmethod
     def range_sub(amin, amax, bmin, bmax):
         return range_logic.periodic_range_sub(amin, amax, bmin, bmax)

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -248,8 +248,15 @@ class CVDefinedVolume(Volume):
         '''
         super(CVDefinedVolume, self).__init__()
         self.collectivevariable = collectivevariable
-        self.lambda_min = lambda_min.__float__()
-        self.lambda_max = lambda_max.__float__()
+        try:
+            self.lambda_min = lambda_min.__float__()
+        except AttributeError:
+            self.lambda_min = float(lambda_min)
+
+        try:
+            self.lambda_max = lambda_max.__float__()
+        except AttributeError:
+            self.lambda_max = float(lambda_max)
 
     # Typically, the logical combinations are only done once. Because of
     # this, it is worth passing these through a check to speed up the logic.
@@ -360,7 +367,13 @@ class CVDefinedVolume(Volume):
 
     def __call__(self, snapshot):
         l = self.collectivevariable(snapshot).__float__()
-        return l >= self.lambda_min and l <= self.lambda_max
+        if self.lambda_min != float('nan') and self.lambda_min > l:
+            return False
+
+        if self.lambda_max != float('nan') and self.lambda_max < l:
+            return False
+
+        return True
 
     def __str__(self):
         return '{{x|{2}(x) in [{0}, {1}]}}'.format( self.lambda_min, self.lambda_max, self.collectivevariable.name)

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -428,9 +428,8 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
         """Wraps `value` into the periodic domain."""
 
         # this looks strange and mimics the modulo operation `%` while
-        # being folly compatible for simtk numbers and plain python as well
-        # ints and floats. I think we usually have floats, but the tests
-        # from dwhswenson use ints and it should work with both
+        # being fully compatible for simtk numbers and plain python as well
+        # working for ints and floats.
         val = value - self._period_shift
 
         # little trick to check for positivity without knowing the the units

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -352,7 +352,7 @@ class CVDefinedVolume(Volume):
         if (type(other) is type(self) and 
                 self.collectivevariable == other.collectivevariable):
             # taking the shortcut here
-            return ((self | other) - (self & other))
+            return (self | other) - (self & other)
         else:
             return super(CVDefinedVolume, self).__xor__(other)
 
@@ -367,12 +367,10 @@ class CVDefinedVolume(Volume):
 
     def __call__(self, snapshot):
         l = self.collectivevariable(snapshot).__float__()
-        if self.lambda_min != float('nan') and \
-                self.lambda_min != float('-inf') and self.lambda_min > l:
+        if self.lambda_min != float('-inf') and self.lambda_min > l:
             return False
 
-        if self.lambda_max != float('nan') and \
-                self.lambda_min != float('inf') and self.lambda_max < l:
+        if self.lambda_min != float('inf') and self.lambda_max < l:
             return False
 
         return True
@@ -475,7 +473,7 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
         if self.lambda_min > self.lambda_max:
             return l >= self.lambda_min or l <= self.lambda_max
         else:
-            return l >= self.lambda_min and l <= self.lambda_max
+            return self.lambda_min <= l <= self.lambda_max
 
     def __str__(self):
         if self.wrap:
@@ -545,7 +543,7 @@ class VoronoiVolume(Volume):
         
         return min_idx
 
-    def __call__(self, snapshot, state = None):
+    def __call__(self, snapshot, state=None):
         '''
         Returns `True` if snapshot belongs to voronoi cell in state
         
@@ -570,6 +568,7 @@ class VoronoiVolume(Volume):
             state = self.state
         
         return self.cell(snapshot) == state
+
 
 class VolumeFactory(object):
     @staticmethod

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -367,6 +367,10 @@ class CVDefinedVolume(Volume):
 
     def __call__(self, snapshot):
         l = self.collectivevariable(snapshot).__float__()
+
+        # we explicitely test for infinity to allow the user to
+        # define `lambda_min/max='inf'` also when using units
+        # a simtk unit cannot be compared to a python infinite float
         if self.lambda_min != float('-inf') and self.lambda_min > l:
             return False
 

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -406,7 +406,16 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
 
     def do_wrap(self, value):
         """Wraps `value` into the periodic domain."""
-        return ((value-self._period_shift) % self._period_len) + self._period_shift
+        val = value - self._period_shift
+        if val > val * 0:
+            return value - int(val / self._period_len) * self._period_len
+        else:
+            wrapped = value + int((self._period_len - val) / self._period_len) \
+                * self._period_len
+            if wrapped >= self._period_len:
+                wrapped -= self._period_len
+
+            return wrapped
 
     # next few functions add support for range logic
     def _copy_with_new_range(self, lmin, lmax):
@@ -423,7 +432,6 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
     def range_sub(amin, amax, bmin, bmax):
         return range_logic.periodic_range_sub(amin, amax, bmin, bmax)
 
-
     def __invert__(self):
         # consists of swapping max and min
         return PeriodicCVDefinedVolume(self.collectivevariable,
@@ -432,7 +440,7 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
                                    )
 
     def __call__(self, snapshot):
-        l = float(self.collectivevariable(snapshot))
+        l = self.collectivevariable(snapshot).__float__()
         if self.wrap:
             l = self.do_wrap(l)
         if self.lambda_min > self.lambda_max:


### PR DESCRIPTION
It adds `simtk.unit` and `simtk.openmm` to the allowed packages and rewrite the 
`CVDefinedVolume` and `PeriodicCVDefinedVolume` that they work also with simtk.unit

Problem was that simtk.unit does not support `%` so I had to rewrite it.

Should pass tests. Ready for review and merge