### PR TITLE
Fix bug in acceptance probability calculation for 2-way shooting

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -551,7 +551,13 @@ class SampleMover(PathMover):
             'metropolis_random': rand
         }
 
-        logger.info("Trial was " + ("accepted" if accepted else "rejected"))
+        if accepted:
+            result_str = "accepted"
+        else:
+            result_str = ("rejected. Acceptance probabilty "
+                          + str(probability))
+
+        logger.info("Trial was " + result_str)
 
         return accepted, details
 
@@ -760,9 +766,7 @@ class EngineMover(SampleMover):
 
         initial_trajectory = input_sample.trajectory
 
-        trial_in_ensemble = input_sample.ensemble(trial_trajectory)
-
-        if stopping_reason is None and trial_in_ensemble: 
+        if stopping_reason is None:
             bias = self.selector.probability_ratio(
                 initial_trajectory[shooting_index],
                 initial_trajectory,

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -760,7 +760,9 @@ class EngineMover(SampleMover):
 
         initial_trajectory = input_sample.trajectory
 
-        if stopping_reason is None:
+        trial_in_ensemble = input_sample.ensemble(trial_trajectory)
+
+        if stopping_reason is None and trial_in_ensemble: 
             bias = self.selector.probability_ratio(
                 initial_trajectory[shooting_index],
                 initial_trajectory,

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -32,7 +32,11 @@ class ShootingPointSelector(StorableNamedObject):
         return 1.0
 
     def probability(self, snapshot, trajectory):
-        return self.f(snapshot, trajectory) / self.sum_bias(trajectory)
+        sum_bias = self.sum_bias(trajectory)
+        if sum_bias > 0.0:
+            return self.f(snapshot, trajectory) / sum_bias
+        else:
+            return 0.0
 
     def probability_ratio(self, snapshot, old_trajectory, new_trajectory):
         p_old = self.probability(snapshot, old_trajectory)


### PR DESCRIPTION
This fixes a little bug I found when calculating the acceptance probability in 2-way shooting. The issue is this:

In 1-way shooting, when we calculate the acceptance probability (i.e., the length of the trajectory, minus the two endpoints that we don't shoot from) we *always* have a full trajectory. It might be A-to-A instead of A-to-B, but it isn't a half-trajectory.

In 2-way shooting, on the other hand, it could happen that your forward shot lands in state A (in a TPS, A->B ensemble). That means that there's no way for the backward shot to ever give something that satisfies the ensemble, so, intelligently, we quit there and the trial is only the forward partial trajectory.

Of course, this won't be accepted, because it doesn't satisfy the ensemble. However, we were checking the acceptance probability for it anyway. And it *is* possible that you shot from the first non-state frame, and went right back into the state, meaning that your trial trajectory is length 2: shooting point and frame in state.

This means that when you say "the odds of selecting that point from the new trajectory are 1/(L-2)", you divide by zero. Program crashes.

The fix is easy: if you don't satisfy the ensemble, we don't even bother checking acceptance probability. This does mean we'll check the ensemble twice for engine movers; at some point we might be able to speed that up some. (Only matters for toy systems, and even then, probably mainly for the minus move.)