### PR TITLE
PathMover update - remove `Sample.details`

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -111,7 +111,7 @@ from pathmover import (
     PartialAcceptanceSequentialMover, BackwardShootMover, ForwardShootMover,
     BackwardExtendMover, ForwardExtendMover, MinusMover,
     SingleReplicaMinusMover, PathMoverFactory, PathReversalMover,
-    ReplicaExchangeMover, EnsembleHopMover, ReplicaIDChangeMover,
+    ReplicaExchangeMover, EnsembleHopMover,
     SequentialMover, ConditionalMover,
     PathSimulatorMover, PathReversalSet, NeighborEnsembleReplicaExchange,
     SampleMover, StateSwapMover, FinalSubtrajectorySelectMover, EngineMover,

--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -121,7 +121,7 @@ class ShootingPointAnalysis(SnapshotByCoordinateDict):
         """
         key = self.step_key(step)
         if key is not None:
-            details = step.change.canonical.trials[0].details
+            details = step.change.canonical.details
             trial_traj = step.change.canonical.trials[0].trajectory
             init_traj = details.initial_trajectory
             test_points = [s for s in [trial_traj[0], trial_traj[-1]]
@@ -161,8 +161,7 @@ class ShootingPointAnalysis(SnapshotByCoordinateDict):
         """
         key = None
         try:
-            # TODO: this should in step.change.canonical.details
-            details = step.change.canonical.trials[0].details
+            details = step.change.canonical.details
             shooting_snap = details.shooting_snapshot
         except AttributeError:
             # wrong kind of move (no shooting_snapshot)

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -2326,9 +2326,8 @@ class MoveDetails(Details):
 class SampleDetails(Details):
     """Details of a sample
 
-    Notes
-    -----
-    Deprecated. Will not present in future versions
+    .. note:: Deprecated in OpenPathSampling 0.9.3
+          `SampleDetails` will be removed in OPS 2.0.0
     """
 
     def __init__(self, **kwargs):

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -1080,7 +1080,7 @@ class SubtrajectorySelectMover(SampleMover):
     If there are no subtrajectories which satisfy the subensemble, this
     returns the zero-length trajectory.
 
-    Parameters
+    Attributes
     ----------
     ensemble : openpathsampling.Ensemble
         the set of allows samples to chose from
@@ -1156,6 +1156,18 @@ class RandomSubtrajectorySelectMover(SubtrajectorySelectMover):
     If there are no subtrajectories which satisfy the subensemble, this
     returns the zero-length trajectory.
 
+    Attributes
+    ----------
+    ensemble : openpathsampling.Ensemble
+        the set of allows samples to chose from
+    sub_ensemble : openpathsampling.Ensemble
+        the subensemble to be searched for
+    n_l : int or None
+        the number of subtrajectories that need to be found. If
+        `None` every number of subtrajectories > 0 is okay.
+        Otherwise the move is only accepted if exactly n_l subtrajectories
+        are found.
+
     """
 
     def _choose(self, trajectory_list):
@@ -1168,6 +1180,19 @@ class FirstSubtrajectorySelectMover(SubtrajectorySelectMover):
 
     If there are no subtrajectories which satisfy the ensemble, this returns
     the zero-length trajectory.
+
+    Attributes
+    ----------
+    ensemble : openpathsampling.Ensemble
+        the set of allows samples to chose from
+    sub_ensemble : openpathsampling.Ensemble
+        the subensemble to be searched for
+    n_l : int or None
+        the number of subtrajectories that need to be found. If
+        `None` every number of subtrajectories > 0 is okay.
+        Otherwise the move is only accepted if exactly n_l subtrajectories
+        are found.
+
     """
 
     def _choose(self, trajectory_list):
@@ -1180,6 +1205,19 @@ class FinalSubtrajectorySelectMover(SubtrajectorySelectMover):
 
     If there are no subtrajectories which satisfy the ensemble, this returns
     the zero-length trajectory.
+
+    Attributes
+    ----------
+    ensemble : openpathsampling.Ensemble
+        the set of allows samples to chose from
+    sub_ensemble : openpathsampling.Ensemble
+        the subensemble to be searched for
+    n_l : int or None
+        the number of subtrajectories that need to be found. If
+        `None` every number of subtrajectories > 0 is okay.
+        Otherwise the move is only accepted if exactly n_l subtrajectories
+        are found.
+
     """
 
     def _choose(self, trajectory_list):
@@ -1502,6 +1540,12 @@ class RandomAllowedChoiceMover(RandomChoiceMover):
     from sub movers that actually can succeed because they have samples in all
     required input_ensembles
 
+    Attributes
+    ----------
+    movers : list of PathMover
+        the PathMovers to choose from
+    weights : list of floats
+        the relative weight of each PathMover (does not need to be normalized)
     """
 
     def _selector(self, sample_set):
@@ -1532,6 +1576,13 @@ class FirstAllowedMover(SelectionMover):
     A mover can only safely be run, if all inputs can be satisfied.
     This will pick the first mover from the list where all ensembles
     from input_ensembles are found.
+
+    Attributes
+    ----------
+    movers : list of PathMover
+        the PathMovers to choose from
+    weights : list of floats
+        the relative weight of each PathMover (does not need to be normalized)
 
     """
 
@@ -1564,6 +1615,13 @@ class LastAllowedMover(SelectionMover):
     A mover can only safely be run, if all inputs can be satisfied.
     This will pick the last mover from the list where all ensembles
     from input_ensembles are found.
+
+    Attributes
+    ----------
+    movers : list of PathMover
+        the PathMovers to choose from
+    weights : list of floats
+        the relative weight of each PathMover (does not need to be normalized)
 
     """
 

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -764,7 +764,7 @@ class EngineMover(SampleMover):
             replica=input_sample.replica,
             trajectory=trial_trajectory,
             ensemble=self.target_ensemble,
-            # parent=input_sample,
+            parent=input_sample,
             mover=self,
             bias=bias
         )
