### PR TITLE
Remove unnecessary packages from test environment

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -32,10 +32,6 @@ requirements:
     - matplotlib
 
 test:
-  requires:
-    - msmbuilder
-    - pyemma
-
   imports:
     - openpathsampling
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   requires:
     - nose
     - nose-timer
-    - python-coveralls
+    - python-coveralls  # [not win]
     - msmbuilder
     - pyemma
     - ipynbtest

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -33,12 +33,8 @@ requirements:
 
 test:
   requires:
-    - nose
-    - nose-timer
-    - python-coveralls  # [not win]
     - msmbuilder
     - pyemma
-    - ipynbtest
 
   imports:
     - openpathsampling


### PR DESCRIPTION
We (ab)used the test environement prior to conda-build 2 to also run nose tests, etc. This is not possible anymore so we can remove the packages which should fix windows conda builds.