### PR TITLE
Pin pyqt 4.11.4-py27_3

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - mdtraj
     - svgwrite
     - networkx
-    - pyqt 4*
+    - pyqt 4.11.4 py27_3
     - matplotlib
     - ujson
 


### PR DESCRIPTION
As the folks at `conda` are working to make it so we can unpin `pyqt` overall, things got temporarily a little worse. Now we need to pin to a specific build.

From the response I got at https://github.com/ContinuumIO/anaconda-issues/issues/1090, it sounds like it'll be fixed soon. But this should handle it in the meantime.