@@ -969,14 +969,14 @@ class ReplicaExchangeMover(SampleMover):
             replica=replica1,
             trajectory=trajectory1,
             ensemble=ensemble2,
-            # parent=sample1,
+            parent=sample1,
             mover=self
         )
         trial2 = paths.Sample(
             replica=replica2,
             trajectory=trajectory2,
             ensemble=ensemble1,
-            # parent=sample2,
+            parent=sample2,
             mover=self
         )
 
@@ -1136,7 +1136,7 @@ class SubtrajectorySelectMover(SampleMover):
                 replica=replica,
                 trajectory=subtraj,
                 ensemble=self.sub_ensemble,
-                # parent=trial,
+                parent=trial,
                 mover=self,
                 bias=bias
             )
@@ -1231,7 +1231,7 @@ class PathReversalMover(SampleMover):
             trajectory=reversed_trajectory,
             ensemble=ensemble,
             mover=self,
-            # parent=trial,
+            parent=trial,
             bias=bias
         )
 
@@ -1858,7 +1858,7 @@ class ConditionalSequentialMover(SequentialMover):
 #             replica=rep_to,
 #             ensemble=rep_sample.ensemble,
 #             trajectory=rep_sample.trajectory,
-#             # parent=rep_sample,
+#             parent=rep_sample,
 #             mover=self
 #         )
 #

--- a/openpathsampling/sample.py
+++ b/openpathsampling/sample.py
@@ -761,7 +761,7 @@ class Sample(StorableObject):
                  trajectory=None,
                  ensemble=None,
                  bias=1.0,
-                 # details=None,
+                 details=None,
                  parent=None,
                  mover=None
                  ):

