### PR TITLE
Use interface lambda hinting in WHAM DF cleaning

### DIFF
--- a/openpathsampling/analysis/tis_analysis.py
+++ b/openpathsampling/analysis/tis_analysis.py
@@ -389,7 +389,9 @@ class TISTransition(Transition):
                 self.histograms['max_lambda'].values(),
                 fcn="reverse_cumulative"
             ).sort_index(axis=1)
-            wham = WHAM()
+            # if lambdas not set, returns None and WHAM uses fallback
+            lambdas = self.interfaces.lambdas
+            wham = WHAM(interfaces=lambdas)
             # wham.load_from_dataframe(df)
             # wham.clean_leading_ones()
             tcp = wham.wham_bam_histogram(df).to_dict()

--- a/openpathsampling/tests/testwham.py
+++ b/openpathsampling/tests/testwham.py
@@ -58,6 +58,19 @@ class testWHAM(object):
         np.testing.assert_allclose(cleaned.as_matrix(),
                                    self.expected_cleaned)
 
+    def test_prep_reverse_cumulative_with_interfaces(self):
+        wham = paths.analysis.WHAM(cutoff=0.1, interfaces=[0.0, 0.2, 0.3])
+        cleaned = wham.prep_reverse_cumulative(self.input_df)
+        np.testing.assert_allclose(cleaned.as_matrix(),
+                                   np.array([[2.0, 0.0, 0.0],
+                                             [1.0, 0.0, 0.0],
+                                             [0.5, 1.0, 0.0],
+                                             [0.25, 0.5, 3.0],
+                                             [0.0, 0.25, 3.0],
+                                             [0.0, 0.125, 1.5],
+                                             [0.0, 0.0, 0.75]]))
+
+
     def test_unweighting_tis(self):
         unweighting = self.wham.unweighting_tis(self.cleaned)
         expected = np.array([[1.0, 0.0, 0.0],


### PR DESCRIPTION
The problems in #549 were two-fold: both were sampling, but for different reasons. First, sometimes interfaces didn't overlap because no path from the inner interface crossed the outer interface. Second, if 100% of paths in an outer interface went well past the interface boundary, the automatic identification of the interface boundary failed.

Both can be solved by more sampling. The second one, however, could also use the new `InterfaceSet` object to hint what the interface values are.

That's what this code implements. If the interface lambdas are defined in the interface set, then we use that information. If not, we fall back on the old approach.

This should help tests pass some, although the first problem remains.