### PR TITLE
Cleanup of `Details` objects

### DIFF
--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -26,7 +26,7 @@ ipynbtest.py "toy_mistis_3_analysis.ipynb" || testfail=1
 date
 cd ../tests/
 cp ../toy_model_mstis/mstis.nc ./
-ipynbtest.py --strict "test_openmm_integration.ipynb" || testfail=1
+ipynbtest.py --strict --show-diff "test_openmm_integration.ipynb" || testfail=1
 date
 ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
 date

--- a/openpathsampling/movechange.py
+++ b/openpathsampling/movechange.py
@@ -304,7 +304,7 @@ class SampleMoveChange(MoveChange):
     This is the most common MoveChange and all other moves use this
     as leaves and on the lowest level consist only of `SampleMoveChange`
     """
-    def __init__(self, samples, mover=None, details=None):
+    def __init__(self, samples, mover=None, details=None, input_samples=None):
         """
         Parameters
         ----------
@@ -327,6 +327,7 @@ class SampleMoveChange(MoveChange):
             samples = [samples]
 
         self.samples = samples
+        self.input_samples = input_samples
 
     def _get_results(self):
         return []

--- a/openpathsampling/movechange.py
+++ b/openpathsampling/movechange.py
@@ -28,7 +28,8 @@ class MoveChange(TreeMixin, StorableObject):
         E.g. for a RandomChoiceMover which Mover was selected.
     '''
 
-    def __init__(self, subchanges=None, samples=None, mover=None, details=None):
+    def __init__(self, subchanges=None, samples=None, mover=None,
+                 details=None, input_samples=None):
         StorableObject.__init__(self)
 
         self._len = None
@@ -46,6 +47,12 @@ class MoveChange(TreeMixin, StorableObject):
             self.samples = list()
         else:
             self.samples = samples
+
+        if input_samples is None:
+            self.input_samples = list()
+        else:
+            self.input_samples = input_samples
+
         self.details = details
 
     def __getattr__(self, item):
@@ -321,13 +328,16 @@ class SampleMoveChange(MoveChange):
         mover
         details
         """
-        super(SampleMoveChange, self).__init__(mover=mover, details=details)
+        super(SampleMoveChange, self).__init__(
+            mover=mover,
+            details=details,
+            input_samples=input_samples
+        )
 
         if samples.__class__ is paths.Sample:
             samples = [samples]
 
         self.samples = samples
-        self.input_samples = input_samples
 
     def _get_results(self):
         return []

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -2321,15 +2321,6 @@ class Details(StorableObject):
 class MoveDetails(Details):
     """Details of the move as applied to a given replica
 
-    Attributes
-    ----------
-    inputs : list of Trajectory
-        the Samples which were used as inputs to the move
-    trials : list of Trajectory
-        the trial trajectories
-    results : list of Trajectory
-        the results
-
     Specific move types may have add several other attributes for each
     MoveDetails object. For example, shooting moves will also include
     information about the shooting point selection, etc.
@@ -2338,34 +2329,15 @@ class MoveDetails(Details):
     rejection_reason : String
         explanation of reasons the path was rejected
 
-    RENAME: inputs=>initial
-            accepted=>trial_in_ensemble (probably only in shooting)
-
-    TODO:
-    Currently trial/accepted are in terms of Trajectory objects. I
-    think it makes more sense for them to be Samples.
-    I kept trial, accepted as a trajectory and only changed inputs
-    to a list of samples. Since trial, accepted are move related
-    to the shooting and not necessarily dependent on a replica or
-    initial ensemble.
     """
 
     def __init__(self, **kwargs):
-        self.inputs = None
-        self.trials = None
-        self.results = None
         super(MoveDetails, self).__init__(**kwargs)
 
 
 class SampleDetails(Details):
     """Details of a sample
-
-    Attributes
-    ----------
-    selection_probability : float
-        the chance that a sample will be accepted due to asymmetrical proposal
     """
 
     def __init__(self, **kwargs):
-        self.selection_probability = 1.0
         super(SampleDetails, self).__init__(**kwargs)

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -544,8 +544,8 @@ class SampleMover(PathMover):
             accepted = False
 
         details = paths.MoveDetails(
-            total_acceptance=probability,
-            random_value=rand
+            metropolis_acceptance=probability,
+            metropolis_random=rand
         )
 
         logger.info("Trial was " + ("accepted" if accepted else "rejected"))

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -959,7 +959,6 @@ class ReplicaExchangeMover(SampleMover):
             trajectory=trajectory1,
             ensemble=ensemble2,
             parent=sample1,
-            details=SampleDetails(),
             mover=self
         )
         trial2 = paths.Sample(
@@ -967,7 +966,6 @@ class ReplicaExchangeMover(SampleMover):
             trajectory=trajectory2,
             ensemble=ensemble1,
             parent=sample2,
-            details=SampleDetails(),
             mover=self
         )
 
@@ -1898,6 +1896,7 @@ class ReplicaIDChangeMover(PathMover):
         return paths.AcceptedSampleMoveChange(
             samples=[new_sample],
             mover=self,
+            input_samples=samples,
             details=details
         )
 

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -587,13 +587,15 @@ class SampleMover(PathMover):
             return paths.RejectedNaNSampleMoveChange(
                 samples=e.trial_sample,
                 mover=self,
+                input_samples=samples,
                 details=paths.MoveDetails(
-                    rejection_reason='nan')
+                    rejection_reason='nan'),
             )
         except SampleMaxLengthError as e:
             return paths.RejectedMaxLengthSampleMoveChange(
                 samples=e.trial_sample,
                 mover=self,
+                input_samples=samples,
                 details=paths.MoveDetails(
                     rejection_reason='max_length')
             )
@@ -606,12 +608,14 @@ class SampleMover(PathMover):
             return paths.AcceptedSampleMoveChange(
                 samples=trials,
                 mover=self,
+                input_samples=samples,
                 details=details
             )
         else:
             return paths.RejectedSampleMoveChange(
                 samples=trials,
                 mover=self,
+                input_samples=samples,
                 details=details
             )
 

--- a/openpathsampling/storage/stores/movechange.py
+++ b/openpathsampling/storage/stores/movechange.py
@@ -19,6 +19,7 @@ class MoveChangeStore(ObjectStore):
 
     def _save(self, movechange, idx):
         self.vars['samples'][idx] = movechange.samples
+        self.vars['input_samples'][idx] = movechange.input_samples
         self.vars['subchanges'][idx] = movechange.subchanges
         self.write('details', idx, movechange)
         self.vars['mover'][idx] = movechange.mover
@@ -34,6 +35,10 @@ class MoveChangeStore(ObjectStore):
         obj.samples = self.vars['samples'][idx]
         obj.subchanges = self.vars['subchanges'][idx]
         obj.details = self.vars['details'][idx]
+        try:
+            obj.input_samples = self.vars['input_samples'][idx]
+        except KeyError:  # BACKWARDS COMPATIBILITY; REMOVE IN 2.0
+            obj.input_samples = None
 
         return obj
 
@@ -52,6 +57,11 @@ class MoveChangeStore(ObjectStore):
         self.create_variable('samples', 'obj.samples',
                              dimensions='...',
                              chunksizes=(10240,))
+
+        self.create_variable('input_samples', 'obj.samples',
+                             dimensions='...',
+                             chunksizes=(10240,))
+
 
     def cache_all(self):
         """Load all samples as fast as possible into the cache


### PR DESCRIPTION
We had a lot of old cruft (pre-dating the `MoveChange` object) that was stored as part of various `Details` objects. Following some email discussion with @jhprinz, this PR does the following:

- [x] Remove all default values from `Details` (`trials`, `results`, `inputs` from `MoveDetails`; `selection_probability` from `SampleDetails`): these were unused/redundant with `MoveChange`
- [x] Rename Metropolis-related details: `total_acceptance`=>`metropolis_acceptance`; `random_value`=>`metropolis_random`
- [x] Add `input_samples` to `SampleMoveChange`
- [x] Check that everything is being stored correctly in new results.

Note that this does not (yet) end the distinction between `MoveDetails` and `SampleDetails`, although now the objects are essentially equivalent (and are just renamed subclasses of `Details`.  @jhprinz, if you think I should change that here, I can easily.