--- a/openpathsampling/sample.py
+++ b/openpathsampling/sample.py
@@ -87,7 +87,7 @@ class SampleSet(StorableObject):
             return (self[element] for element in key)
         elif type(key) is slice:
             rep_idxs = filter(
-                lambda x :
+                lambda x:
                     (key.start is None or x >= key.start) and
                     (key.stop is None or x < key.stop),
                 sorted(self.replica_dict.keys())
@@ -192,13 +192,14 @@ class SampleSet(StorableObject):
             self.append(samples)
 
     def apply_samples(self, samples, copy=True):
-        '''Updates the SampleSet based on a list of samples, by setting them
-        by replica in the order given in the argument list.'''
+        """Update by setting samples by replica in the order given
+
+        """
         if isinstance(samples, Sample):
             samples = [samples]
         elif isinstance(samples, paths.MoveChange):
             samples = samples.results
-        if copy==True:
+        if copy:
             newset = SampleSet(self)
         else:
             newset = self
@@ -211,25 +212,25 @@ class SampleSet(StorableObject):
         return newset
 
     def replica_list(self):
-        '''Returns the list of replicas IDs in this SampleSet'''
+        """Returns the list of replicas IDs in this SampleSet
+
+        """
         return self.replica_dict.keys()
 
     def ensemble_list(self):
-        '''Returns the list of ensembles in this SampleSet'''
+        """Returns the list of ensembles in this SampleSet
+
+        """
         return self.ensemble_dict.keys()
 
     def sanity_check(self):
-        '''Checks that the sample trajectories satisfy their ensembles
-        '''
+        """Checks that the sample trajectories satisfy their ensembles
+
+        """
         logger.info("Starting sanity check")
         for sample in self:
-            # TODO: Replace by using .valid which means that it is in the ensemble
-            # and does the same testing but with caching so the .valid might
-            # fail in case of some bad hacks. Since we check anyway, let's just
-
-            #assert(sample.valid)
-            logger.info("Checking sanity of "+repr(sample.ensemble)+
-                        " with "+str(sample.trajectory))
+            logger.info("Checking sanity of " + repr(sample.ensemble) +
+                        " with " + str(sample.trajectory))
             try:
                 assert(sample.ensemble(sample.trajectory))
             except AssertionError as e:
@@ -240,15 +241,15 @@ class SampleSet(StorableObject):
                 else:
                     arg0 = failmsg + e.args[0]
                     e.args = tuple([arg0] + list(e.args[1:]))
-                raise # reraises last exception
+                raise  # re-raise last exception
 
     def consistency_check(self):
-        '''Check that all internal dictionaries are consistent
+        """Check that all internal dictionaries are consistent
 
         This is mainly a sanity check for use in testing, but might be
         good to run (rarely) in the code until we're sure the tests cover
         all use cases.
-        '''
+        """
 
         # check that we have the same number of samples in everything
         nsamps_ens = 0
@@ -258,18 +259,19 @@ class SampleSet(StorableObject):
         for rep in self.replica_dict.keys():
             nsamps_rep += len(self.replica_dict[rep])
         nsamps = len(self.samples)
-        assert nsamps==nsamps_ens, \
-                "nsamps != nsamps_ens : %d != %d" % (nsamps, nsamps_ens)
-        assert nsamps==nsamps_rep, \
-                "nsamps != nsamps_rep : %d != %d" % (nsamps, nsamps_rep)
+        assert nsamps == nsamps_ens, \
+            "nsamps != nsamps_ens : %d != %d" % (nsamps, nsamps_ens)
+        assert nsamps == nsamps_rep, \
+            "nsamps != nsamps_rep : %d != %d" % (nsamps, nsamps_rep)
 
         # if we have the same number of samples, then we check that each
         # sample in samples is in each of the dictionaries
         for samp in self.samples:
             assert samp in self.ensemble_dict[samp.ensemble], \
-                    "Sample not in ensemble_dict! %r %r" % (samp, self.ensemble_dict)
+                "Sample not in ensemble_dict! %r %r" % (
+                    samp, self.ensemble_dict)
             assert samp in self.replica_dict[samp.replica], \
-                    "Sample not in replica_dict! %r %r" % (samp, self.replica_dict)
+                "Sample not in replica_dict! %r %r" % (samp, self.replica_dict)
 
         # finally, check to be sure that thre are no duplicates in
         # self.samples; this completes the consistency check
@@ -285,15 +287,15 @@ class SampleSet(StorableObject):
         previous replica ID.
         """
         if len(self) == 0:
-            max_repID = -1
+            max_replica = -1
         else:
-            max_repID = max([s.replica for s in self.samples])
+            max_replica = max([s.replica for s in self.samples])
         self.append(Sample(
-            replica=max_repID + 1,
+            replica=max_replica + 1,
             trajectory=sample.trajectory,
             ensemble=sample.ensemble,
             bias=sample.bias,
-            details=sample.details,
+            # details=sample.details,
             parent=sample.parent,
             mover=sample.mover
         ))
@@ -309,8 +311,8 @@ class SampleSet(StorableObject):
         return SampleSet([
             Sample.initial_sample(
                 replica=ensembles.index(e),
-                trajectory=paths.Trajectory(trajectory.as_proxies()), # copy
-                ensemble = e)
+                trajectory=paths.Trajectory(trajectory.as_proxies()),  # copy
+                ensemble=e)
             for e in ensembles
         ])
 
