### PR TITLE
Fix caching of MoveChanges for changes with no samples

### DIFF
--- a/openpathsampling/movechange.py
+++ b/openpathsampling/movechange.py
@@ -38,12 +38,12 @@ class MoveChange(TreeMixin, StorableObject):
         self._accepted = None
         self.mover = mover
         if subchanges is None:
-            self.subchanges = list()
+            self.subchanges = []
         else:
             self.subchanges = subchanges
 
         if samples is None:
-            self.samples = list()
+            self.samples = []
         else:
             self.samples = samples
         self.details = details

--- a/openpathsampling/storage/stores/movechange.py
+++ b/openpathsampling/storage/stores/movechange.py
@@ -125,15 +125,16 @@ class MoveChangeStore(ObjectStore):
                 obj,
                 mover=self.storage.pathmovers[int(mover_idx)])
 
-        if len(samples_idxs) > 0:
-            if self.reference_by_uuid:
+        if self.reference_by_uuid:
+            if len(samples_idxs) > 0:
                 samples_idxs = self.storage.to_uuid_chunks(samples_idxs)
                 obj.samples = \
                     [self.storage.samples[UUID(idx)] for idx in samples_idxs]
-                obj.details = self.storage.details.proxy(str(details_idx))
-            else:
+            obj.details = self.storage.details.proxy(str(details_idx))
+        else:
+            if len(samples_idxs) > 0:
                 obj.samples = \
                     [self.storage.samples[int(idx)] for idx in samples_idxs]
-                obj.details = self.storage.details.proxy(int(details_idx))
+            obj.details = self.storage.details.proxy(int(details_idx))
 
         return obj


### PR DESCRIPTION
Simple fix. Resolves #630 .

Problem was for (unknown) reason details were only loaded when caching all if a change had no samples. 