### PR TITLE
Snapshot features: `n_degrees_of_freedom` and `instantaneous_temperature`

### DIFF
--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -374,7 +374,11 @@ class OpenMMEngine(DynamicsEngine):
             self.simulation.context.setVelocities(snapshot.velocities)
 
             # After the updates cache the new snapshot
-            self._current_snapshot = snapshot
+            if snapshot.engine is self:
+                # no need for copy if this snap is from this engine
+                self._current_snapshot = snapshot
+            else:
+                self._current_snapshot = self._build_current_snapshot()
 
     def generate_next_frame(self):
         self.simulation.step(self.n_steps_per_frame)

--- a/openpathsampling/engines/openmm/features/__init__.py
+++ b/openpathsampling/engines/openmm/features/__init__.py
@@ -1,3 +1,4 @@
 from openpathsampling.engines.features import *
 from openpathsampling.engines.features.shared import StaticContainer, KineticContainer
 import masses
+import instantaneous_temperature

--- a/openpathsampling/engines/openmm/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/openmm/features/instantaneous_temperature.py
@@ -3,6 +3,13 @@ import simtk.unit as u
 
 @property
 def n_degrees_of_freedom(snapshot):
+    """
+    Returns
+    -------
+    n_degrees_of_freedom: int
+        number of degrees of freedom in this system (after accounting for
+        constraints)
+    """
     # dof calculation taken from OpenMM's StateDataReporter
     n_spatial = 3  # can we get this programmatically?
     system = snapshot.engine.simulation.system
@@ -19,6 +26,12 @@ def n_degrees_of_freedom(snapshot):
 
 @property
 def instantaneous_temperature(snapshot):
+    """
+    Returns
+    -------
+    instantaneous_temperature : simtk.unit.Quantity (temperature)
+        instantaneous temperature from the kinetic energy of this snapshot
+    """
     # TODO: this can be generalized as a feature that works with any
     # snapshot that has features for KE (in units of kB) and n_dofs
     state = snapshot.engine.simulation.context.getState(getEnergy=True)

--- a/openpathsampling/engines/openmm/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/openmm/features/instantaneous_temperature.py
@@ -1,0 +1,33 @@
+import simtk.openmm as mm
+import simtk.unit as u
+
+@property
+def n_degrees_of_freedom(snapshot):
+    # dof calculation taken from OpenMM's StateDataReporter
+    n_spatial = 3  # can we get this programmatically?
+    system = snapshot.engine.simulation.system
+    n_particles = system.getNumParticles()
+    dofs_particles = sum([n_spatial for i in range(n_particles)
+                               if system.getParticleMass(i) > 0*u.dalton])
+    dofs_constaints = system.getNumConstraints()
+    dofs_motion_removers = 0
+    if any(type(system.getForce(i)) == mm.CMMotionRemover 
+           for i in range(system.getNumForces())):
+        dofs_motion_removers += 3
+    dofs = dofs_particles - dofs_constaints - dofs_motion_removers
+    return dofs
+
+@property
+def instantaneous_temperature(snapshot):
+    # TODO: this can be generalized as a feature that works with any
+    # snapshot that has features for KE (in units of kB) and n_dofs
+    state = snapshot.engine.simulation.context.getState(getEnergy=True)
+    # divide by Avogadro b/c OpenMM reports energy/mole
+    ke_in_energy = state.getKineticEnergy() / u.AVOGADRO_CONSTANT_NA
+    ke_per_kB = ke_in_energy / u.BOLTZMANN_CONSTANT_kB
+
+    dofs = snapshot.n_degrees_of_freedom
+
+    temperature = 2 * ke_per_kB / dofs
+    return temperature
+

--- a/openpathsampling/engines/openmm/snapshot.py
+++ b/openpathsampling/engines/openmm/snapshot.py
@@ -27,7 +27,6 @@ class MDSnapshot(BaseSnapshot):
 #         features.velocities,
 #         features.coordinates,
 #         features.box_vectors,
-#         features.masses,
 #         features.engine
 #     ],
 #     description="A fast MDSnapshot",
@@ -39,6 +38,7 @@ class MDSnapshot(BaseSnapshot):
     features.statics,
     features.kinetics,
     features.masses,
