### PR TITLE
Shortcut: `ops_load_trajectory`

### DIFF
--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -326,4 +326,6 @@ def trajectory_to_mdtraj(trajectory, md_topology=None):
     # traj = md.Trajectory(output, md_topology)
     # traj.unitcell_vectors = trajectory.box_vectors
     return trajectory.to_mdtraj(md_topology)
-                         
+
+def ops_load_trajectory(filename, **kwargs):
+    return trajectory_from_mdtraj(md.load(filename, **kwargs))

--- a/openpathsampling/tests/test_mdtraj_support.py
+++ b/openpathsampling/tests/test_mdtraj_support.py
@@ -11,7 +11,7 @@ import openpathsampling as paths
 import mdtraj as md
 
 from openpathsampling.engines.openmm.tools import (
-    trajectory_from_mdtraj, trajectory_to_mdtraj
+    trajectory_from_mdtraj, trajectory_to_mdtraj, ops_load_trajectory
 )
 
 logging.getLogger('opentis.trajectory').setLevel(logging.DEBUG)
@@ -48,3 +48,8 @@ class testMDTrajSupport(object):
         md2 = trajectory_to_mdtraj([snap])
         assert_equal(md1, md2)
 
+    def test_ops_load_trajectory_pdb(self):
+        pdb_file = data_filename("ala_small_traj.pdb")
+        ops_trajectory = ops_load_trajectory(pdb_file)
+        # TODO: we should add tests to make sure this also works correctly
+        # with other file formats (e.g., gromacs, where `top` kw is req'd)


### PR DESCRIPTION
We've talked about adding this before. It's basically an OPS wrapper on MDTraj's `load` method. After MDTraj loads the file, we convert the MDTraj trajectory to an OPS trajectory.

I've locally tested with Gromacs file including a `.gro` for the `top` keyword, and it works. At some point, we'll want to add formal unit tests on that.

(I got tired of every analysis-based example starting with what was basically this little one-line function.)

Would like to put this in 0.9.2, so please review soon.