@@ -350,7 +352,7 @@ class SampleSet(StorableObject):
     @staticmethod
     def relabel_replicas_per_ensemble(ssets):
         """
-        Return a SampleSet with one trajectory ID per ensemble in the given ssets.
+        Return a SampleSet with one trajectory ID per ensemble in `ssets`
 
         This is used if you create several sample sets (e.g., from
         bootstrapping different transitions) which have the same trajectory
@@ -561,6 +563,8 @@ class SampleSet(StorableObject):
 
                     # fill only the first in ens_list that can be filled
 
+                    sample = None
+
                     if strategy == 'get':
                         sample = ens.get_sample_from_trajectories(
                             trajectories=trajectories,
@@ -599,8 +603,6 @@ class SampleSet(StorableObject):
                                 level='native',
                                 **opts
                             )
-                    else:
-                        sample = None
 
                     # now, if we've found a sample, add it and
                     # make sure we chose a proper replica ID
@@ -723,14 +725,14 @@ class SampleSet(StorableObject):
                 trajectory=s.trajectory,
                 ensemble=s.ensemble,
                 bias=s.bias,
-                details=s.details,
-                parent=None,
+                # details=s.details,
                 mover=s.mover
             ) for s in self]
         )
 
 
-@lazy_loading_attributes('parent', 'details', 'mover')
+# @lazy_loading_attributes('parent', 'details', 'mover')
+@lazy_loading_attributes('parent', 'mover')
 class Sample(StorableObject):
     """
     A Sample represents a given "draw" from its ensemble, and is the return
@@ -746,15 +748,12 @@ class Sample(StorableObject):
     Attributes
     ----------
     replica : int
-        The replica ID to which this Sample applies. The replica ID can also be negative.
+        The replica ID to which this Sample applies. The replica ID can also
+        be negative.
     trajectory : openpathsampling.Trajectory
         The trajectory (path) for this sample
     ensemble : openpathsampling.Ensemble
         The Ensemble this sample is drawn from
