### PR TITLE
Updates to flux calc in TrajectoryTransitionAnalysis

### DIFF
--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -426,6 +426,10 @@ class Ensemble(StorableNamedObject):
                         pad = min(overlap + 1, end - start - 2)
                         start = end - pad
                     else:
+                        # TODO: for some ensembles, there are better ways to
+                        # change start. For frame-by-frame ensembles
+                        # (AllInX, AllOutX) we know that we can completely
+                        # stop for all subtrajectories.
                         start += 1
                     end = start + min_length
 


### PR DESCRIPTION
A little bit of improvement to make a direct calculation of the flux (not just the dictionary that is then used to calculate the flux) 

* `analyze_flux` function now works with multiple trajectories as input
* new `flux` function calculates the actual numeric flux (previously, only had the `analyze_flux` method, which returns a dict of the "in" and "out" frames, from which the flux can be calculated)

Also fixes a stupid error in the `analyze` method where I'd flipped "A" and "B". Finally, adds a note for future improvement in `ensemble.py` (unrelated; just something that I noticed could be made faster with a little more algorithmic effort).