### PR TITLE
Velocity Direction Modifiers for 2-way shooting

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -134,7 +134,10 @@ from sample import Sample, SampleSet
 from shooting import ShootingPointSelector, UniformSelector, \
     GaussianBiasSelector, FirstFrameSelector, FinalFrameSelector
 
-from snapshot_modifier import NoModification, RandomVelocities
+from snapshot_modifier import (
+    NoModification, RandomVelocities, VelocityDirectionModifier,
+    SingleAtomVelocityDirectionModifier
+)
 
 from storage.storage import Storage, AnalysisStorage
 

--- a/openpathsampling/engines/openmm/features/masses.py
+++ b/openpathsampling/engines/openmm/features/masses.py
@@ -1,4 +1,5 @@
 import simtk.unit as u
+import numpy as np
 
 @property
 def masses_per_mole(snapshot):
@@ -22,6 +23,11 @@ def masses_per_mole(snapshot):
         n_particles = system.getNumParticles()
         masses_per_mole = [system.getParticleMass(i)
                   for i in range(system.getNumParticles())]
+    masses_per_mole = u.Quantity(
+        value=np.array([m.value_in_unit(u.dalton) 
+                        for m in masses_per_mole]),
+        unit=u.dalton
+    )
     return masses_per_mole
 
 @property
@@ -33,5 +39,6 @@ def masses(snapshot):
         atomic masses (with simtk.unit attached) in units of mass
     """
     masses_per_mole = snapshot.masses_per_mole
-    masses = [m / u.AVOGADRO_CONSTANT_NA for m in masses_per_mole]
+    masses = masses_per_mole / u.AVOGADRO_CONSTANT_NA
+    # [m / u.AVOGADRO_CONSTANT_NA for m in masses_per_mole]
     return masses

--- a/openpathsampling/engines/toy/engine.py
+++ b/openpathsampling/engines/toy/engine.py
@@ -39,6 +39,7 @@ class ToyEngine(DynamicsEngine):
     """
 
     base_snapshot_type = Snapshot
