### PR TITLE
Fix OpenMM Precision Bug

### DIFF
--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -227,20 +227,23 @@ class OpenMMEngine(DynamicsEngine):
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
                     integrator=self.integrator,
-                    platform=simtk.openmm.Platform.getPlatformByName(platform)
+                    platform=simtk.openmm.Platform.getPlatformByName(platform),
+                    platformProperties=self.openmm_properties
                 )
             elif platform is None:
                 self._simulation = simtk.openmm.app.Simulation(
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
-                    integrator=self.integrator
+                    integrator=self.integrator,
+                    platformProperties=self.openmm_properties
                 )
             else:
                 self._simulation = simtk.openmm.app.Simulation(
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
                     integrator=self.integrator,
-                    platform=platform
+                    platform=platform,
+                    platformProperties=self.openmm_properties
                 )
 
             logger.info(


### PR DESCRIPTION
There was a bug (presumeably) by some merge faults so that the openmm_platform_properties were saved with an engine, but not used in the construction of the actual OpenMM Instance.

This will fix this. On my machine now OpenCL does not work with mixed precision. This seems to be the cause of all the `NaN`s.

@jchodera This is an important fix for you, too, if you use OpenCL!!!!