+    features.instantaneous_temperature,
     features.engine
 ])
 class Snapshot(BaseSnapshot):

--- a/openpathsampling/engines/toy/features/__init__.py
+++ b/openpathsampling/engines/toy/features/__init__.py
@@ -4,3 +4,5 @@ from openpathsampling.engines.features import (
     velocities,
     engine
 )
+
+import instantaneous_temperature

--- a/openpathsampling/engines/toy/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/toy/features/instantaneous_temperature.py
@@ -12,7 +12,7 @@ def instantaneous_temperature(snapshot):
     double_ke = sum([masses[i] * velocities[i].dot(velocities[i])
                      for i in range(len(masses))])
 
-    dofs = snaphost.n_degrees_of_freedom
+    dofs = snapshot.n_degrees_of_freedom
 
     temperature = double_ke / dofs
     return temperature

--- a/openpathsampling/engines/toy/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/toy/features/instantaneous_temperature.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+@property
+def n_degrees_of_freedom(snapshot):
+    topol = snapshot.engine.topology
+    return topol.n_atoms * topol.n_spatial
+
+@property
+def instantaneous_temperature(snapshot):
+    masses = snapshot.masses
+    velocities = snapshot.velocities
+    double_ke = sum([masses[i] * velocities[i].dot(velocities[i])
+                     for i in range(len(masses))])
+
+    dofs = snaphost.n_degrees_of_freedom
+
+    temperature = double_ke / dofs
+    return temperature
+
+

--- a/openpathsampling/engines/toy/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/toy/features/instantaneous_temperature.py
@@ -2,11 +2,24 @@ import numpy as np
 
 @property
 def n_degrees_of_freedom(snapshot):
+    """
+    Returns
+    -------
+    n_degrees_of_freedom: int
+        number of degrees of freedom in this system (after accounting for
+        constraints)
+    """
     topol = snapshot.engine.topology
     return topol.n_atoms * topol.n_spatial
 
 @property
 def instantaneous_temperature(snapshot):