+    ignore_linear_momentum = True
 
     _default_options = {
         'integ': None,

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -77,7 +77,7 @@ class SnapshotModifier(StorableNamedObject):
         -------
         full_array : list-like
             modified version of the input array, where the elements
-            specified by self.subset_mask have been replaced    
+            specified by self.subset_mask have been replaced
         """
         subset_mask = self.subset_mask
         if self.subset_mask is None:
@@ -87,7 +87,7 @@ class SnapshotModifier(StorableNamedObject):
         return full_array
 
     @abc.abstractmethod
-    def __call__(self, snapshot): 
+    def __call__(self, snapshot):
         raise NotImplementedError
 
 class NoModification(SnapshotModifier):
@@ -105,7 +105,7 @@ class RandomVelocities(SnapshotModifier):
     that the input `beta` and the features `masses` and `velocities` are all
     in the same unit system. In particular, `1.0 / beta * masses` must be in
     units of `velocity**2`.
-    
+
     Parameters
     ----------
     beta : float
@@ -121,7 +121,7 @@ class RandomVelocities(SnapshotModifier):
     def __init__(self, beta, engine=None, subset_mask=None):
         super(RandomVelocities, self).__init__(subset_mask)
         self.beta = beta
-        self.engine = engine 
+        self.engine = engine
 
     def __call__(self, snapshot):
         # raises AttributeError is snapshot doesn't support velocities
@@ -175,7 +175,7 @@ class GeneralizedDirectionModifier(SnapshotModifier):
             box_vectors = snapshot.box_vectors
         except AttributeError:
             box_vectors = None
-        
+
         try:
             n_dofs = snapshot.n_degrees_of_freedom
         except AttributeError:
@@ -191,10 +191,11 @@ class GeneralizedDirectionModifier(SnapshotModifier):
         n_motion_removers = n_spatial * (remove_linear + remove_angular)
 
         n_dofs_required = n_spatial * n_atoms - n_motion_removers
-        
+
         if n_dofs < n_dofs_required:
             raise RuntimeError("Snapshot has " + str(n_dofs)
-                               + " degrees of freedom. "
+                               + " degrees of freedom, not " 
+                               + str(n_dofs_required) + ". "
                                + "Are there constraints? Constraints can't"
                                + " be used with this modifier.")
 

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -249,5 +249,5 @@ class VelocityDirectionModifier(GeneralizedDirectionModifier):
 
 class SingleAtomVelocityDirectionModifier(GeneralizedDirectionModifier):
     def _select_atoms_to_modify(self, n_subset_atoms):
-        return np.random.choice(range(n_subset_atoms))
+        return [np.random.choice(range(n_subset_atoms))]
 

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -241,9 +241,9 @@ class GeneralizedDirectionModifier(SnapshotModifier):
 
 class VelocityDirectionModifier(GeneralizedDirectionModifier):
     def _select_atoms_to_modify(self, n_subset_atoms):
-        pass
+        return range(n_subset_atoms)
 
 class SingleAtomVelocityDirectionModifier(GeneralizedDirectionModifier):
     def _select_atoms_to_modify(self, n_subset_atoms):
-        pass
+        return np.random.choice(range(n_subset_atoms))
 

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -156,3 +156,44 @@ class RandomVelocities(SnapshotModifier):
 
         return new_snap
 
+class GaussianDeltaP(SnapshotModifier):
+    """
+    Snapshot modifier which changes momentum direction with constant energy.
+    """
+    def __init__(self, subset_mask=None, delta_P=None):
+        pass
+
+    def _verify_snapshot(self, snapshot):
+        try:
+            box_vectors = snapshot.box_vectors
+        except AttributeError:
+            box_vectors = None
+        
+        try:
+            n_dofs = snapshot.n_degrees_of_freedom
+        except AttributeError:
+            raise RuntimeError("Snapshot missing n_degrees_of_freedom. "
+                               + "Can't use this snapshot modifier.")
+
+        # all engines should have n_spatial and n_atoms
+        n_spatial = snapshot.engine.n_spatial
+        n_atoms = snapshot.engine.n_atoms
+
+        remove_angular = 0 if box_vectors is None else 1
+        remove_linear = 0 if n_atoms == 1 else 1
+        n_motion_removers = n_spatial * (remove_linear + remove_angular)
+
+        n_dofs_required = n_spatial * n_atoms - n_motion_removers
+        
+        if n_dofs < n_dofs_required:
+            raise RuntimeError("Snapshot has " + str(n_dofs)
+                               + " degrees of freedom. "
+                               + "Are there constrints?")
+
+
+    def __call__(self, snapshot):
+        velocities = copy.copy(snapshot.velocities)
+        vel_subset = self.extract_subset(velocities)
+        masses = self.extract_subset(snapshot.masses)
+
+        pass

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -214,7 +214,6 @@ class GeneralizedDirectionModifier(SnapshotModifier):
         # assert len(dv_widths) == n_subset_atoms
         return dv_widths
 
-
     def __call__(self, snapshot):
         self._verify_snapshot(snapshot)
         velocities = copy.copy(snapshot.velocities)
@@ -234,7 +233,6 @@ class GeneralizedDirectionModifier(SnapshotModifier):
             rescale_factor = initial_sum_sq_vel / final_sum_sq_vel
             vel_subset[atom_i] *= rescale_factor
 
-
         self.apply_to_subset(velocities, vel_subset)
         new_snap = snapshot.copy_with_replacement(velocities=velocities)
 
@@ -242,7 +240,10 @@ class GeneralizedDirectionModifier(SnapshotModifier):
         return new_snap
 
 class VelocityDirectionModifier(GeneralizedDirectionModifier):
-    pass
+    def _select_atoms_to_modify(self, n_subset_atoms):
+        pass
 
 class SingleAtomVelocityDirectionModifier(GeneralizedDirectionModifier):
-    pass
+    def _select_atoms_to_modify(self, n_subset_atoms):
+        pass
+

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -224,13 +224,17 @@ class GeneralizedDirectionModifier(SnapshotModifier):
         dv_widths = self._dv_widths(n_atoms=len(velocities),
                                     n_subset_atoms=len(vel_subset))
 
+        # zero_with_units is a hack for using units (or not) in `sum`
+        zero_with_units = (vel_subset[0][0] - vel_subset[0][0])**2
         for atom_i in atoms_to_change:
-            initial_sum_sq_vel = sum([v**2 for v in vel_subset[atom_i]])
+            initial_sum_sq_vel = sum([v**2 for v in vel_subset[atom_i]],
+                                     zero_with_units)
             randoms = np.random.normal(size=len(vel_subset[atom_i]))
             delta_v = dv_widths[atom_i] * randoms
             vel_subset[atom_i] += delta_v
-            final_sum_sq_vel = sum([v**2 for v in vel_subset[atom_i]])
-            rescale_factor = initial_sum_sq_vel / final_sum_sq_vel
+            final_sum_sq_vel = sum([v**2 for v in vel_subset[atom_i]],
+                                   zero_with_units)
+            rescale_factor = np.sqrt(initial_sum_sq_vel / final_sum_sq_vel)
             vel_subset[atom_i] *= rescale_factor
 
         self.apply_to_subset(velocities, vel_subset)

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -243,7 +243,8 @@ class GeneralizedDirectionModifier(SnapshotModifier):
         # assert len(dv_widths) == n_subset_atoms
         return dv_widths
 
-    def rescale_linear_momenta_constant_energy(self, velocities, masses):
+    @staticmethod
+    def rescale_linear_momenta_constant_energy(velocities, masses):
         # TODO: initially, maybe see if there's an internal motion remover
         # to do most of this? and get KE from a snapshot feature?
         n_atoms = len(masses)

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -221,3 +221,22 @@ class testRandomizeVelocities(object):
         assert_equal(engine.current_snapshot, zero_snap)
         engine.generate(new_snap, [lambda x, foo: len(x) <= 4])
 
+class testGeneralizedDirectionModifier(object):
+    def setup(self):
+        toy_modifier = GeneralizedDirectionModifier(
+            subset_mask=[1, 2],
+            delta_v = [1.0, 2.0]
+        )
+        pass
+
+    def test_verify_snapshot_toy(self):
+        pass
+
+    def test_verify_snapshot_openmm(self):
+        pass
+
+    def test_dv_widths_toy(self):
+        pass
+
+    def test_dv_widths_openmm(self):
+        pass

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -223,16 +223,50 @@ class testRandomizeVelocities(object):
 
 class testGeneralizedDirectionModifier(object):
     def setup(self):
-        toy_modifier = GeneralizedDirectionModifier(
-            subset_mask=[1, 2],
-            delta_v = [1.0, 2.0]
+        import openpathsampling.engines.toy as toys
+        # applies one delta_v to all atoms
+        self.toy_modifier_all = GeneralizedDirectionModifier(1.5)
+        # defines delta_v per atom, including those not in the mask
+        self.toy_modifier_long_dv = GeneralizedDirectionModifier(
+            delta_v=[0.5, 1.0, 2.0],
+            subset_mask=[1, 2]
         )
+        # defines delta_v per atom in the subset mask
+        self.toy_modifier = GeneralizedDirectionModifier(
+            delta_v=[1.0, 2.0],
+            subset_mask=[1, 2]
+        )
+        self.toy_engine = toys.Engine(
+            topology=toys.Topology(n_spatial=2, n_atoms=3, pes=None,
+                                   masses=[1.0, 1.5, 4.0]),
+            options={}
+        )
+        self.toy_snapshot = toys.Snapshot(
+            coordinates=np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]),
+            velocities=np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]),
+            engine=self.toy_engine
+        )
+
+        # create the OpenMM versions
+        #
         pass
 
     def test_verify_snapshot_toy(self):
-        pass
+        self.toy_modifier._verify_snapshot(self.toy_snapshot)
+        self.toy_modifier_all._verify_snapshot(self.toy_snapshot)
+        self.toy_modifier_long_dv._verify_snapshot(self.toy_snapshot)
+
 
     def test_verify_snapshot_openmm(self):
+        pass
+
+    def test_verify_snapshot_no_dofs(self):
+        pass
+
+    def test_verify_snapshot_constraints(self):
+        pass
+
+    def test_verify_snapshot_box_vectors(self):
         pass
 
     def test_dv_widths_toy(self):

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -328,6 +328,24 @@ class testGeneralizedDirectionModifier(object):
             assert_almost_equal(truth, beauty)
 
 
+    def test_rescale_linear_momenta_constant_energy_toy(self):
+        velocities = np.array([[1.5, -1.0], [-1.0, 2.0], [0.25, -1.0]])
+        masses = np.array([1.0, 1.5, 4.0])
+        new_vel = self.toy_modifier.rescale_linear_momenta_constant_energy(
+            velocities=velocities,
+            masses=masses
+        )
+        #expected = np.array([[7.0/6.0, 1.0/3.0],
+                             #[-11.0/9.0, 22.0/9.0],
+                             #[1.0/6.0, 5.0/6.0]])
+        assert_array_almost_equal(new_vel, expected)
+
+        raise SkipTest
+
+    def test_rescale_linear_momenta_constant_energy_openmm(self):
+        raise SkipTest
+
+
 class testVelocityDirectionModifier(object):
     def setup(self):
         import openpathsampling.engines.toy as toys
@@ -401,6 +419,9 @@ class testVelocityDirectionModifier(object):
                 sum([(v**2).value_in_unit(u_vel_sq) for v in new_v]),
                 sum([(v**2).value_in_unit(u_vel_sq) for v in old_v])
             )
+
+    def test_call_with_linear_momentum_fix(self):
+        raise SkipTest
 
 class testSingleAtomVelocityDirectionModifier(object):
     def setup(self):

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -248,7 +248,8 @@ class testGeneralizedDirectionModifier(object):
         )
 
         # create the OpenMM versions
-        self.openmm_modifier = GeneralizedDirectionModifier(1.0)
+        u_vel = u.nanometer / u.picosecond
+        self.openmm_modifier = GeneralizedDirectionModifier(1.2 * u_vel)
         ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)
         self.test_snap = omm_engine.snapshot_from_testsystem(ad_vacuum)
         self.openmm_engine = omm_engine.Engine(
@@ -305,7 +306,22 @@ class testGeneralizedDirectionModifier(object):
         self.openmm_modifier._verify_snapshot(ad_explicit_snap)
 
     def test_dv_widths_toy(self):
-        pass
+        selected = np.array([1.0, 2.0])
+        n_atoms = len(self.toy_snapshot.coordinates)
+        assert_array_almost_equal(self.toy_modifier._dv_widths(n_atoms, 2),
+                                  selected)
+        assert_array_almost_equal(
+            self.toy_modifier_long_dv._dv_widths(n_atoms, 2),
+            selected
+        )
+        assert_array_almost_equal(
+            self.toy_modifier_all._dv_widths(n_atoms, n_atoms),
+            np.array([1.5]*3)
+        )
 
     def test_dv_widths_openmm(self):
-        pass
+        n_atoms = len(self.openmm_snap.coordinates)
+        results = self.openmm_modifier._dv_widths(n_atoms, n_atoms)
+        expected = np.array([1.2] * n_atoms) * u.nanometer / u.picosecond
+        for truth, beauty in zip(expected, results):
+            assert_almost_equal(truth, beauty)

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -325,3 +325,24 @@ class testGeneralizedDirectionModifier(object):
         expected = np.array([1.2] * n_atoms) * u.nanometer / u.picosecond
         for truth, beauty in zip(expected, results):
             assert_almost_equal(truth, beauty)
+
+
+class testVelocityDirectionModifier(object):
+    def setup(self):
+        pass
+
+    def test_select_atoms_to_modify(self):
+        pass
+
+    def test_call(self):
+        pass
+
+class testSingleAtomVelocityDirectionModifier(object):
+    def setup(self):
+        pass
+
+    def test_select_atoms_to_modify(self):
+        pass
+
+    def test_call(self):
+        pass

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -333,7 +333,8 @@ class testVelocityDirectionModifier(object):
         import openpathsampling.engines.toy as toys
         self.toy_modifier = VelocityDirectionModifier(
             delta_v=[1.0, 2.0],
-            subset_mask=[1, 2]
+            subset_mask=[1, 2],
+            rescale_linear_momenta=False
         )
         self.toy_engine = toys.Engine(
             topology=toys.Topology(n_spatial=2, n_atoms=3, pes=None,
@@ -347,7 +348,10 @@ class testVelocityDirectionModifier(object):
         )
 
         u_vel = u.nanometer / u.picosecond
-        self.openmm_modifier = VelocityDirectionModifier(1.2 * u_vel)
+        self.openmm_modifier = VelocityDirectionModifier(
+            delta_v=1.2*u_vel,
+            rescale_linear_momenta=False
+        )
         ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)
         self.test_snap = omm_engine.snapshot_from_testsystem(ad_vacuum)
         self.openmm_engine = omm_engine.Engine(
@@ -403,7 +407,8 @@ class testSingleAtomVelocityDirectionModifier(object):
         import openpathsampling.engines.toy as toys
         self.toy_modifier = SingleAtomVelocityDirectionModifier(
             delta_v=[1.0, 2.0],
-            subset_mask=[1, 2]
+            subset_mask=[1, 2],
+            rescale_linear_momenta=False
         )
         self.toy_engine = toys.Engine(
             topology=toys.Topology(n_spatial=2, n_atoms=3, pes=None,
@@ -417,7 +422,10 @@ class testSingleAtomVelocityDirectionModifier(object):
         )
 
         u_vel = u.nanometer / u.picosecond
-        self.openmm_modifier = SingleAtomVelocityDirectionModifier(1.2*u_vel)
+        self.openmm_modifier = SingleAtomVelocityDirectionModifier(
+            delta_v=1.2*u_vel,
+            rescale_linear_momenta=False
+        )
         ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)
         self.test_snap = omm_engine.snapshot_from_testsystem(ad_vacuum)
         self.openmm_engine = omm_engine.Engine(

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -459,7 +459,32 @@ class testVelocityDirectionModifier(object):
             )
 
     def test_call_with_linear_momentum_fix(self):
-        raise SkipTest
+        toy_modifier = VelocityDirectionModifier(
+            delta_v=[1.0, 2.0],
+            subset_mask=[1, 2],
+            remove_linear_momentum=True
+        )
+        new_toy_snap = toy_modifier(self.toy_snapshot)
+        velocities = new_toy_snap.velocities
+        momenta = velocities * new_toy_snap.masses[:, np.newaxis]
+        assert_array_almost_equal(sum(momenta), np.array([0.0]*2))
+        double_ke = sum(sum(momenta * velocities))
+        assert_almost_equal(double_ke, 86.0)
+
+        u_vel = u.nanometer / u.picosecond
+        u_mass = u.dalton / u.AVOGADRO_CONSTANT_NA
+
+        openmm_modifier = VelocityDirectionModifier(
+            delta_v=1.2*u_vel,
+            remove_linear_momentum=False
+        )
+        new_openmm_snap = openmm_modifier(self.openmm_snap)
+        velocities = new_openmm_snap.velocities
+        momenta = velocities * new_openmm_snap.masses[:, np.newaxis]
+        zero_momentum = 0 * u_vel * u_mass
+        total_momenta = sum(momenta, zero_momentum)
+        assert_array_almost_equal(total_momenta,
+                                  np.array([0.0]*3) * u_vel * u_mass)
 
 class testSingleAtomVelocityDirectionModifier(object):
     def setup(self):
@@ -538,3 +563,31 @@ class testSingleAtomVelocityDirectionModifier(object):
                 sum([(v**2).value_in_unit(u_vel_sq) for v in new_v]),
                 sum([(v**2).value_in_unit(u_vel_sq) for v in old_v])
             )
+
+    def test_call_with_linear_momentum_fix(self):
+        toy_modifier = SingleAtomVelocityDirectionModifier(
+            delta_v=[1.0, 2.0],
+            subset_mask=[1, 2],
+            remove_linear_momentum=True
+        )
+        new_toy_snap = toy_modifier(self.toy_snapshot)
+        velocities = new_toy_snap.velocities
+        momenta = velocities * new_toy_snap.masses[:, np.newaxis]
+        assert_array_almost_equal(sum(momenta), np.array([0.0]*2))
+        double_ke = sum(sum(momenta * velocities))
+        assert_almost_equal(double_ke, 86.0)
+
+        u_vel = u.nanometer / u.picosecond
+        u_mass = u.dalton / u.AVOGADRO_CONSTANT_NA
+
+        openmm_modifier = SingleAtomVelocityDirectionModifier(
+            delta_v=1.2*u_vel,
+            remove_linear_momentum=False
+        )
+        new_openmm_snap = openmm_modifier(self.openmm_snap)
+        velocities = new_openmm_snap.velocities
+        momenta = velocities * new_openmm_snap.masses[:, np.newaxis]
+        zero_momentum = 0 * u_vel * u_mass
+        total_momenta = sum(momenta, zero_momentum)
+        assert_array_almost_equal(total_momenta,
+                                  np.array([0.0]*3) * u_vel * u_mass)


### PR DESCRIPTION
This PR includes a way to modify the velocities of a snapshot, as described in the early work on 2-way shooting. Note that these techniques can get very complicated if the system includes constraints. To avoid that, this snapshot modifier checks that the number of degrees of freedom is as expected (meaning the engine's snapshots must implement the `n_degrees_of_freedom` snapshot feature, otherwise this raises an error.)

It includes an abstract class `GeneralizedDirectionModifier`, and two concrete subclasses: `VelocityDirectionModifer` (which modifies all velocities) and `SingleAtomVelocityDirectionModifier` (randomly picks a single atom to change its velocity.) Both of these have the ability to restrict the atoms which they change to a subset of the full system (as do all `SnapshotModifier`s.)

The basic approach is to modify the velocities according to a Gaussian in each direction, and then rescale them to put them on the sphere with the magnitude of the original velocity. This satisfies detailed balance (in the absence of contraints). It also means that the speed of each atom stays the same; only the direction changes.

- [x] Implement `GeneralizedDirectionModifier`
- [x] Tests for `GeneralizedDirectionModifier` on toy snapshots
- [x] Tests for `GeneralizedDirectionModifier` on OpenMM snapshots
- [x] Implement `VelocityDirectionModifer` and `SingleAtomVelocityDirectionModifier`
- [x] Tests for concrete modifier subclasses
- [x] Include corrections for linear momentum and kinetic energy
- [x] Docstrings