### PR TITLE
Quick fix for NaN reporting problems

### DIFF
--- a/openpathsampling/engines/features/shared.py
+++ b/openpathsampling/engines/features/shared.py
@@ -52,14 +52,10 @@ class StaticContainer(StorableObject):
                 coords = self.coordinates
 
             if np.any(np.isnan(coords)):
-                try:
-                    import pandas as pd
-                except ImportError:
-                    df=""
-                else:
-                    df=str(pd.Dataframe(coords)) + "\n"
-                raise ValueError(df + "Some coordinates became 'nan'; " +
-                                 "simulation is unstable or buggy.")
+                bad_atoms = [i for i in range(len(coords))
+                             if np.any(np.isnan(coords[i]))]
+                raise ValueError("Coordinates went 'nan' for atoms: " + 
+                                 str(bad_atoms))
 
         return
 

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -200,25 +200,18 @@ class OpenMMEngine(DynamicsEngine):
         return self.n_steps_per_frame * self.simulation.integrator.getStepSize()
 
     def _build_current_snapshot(self):
-        try:
-            # TODO: Add caching for this and mark if changed
+        # TODO: Add caching for this and mark if changed
 
-            state = self.simulation.context.getState(getPositions=True,
-                                                     getVelocities=True,
-                                                     getEnergy=True)
+        state = self.simulation.context.getState(getPositions=True,
+                                                 getVelocities=True,
+                                                 getEnergy=True)
 
-            snapshot = Snapshot.construct(
-                coordinates=state.getPositions(asNumpy=True),
-                box_vectors=state.getPeriodicBoxVectors(asNumpy=True),
-                velocities=state.getVelocities(asNumpy=True),
-                engine=self
-            )
-
-        except AttributeError as e:
-            raise ValueError('No attribute' + str(e))
-        except:
-            print "Unexpected error:", sys.exc_info()[0]
-            raise
+        snapshot = Snapshot.construct(
+            coordinates=state.getPositions(asNumpy=True),
+            box_vectors=state.getPeriodicBoxVectors(asNumpy=True),
+            velocities=state.getVelocities(asNumpy=True),
+            engine=self
+        )
 
         return snapshot
 


### PR DESCRIPTION
I changed from trying to report a whole pandas `DataFrame` (a typo in that was the problem) to just reporting the bad atoms.

Also removed the `try: except:` wrappers around `OpenMMEngine._build_current_snapshot`.

See discussion in https://github.com/choderalab/ligand-binding-pathsampling/pull/4