### PR TITLE
Fixes for test output

### DIFF
--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -285,7 +285,9 @@ class ShootingPointAnalysis(SnapshotByCoordinateDict):
                 bins=bins
             )
             b_list = [b_x, b_y]
-        state_frac = np.true_divide(state_hist, all_hist)
+        # if all_hist is 0, state_hist is NaN: ignore warning, return NaN
+        with np.errstate(divide='ignore', invalid='ignore'):
+            state_frac = np.true_divide(state_hist, all_hist)
         return tuple([state_frac] + b_list)
 
     def to_pandas(self, label_function=None):

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -586,7 +586,6 @@ class SampleMover(PathMover):
             # Most common should be `EngineNaNError` if nan is detected and
             # `EngineMaxLengthError`
             trials, call_details = self(*samples)
-            print self, trials, call_details
 
         except SampleNaNError as e:
             return paths.RejectedNaNSampleMoveChange(


### PR DESCRIPTION
Two very minor fixes:

* #633 left a print statement (used for debugging, I assume?) in `pathmover.py`. Removed that.
* numpy 1.11 will start throwing RuntimeWarnings if `true_divide` has a NaN or divides by zero (I was *using* `true_divide` to get the desired behavior that `NaN/0.0` gives `NaN`!) Conda is still on 1.10, but I've upgraded to 1.11 and see this warning when I run tests locally.

Should be ready for review immediately; just a matter of waiting to pass tests.