### PR TITLE
Fix OpenMM instantaneous temperature

### DIFF
--- a/openpathsampling/engines/openmm/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/openmm/features/instantaneous_temperature.py
@@ -34,6 +34,8 @@ def instantaneous_temperature(snapshot):
     """
     # TODO: this can be generalized as a feature that works with any
     # snapshot that has features for KE (in units of kB) and n_dofs
+    old_snap = snapshot.engine.current_snapshot
+    snapshot.engine.current_snapshot = snapshot
     state = snapshot.engine.simulation.context.getState(getEnergy=True)
     # divide by Avogadro b/c OpenMM reports energy/mole
     ke_in_energy = state.getKineticEnergy() / u.AVOGADRO_CONSTANT_NA
@@ -42,5 +44,6 @@ def instantaneous_temperature(snapshot):
     dofs = snapshot.n_degrees_of_freedom
 
     temperature = 2 * ke_per_kB / dofs
+    snapshot.engine.current_snapshot = old_snap
     return temperature
 

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -1,6 +1,6 @@
 import openpathsampling.engines.openmm as omm_engine
 import openpathsampling as paths
-from nose.tools import assert_equal, assert_almost_equal
+from nose.tools import assert_equal, assert_almost_equal, assert_not_equal
 from test_helpers import data_filename, assert_close_unit
 
 import openmmtools as omt
@@ -55,3 +55,10 @@ class testOpenMMSnapshot(object):
         n_dofs = 51.0  # see test above
         assert_close_unit(test_snap.instantaneous_temperature,
                           expected_ke / u.BOLTZMANN_CONSTANT_kB / n_dofs)
+
+    def test_instantaneous_temperature_changes(self):
+        trajectory = self.engine.generate(self.template,
+                                          [lambda t, foo: len(t) < 4])
+        temp_1 = trajectory[1].instantaneous_temperature
+        temp_2 = trajectory[2].instantaneous_temperature
+        assert_not_equal(temp_1, temp_2)


### PR DESCRIPTION
There was a bug in the `instantaneous_temperature` feature for OpenMM engine snapshots. It did not set context with desired snapshot, so the temperature that returns was always the from the last snapshot the engine had generated. Fix, plus regression test, in this PR.

Should be ready for review as soon as it passes tests.