-    details : openpathsampling.MoveDetails
-        Object 
-    step : int
-        the Monte Carlo step number associated with this Sample
     """
 
     def __init__(self,
@@ -762,7 +761,7 @@ class Sample(StorableObject):
                  trajectory=None,
                  ensemble=None,
                  bias=1.0,
-                 details=None,
+                 # details=None,
                  parent=None,
                  mover=None
                  ):
@@ -773,8 +772,10 @@ class Sample(StorableObject):
         self.ensemble = ensemble
         self.trajectory = trajectory
         self.parent = parent
-        self.details = details
+        # self.details = details
         self.mover = mover
+
+        self._valid = None
 
     # ==========================================================================
     # LIST INHERITANCE FUNCTIONS
@@ -808,13 +809,13 @@ class Sample(StorableObject):
         if self.trajectory is not None:
             return reversed(self.trajectory)
         else:
-            return [] # empty iterator
+            return []  # empty iterator
 
     def as_proxies(self):
         if self.trajectory is not None:
             return self.trajectory.as_proxies()
         else:
-            return [] # empty iterator
+            return []  # empty iterator
 
     def __iter__(self):
         """
@@ -829,12 +830,14 @@ class Sample(StorableObject):
         if self.trajectory is not None:
             return iter(self.trajectory)
         else:
-            return [] # empty iterator
+            return []  # empty iterator
 
     def __str__(self):
-        mystr  = "Replica: "+str(self.replica)+"\n"
-        mystr += "Trajectory: "+str(self.trajectory)+"\n"
-        mystr += "Ensemble: "+repr(self.ensemble)+"\n"
+        # mystr  = "Replica: "+str(self.replica)+"\n"
+        # mystr += "Trajectory: "+str(self.trajectory)+"\n"
+        # mystr += "Ensemble: "+repr(self.ensemble)+"\n"
+        mystr = 'Sample(RepID: %d, Ens: %s, %d steps)' % (
+            self.replica, repr(self.ensemble), len(self.trajectory))
         return mystr
 
     @property
@@ -862,9 +865,9 @@ class Sample(StorableObject):
         return '<Sample @ ' + str(hex(id(self))) + '>'
 
     def copy_reset(self):
-        '''
+        """
         Copy of Sample with initialization move details.
-        '''
+        """
         result = Sample(
             replica=self.replica,
             trajectory=self.trajectory,
@@ -886,7 +889,6 @@ class Sample(StorableObject):
             ensemble=ensemble
         )
         return result
-
 
     @property
     def acceptance(self):

--- a/openpathsampling/storage/stores/movechange.py
+++ b/openpathsampling/storage/stores/movechange.py
@@ -151,13 +151,19 @@ class MoveChangeStore(ObjectStore):
                     self.storage.to_uuid_chunks(input_samples_idxs)
                 obj.samples = \
                     [self.storage.samples[UUID(idx)] for idx in samples_idxs]
-                obj.input_samples = [self.storage.samples[UUID(idx)]
-                                     for idx in input_samples_idxs]
+            if len(input_samples_idxs) > 0:
+                obj.input_samples = [
+                    self.storage.samples[UUID(idx)]
+                    for idx in input_samples_idxs]
             obj.details = self.storage.details.proxy(str(details_idx))
         else:
             if len(samples_idxs) > 0:
                 obj.samples = \
                     [self.storage.samples[int(idx)] for idx in samples_idxs]
+            if len(input_samples_idxs) > 0:
+                obj.input_samples = [
+                    self.storage.samples[int(idx)]
+                    for idx in input_samples_idxs]
             obj.details = self.storage.details.proxy(int(details_idx))
 
         return obj

--- a/openpathsampling/storage/stores/movechange.py
+++ b/openpathsampling/storage/stores/movechange.py
@@ -62,7 +62,6 @@ class MoveChangeStore(ObjectStore):
                              dimensions='...',
                              chunksizes=(10240,))
 
-
     def cache_all(self):
         """Load all samples as fast as possible into the cache
 

--- a/openpathsampling/storage/stores/sample.py
+++ b/openpathsampling/storage/stores/sample.py
@@ -7,7 +7,7 @@ class SampleStore(VariableStore):
         super(SampleStore, self).__init__(
             Sample,
             ['trajectory', 'ensemble', 'replica', 'parent',
-             'details', 'bias', 'mover']
+             'bias', 'mover']
         )
 
     def by_ensemble(self, ensemble):
