### PR TITLE
Failsafe for `segment_id` in `to_dict` of mdtraj topology

### DIFF
--- a/openpathsampling/engines/openmm/topology.py
+++ b/openpathsampling/engines/openmm/topology.py
@@ -24,10 +24,16 @@ class MDTrajTopology(Topology):
             else:
                 element_symbol = atom.element.symbol
 
-            atom_data.append((
-                atom.serial, atom.name, element_symbol,
-                int(atom.residue.resSeq), atom.residue.name,
-                atom.residue.chain.index, atom.segment_id))
+            if hasattr(atom, 'segment_id'):
+                atom_data.append((
+                    atom.serial, atom.name, element_symbol,
+                    int(atom.residue.resSeq), atom.residue.name,
+                    atom.residue.chain.index, atom.segment_id))
+            else:
+                atom_data.append((
+                    atom.serial, atom.name, element_symbol,
+                    int(atom.residue.resSeq), atom.residue.name,
+                    atom.residue.chain.index, ''))
 
         out['atom_columns'] = ["serial", "name", "element", "resSeq",
                                "resName", "chainID", "segmentID"]


### PR DESCRIPTION
I had problems that in some cases the `mdtraj.Topology.Atom` object does not have a `segment_id` property. In this case the segment_id will be empty. This fixes this, but in the long run we should work on getter a better pickling for the topology.