+    """
+    Returns
+    -------
+    instantaneous_temperature : float
+        instantaneous temperature from the kinetic energy of this snapshot
+    """
     masses = snapshot.masses
     velocities = snapshot.velocities
     double_ke = sum([masses[i] * velocities[i].dot(velocities[i])

--- a/openpathsampling/engines/toy/snapshot.py
+++ b/openpathsampling/engines/toy/snapshot.py
@@ -6,11 +6,13 @@
 
 from openpathsampling.engines import BaseSnapshot, SnapshotFactory
 import openpathsampling.engines.features as feats
+import features as toy_feats
 
 
 @feats.attach_features([
     feats.velocities,
     feats.coordinates,
+    toy_feats.instantaneous_temperature,
     feats.engine
 ])
 class ToySnapshot(BaseSnapshot):

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -22,14 +22,16 @@ class testOpenMMSnapshot(object):
             integrator=omt.integrators.VVVRIntegrator()
         )
         self.n_atoms = self.engine.topology.n_atoms
+        self.engine.current_snapshot = self.template
 
     def test_masses_from_file(self):
         masses = self.template.masses
         assert_equal(len(masses), self.n_atoms)
 
     def test_masses_from_simulation(self):
-        self.engine.generate(self.template,
-                             [paths.LengthEnsemble(2).can_append])
         sim_snap = self.engine.current_snapshot
         masses = sim_snap.masses
         assert_equal(len(masses), self.n_atoms)
+
+    def test_n_degrees_of_freedom(self):
+        assert_equal(self.engine.current_snapshot.n_degrees_of_freedom, 51)

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -1,9 +1,11 @@
 import openpathsampling.engines.openmm as omm_engine
 import openpathsampling as paths
-from nose.tools import assert_equal
-from test_helpers import data_filename
+from nose.tools import assert_equal, assert_almost_equal
+from test_helpers import data_filename, assert_close_unit
 
 import openmmtools as omt
+import simtk.unit as u
+import numpy as np
 
 import logging
 
@@ -35,3 +37,21 @@ class testOpenMMSnapshot(object):
 
     def test_n_degrees_of_freedom(self):
         assert_equal(self.engine.current_snapshot.n_degrees_of_freedom, 51)
+
+    def test_instantaneous_temperature(self):
+        vel_unit = u.nanometers / u.picoseconds
+        new_velocities = [[1.0, 0.0, 0.0]] * self.n_atoms * vel_unit
+        self.engine.current_snapshot = omm_engine.Snapshot.construct(
+            coordinates=self.engine.current_snapshot.coordinates,
+            box_vectors=self.engine.current_snapshot.box_vectors,
+            velocities=new_velocities,
+            engine=self.engine
+        )
+        test_snap = self.engine.current_snapshot
+        expected_ke = sum(
+            [m * vel_unit**2 for m in test_snap.masses], 
+            0.0*u.joule
+        )
+        n_dofs = 51.0  # see test above
+        assert_close_unit(test_snap.instantaneous_temperature,
+                          expected_ke / u.BOLTZMANN_CONSTANT_kB / n_dofs)

--- a/openpathsampling/tests/test_toy_features.py
+++ b/openpathsampling/tests/test_toy_features.py
@@ -1,0 +1,48 @@
+import openpathsampling.engines.toy as toys
+import numpy as np
+
+from nose.tools import assert_equal, assert_almost_equal
+from nose.plugins.skip import SkipTest
+import logging
+
+logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
+class testToySnapshotFeatures(object):
+    def setup(self):
+        integ = toys.LangevinBAOABIntegrator(dt=0.002,
+                                             temperature=1.0,
+                                             gamma=2.5)
+        options={'integ': integ, 'n_frames_max': 5}
+        topology_2D = toys.Topology(n_spatial=2,
+                                    masses=[1.0],
+                                    pes=None)
+        engine_2D = toys.Engine(options=options, topology=topology_2D)
+        self.snap_2D = toys.Snapshot(coordinates=np.array([[0.0, 0.0]]),
+                                     velocities=np.array([[2.0, 4.0]]),
+                                     engine=engine_2D)
+
+        topology_6D = toys.Topology(n_spatial=3,
+                                    n_atoms=2,
+                                    masses=[1.0, 2.0],
+                                    pes=None)
+        engine_6D = toys.Engine(options=options, topology=topology_6D)
+        self.snap_6D = toys.Snapshot(coordinates=np.array([[0.0, 0.0, 0.0],
+                                                           [0.0, 0.0, 0.0]]),
+                                     velocities=np.array([[1.0, 0.0, 0.0],
+                                                          [1.0, 0.0, 0.0]]),
+                                     engine=engine_6D)
+
+    def test_n_degrees_of_freedom(self):
+        assert_equal(self.snap_2D.n_degrees_of_freedom, 2)
+        assert_equal(self.snap_6D.n_degrees_of_freedom, 6)
+
+    def test_instantaneous_temperature(self):
+        # KE = 0.5 * (1.0*2.0**2 + 1.0*4.0**2) = 10.0
+        # T = 2 * KE / 2 = KE = 10.0
+        assert_almost_equal(self.snap_2D.instantaneous_temperature, 10.0)
+        # KE = 0.5 * (1.0*1.0**2 + 2.0*1.0**2) = 1.5
+        # T = 2 * KE / 6 = 0.5
+        assert_almost_equal(self.snap_6D.instantaneous_temperature, 0.5)


### PR DESCRIPTION
Note: these are not intended to be features that are required of every engine. However, they could be very useful.

In particular, I'm pretty sure we want something like `n_degrees_of_freedom`: that shows up in enough other calculations, and will be very much engine dependent. Not having this leads to all sorts of ugliness when I wanted to check instantaneous temperature in the AD TPS example: a lot of code that is OpenMM-specific.

Whether we directly include `instantaneous_temperature` is a little less vital, in my opinion. A competent user can handle that little bit of code for their engine. For now, I've added it for consideration.

- [x] Draft `n_degrees_of_freedom` and `instantaneous_temperature` for OpenMM
- [x] Draft `n_degrees_of_freedom` and `instantaneous_temperature` for Toy engine
- [x] Tests for `n_degrees_of_freedom` and `instantaneous_temperature` for OpenMM
- [x] Tests for `n_degrees_of_freedom` and `instantaneous_temperature` for Toy engine
- [x] Add docstrings