@@ -22,7 +22,7 @@ class SampleStore(VariableStore):
         self.create_variable('ensemble', 'obj.ensembles')
         self.create_variable('replica', 'int')
         self.create_variable('parent', 'lazyobj.samples')
-        self.create_variable('details', 'lazyobj.details')
+        # self.create_variable('details', 'lazyobj.details')
         self.create_variable('bias', 'float')
         self.create_variable('mover', 'obj.pathmovers')
 

--- a/openpathsampling/tests/testopenmmengine.py
+++ b/openpathsampling/tests/testopenmmengine.py
@@ -212,7 +212,6 @@ class testOpenMMEngine(object):
         change = mover.move(init_samp)
 
         assert (isinstance(change, paths.RejectedNaNSampleMoveChange))
-        print change.details.rejection_reason
         assert_equal(change.details.rejection_reason, 'nan')
         # since we shoot, we start with a shorter trajectory
         assert(len(change.samples[0].trajectory) < len(init_traj))

--- a/openpathsampling/tests/testopenmmengine.py
+++ b/openpathsampling/tests/testopenmmengine.py
@@ -212,7 +212,8 @@ class testOpenMMEngine(object):
         change = mover.move(init_samp)
 
         assert (isinstance(change, paths.RejectedNaNSampleMoveChange))
-        assert_equal(change.samples[0].details.stopping_reason, 'nan')
+        print change.details.rejection_reason
+        assert_equal(change.details.rejection_reason, 'nan')
         # since we shoot, we start with a shorter trajectory
         assert(len(change.samples[0].trajectory) < len(init_traj))
 
@@ -244,7 +245,7 @@ class testOpenMMEngine(object):
         change = mover.move(init_samp)
 
         assert(isinstance(change, paths.RejectedMaxLengthSampleMoveChange))
-        assert_equal(change.samples[0].details.stopping_reason, 'max_length')
+        assert_equal(change.details.rejection_reason, 'max_length')
         assert_equal(
             len(change.samples[0].trajectory), self.engine.n_frames_max)
 

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -285,8 +285,7 @@ class testCommittorSimulation(object):
         snap1_coords = snap1.coordinates.tolist()
         count = {self.snap0: 0, snap1: 0}
         for step in self.storage.steps:
-            # TODO: this should in step.change.canonical.details
-            shooting_snap = step.change.trials[0].details.shooting_snapshot
+            shooting_snap = step.change.canonical.details.shooting_snapshot
             if shooting_snap.coordinates.tolist() == snap0_coords:
                 mysnap = self.snap0
             elif shooting_snap.coordinates.tolist() == snap1_coords:

--- a/openpathsampling/visualize.py
+++ b/openpathsampling/visualize.py
@@ -2492,7 +2492,7 @@ class SampleList(OrderedDict):
                         trajectory=traj,
                         ensemble=sample.ensemble,
                         bias=sample.bias,
-                        details=sample.details,
+                        # details=sample.details,
                         parent=sample.parent,
                         mover=sample.mover
                     )

--- a/openpathsampling/visualize.py
+++ b/openpathsampling/visualize.py
@@ -2237,13 +2237,6 @@ class SampleList(OrderedDict):
     @staticmethod
     def _get_samples_from_steps(steps, replica, accepted, intermediates=True):
         if accepted:
-            # samp = steps[-1].active[replica]
-            # samples = [samp]
-            # while samp.parent is not None:
-            #     samp = samp.parent
-            #     samples.append(samp)
-            #
-            # return list(reversed(samples))
             samples = []
             for step in steps:
                 if step.active and replica in step.active:


### PR DESCRIPTION
This removes the `.details` property from `Sample`. The necessary information is now stored in the `MoveChange`. 