### PR TITLE
Method to avoid refreshing ipynb cells from wrapped simulators

### DIFF
--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -71,6 +71,10 @@ class PathSimulator(StorableNamedObject):
     output_stream : file
         Subclasses should write output to this, allowing a standard way to
         redirect any output.
+    allow_refresh : bool
+        Whether to allow the output to refresh an ipynb cell; default True.
+        This is likely to be overridden when a pathsimulator is wrapped in
+        another simulation.
     """
     __metaclass__ = abc.ABCMeta
 
@@ -90,6 +94,7 @@ class PathSimulator(StorableNamedObject):
         )
         self.sample_set = None
         self.output_stream = sys.stdout  # user can change to file handler
+        self.allow_refresh =  True
 
     def sync_storage(self):
         """
@@ -268,7 +273,8 @@ class Bootstrapping(PathSimulator):
                 ("Working on Bootstrapping cycle step %d" +
                 " in ensemble %d/%d .\n") %
                 ( self.step, ens_num + 1, len(self.ensembles) ),
-                output_stream=self.output_stream
+                output_stream=self.output_stream,
+                refresh=self.allow_refresh
             )
 
             movepath = bootstrapmove.move(self.sample_set)
@@ -328,7 +334,8 @@ class Bootstrapping(PathSimulator):
             ("DONE! Completed Bootstrapping cycle step %d" +
             " in ensemble %d/%d.\n") %
             ( self.step, ens_num + 1, len(self.ensembles) ),
-            output_stream=self.output_stream
+            output_stream=self.output_stream,
+            refresh=self.allow_refresh
         )
 
 
@@ -683,7 +690,7 @@ class PathSampling(PathSimulator):
         for nn in range(n_steps):
             self.step += 1
             logger.info("Beginning MC cycle " + str(self.step))
-            refresh = True
+            refresh = self.allow_refresh
             if self.step % self.status_update_frequency == 0:
                 # do we visualize this step?
                 if self.live_visualizer is not None and mcstep is not None:
@@ -854,6 +861,7 @@ class CommittorSimulation(PathSimulator):
                         step+1, n_per_snapshot
                     ),
                     output_stream=self.output_stream,
+                    refresh=self.allow_refresh
                 )
 
                 if as_chain:


### PR DESCRIPTION
This should fix a problem that @sroet brought to my attention at the ESDW today. The basic problem is this:

Some path simulators will wrap other path simulators (e.g., for some iterative process). The problem that @sroet was having was that, even if the output of the wrapped simulator was sent to `dev/null`, the `refresh` command was emptying the cell, deleting desired output from the outer simulator.

This adds a new attribute for `PathSimulator`s called `allow_refresh`, which defaults to `True`. When a simulator calls the `refresh_output` command, the `refresh` attribute is set to `self.allow_refresh`. Combining `inner_sim.allow_refresh = False` with `inner_sim.output_stream = os.devnull`, this can completely silence the output behavior of the inner simulator.

@sroet: Could you check out this branch and test that it fixes your problem? We should check that it fixed the issue before merging.