### PR TITLE
Details on engine exceptions

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -602,7 +602,7 @@ class SampleMover(PathMover):
                 samples=e.trial_sample,
                 mover=self,
                 input_samples=samples,
-                details=paths.MoveDetails(details)
+                details=paths.Details(**details)
             )
 
         # 4. accept/reject

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -588,21 +588,20 @@ class SampleMover(PathMover):
             trials, call_details = self(*samples)
 
         except SampleNaNError as e:
+            e.details.update({'rejection_reason': 'nan'})
             return paths.RejectedNaNSampleMoveChange(
                 samples=e.trial_sample,
                 mover=self,
                 input_samples=samples,
-                details=paths.MoveDetails(
-                    rejection_reason='nan'),
+                details=paths.MoveDetails(**e.details)
             )
         except SampleMaxLengthError as e:
-            details = e.details
             e.details.update({'rejection_reason': 'max_length'})
             return paths.RejectedMaxLengthSampleMoveChange(
                 samples=e.trial_sample,
                 mover=self,
                 input_samples=samples,
-                details=paths.Details(**details)
+                details=paths.Details(**e.details)
             )
 
         # 4. accept/reject

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -596,12 +596,13 @@ class SampleMover(PathMover):
                     rejection_reason='nan'),
             )
         except SampleMaxLengthError as e:
+            details = e.details
+            e.details.update({'rejection_reason': 'max_length'})
             return paths.RejectedMaxLengthSampleMoveChange(
                 samples=e.trial_sample,
                 mover=self,
                 input_samples=samples,
-                details=paths.MoveDetails(
-                    rejection_reason='max_length')
+                details=paths.MoveDetails(details)
             )
 
         # 4. accept/reject


### PR DESCRIPTION
Previously, the `SampleMover` would overwrite the details from engine exceptions, meaning that, e.g., for a shot that hit max length, you couldn't figure out the shooting point. This fixes that.