### PR TITLE
Switch default velocities in `make_1d_traj` to 1.0

### DIFF
--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -23,7 +23,7 @@ from openpathsampling.engines import DynamicsEngine
 
 def make_1d_traj(coordinates, velocities=None, engine=None):
     if velocities is None:
-        velocities = [0.0]*len(coordinates)
+        velocities = [1.0]*len(coordinates)
     if engine is None:
         engine = toys.Engine(
             {},


### PR DESCRIPTION
Previously, the default velocities in the `make_1d_trajectory` test helper function was 0.0. This changes that to 1.0. `make_1d_trajectory` is often used in concert with the `CalvinistDynamics` mock engine, where the sign of the velocities tells you which way to step through the pre-determined trajectory. Of course, flipping the velocities doesn't do anything when the velocity is 0.0. Switching the default to 1.0 makes this easier, and doesn't change any of our other tests. (Existing tests that needed this sign flip explicitly named velocities as 1.0 in the input to `make_1d_trajectory`; now that behavior is default.)