### PR TITLE
Channel analysis

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -28,8 +28,8 @@ except ImportError:  # pragma: no cover
     if not ops_setup.preferences['released']:
         version.full_version += ".dev-" + version.git_version[:7]
     isrelease = str(ops_setup.preferences['released'])
-        
-        
+
+
 from high_level.move_scheme import (
     MoveScheme, DefaultScheme, LockedMoveScheme, SRTISScheme,
     OneWayShootingMoveScheme
@@ -60,6 +60,8 @@ from analysis.trajectory_transition_analysis import (
     TrajectoryTransitionAnalysis,
     TrajectorySegmentContainer
 )
+
+from analysis.channel_analysis import ChannelAnalysis
 
 from bias_function import (
     BiasFunction, BiasLookupFunction, BiasEnsembleTable,

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -208,7 +208,7 @@ class ChannelAnalysis(StorableNamedObject):
 
     @staticmethod
     def label_to_string(label):
-        return ",".join(sorted(list(label)))
+        return ",".join(sorted([str(l) for l in list(label)]))
 
     @property
     def switching_matrix(self):

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -40,6 +40,23 @@ class ChannelAnalysis(StorableNamedObject):
         if len(steps) > 0:
             self._analyze(steps)
 
+    def to_dict(self):
+        return {
+            'results': self._results,
+            'treat_multiples': self._treat_multiples,
+            'channels': self.channels,
+            'replica': self.replica
+        }
+
+    @classmethod
+    def from_dict(cls, dct):
+        obj = cls(steps=None,
+                  channels=dct['channels'],
+                  replica=dct['replica'])
+        obj._results = dct['results']
+        obj._treat_multiples = dct['treat_multiples']
+        return obj
+
     # separate this because I think much of the code might be generalized
     # later where step_num could be something else
     @staticmethod
@@ -228,7 +245,7 @@ class ChannelAnalysis(StorableNamedObject):
 
         Returns
         -------
-        list of 3-tuples (int, int, frozenset) : 
+        list of 3-tuples (int, int, frozenset) :
             events with ranges such that there is only one channel at any
             given step number, and that channel is the least recent entered
         """
@@ -269,7 +286,7 @@ class ChannelAnalysis(StorableNamedObject):
 
         Returns
         -------
-        list of 3-tuples (int, int, frozenset) : 
+        list of 3-tuples (int, int, frozenset) :
             events such that there is only one event at any given step
             number, with the channel label as the set of all active channels
         """

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -1,6 +1,5 @@
-import openpathsampling as paths
-
 import collections
+import pandas as pd
 
 from openpathsampling.netcdfplus import StorableNamedObject
 
@@ -199,11 +198,24 @@ class ChannelAnalysis(StorableNamedObject):
         }[self.treat_multiples]
         return method(expanded_results)
 
+    @staticmethod
+    def _labels_as_sets_sort_function(label):
+        ll = sorted(list(label))
+        return [len(ll)] + ll
+
+    @staticmethod
+    def label_to_string(label):
+        return ",".join(sorted(list(label)))
+
     @property
     def switching_matrix(self):
         labeled_results = self.labels_by_step()
-        for i in range(len(labeled_results) - 1):
-            pass
+        sorted_set_labels = sorted([ll[2] for ll in labeled_results],
+                                   key=self._labels_as_sets_sort_function)
+        sorted_labels = [self.label_to_string(e) for e in sorted_set_labels]
+        switches = [(labeled_results[i], labeled_results[i+1])
+                    for i in range(len(labeled_results)-1)]
+        switch_count = collections.Counter(switches)
 
     @property
     def residence_times(self):

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -31,7 +31,8 @@ class ChannelAnalysis(StorableNamedObject):
 
         self._treat_multiples = 'all'
         self._results = {c: [] for c in self.channels.keys() + [None]}
-        self._analyze(steps)
+        if len(steps) > 0:
+            self._analyze(steps)
 
     # separate this because I think much of the code might be generalized
     # later where step_num could be something else
@@ -200,7 +201,9 @@ class ChannelAnalysis(StorableNamedObject):
 
     @property
     def switching_matrix(self):
-        pass
+        labeled_results = self.labels_by_step()
+        for i in range(len(labeled_results) - 1):
+            pass
 
     @property
     def residence_times(self):

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -122,7 +122,7 @@ class ChannelAnalysis(StorableNamedObject):
 
     @staticmethod
     def _expand_results(results):
-        expanded = [(domain[0], domain[1], channel)
+        expanded = [(domain[0], domain[1], set([channel]))
                     for channel in results for domain in results[channel]]
         return sorted(expanded, key=lambda tup: tup[0])
 
@@ -137,16 +137,38 @@ class ChannelAnalysis(StorableNamedObject):
         return relabeled
 
     @staticmethod
-    def _labels_by_step_oldest(results):
-        pass
+    def _labels_by_step_oldest(expanded_results):
+        relabeled = []
+        previous = expanded_results[0]
+        for current in expanded_results[1:]:
+            if current[1] > previous[1]:
+                # ends after last one ended
+                # if this isn't true, this one gets skipped
+                # if it is true, then previous is used
+                relabeled += [previous]
+                # save the new starting point
+                previous = (previous[1], current[1], current[2])
+            else:
+                pass # for testing
+        if relabeled[-1] != previous:
+            relabeled += [previous]
+        else:
+            pass # for testing
+        return relabeled
 
     @staticmethod
     def _label_by_step_multiple(results):
         pass
 
-
     def labels_by_step(self):
-        pass
+        expanded_results = self._expand_results(self._results)
+        method = {
+            'all': lambda x: x,
+            'newest': self._labels_by_step_newest,
+            'oldest': self._labels_by_step_oldest,
+            'multiple': self._labels_by_step_multiple
+        }[self.treat_multiples]
+        return method(expanded_results)
 
     @property
     def switching_matrix(self):

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -230,11 +230,21 @@ class ChannelAnalysis(StorableNamedObject):
 
     @property
     def residence_times(self):
-        pass
+        labeled_results = self.labels_by_step()
+        durations = [(self.label_to_string(step[2]), step[1] - step[0])
+                     for step in labeled_results]
+        results = collections.defaultdict(list)
+        for dur in durations:
+            results[dur[0]] += [dur[1]]
+        return results
 
     @property
     def total_time(self):
-        pass
+        residences = self.residence_times
+        results = collections.defaultdict(int)
+        for channel in residences:
+            results[channel] = sum(residences[channel])
+        return results
 
     def status(self, step_number):
         """Which channels were active at a given step number"""

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from openpathsampling.netcdfplus import StorableNamedObject
 
-
 class ChannelAnalysis(StorableNamedObject):
     """Analyze path sampling simulation for multiple channels.
 
@@ -152,8 +151,9 @@ class ChannelAnalysis(StorableNamedObject):
                 relabeled += [previous]
                 # save the new starting point
                 previous = (previous[1], current[1], current[2])
-            else:
-                pass # for testing
+            # NOTE: Tests include a case for the implicit "else" here, but
+            # for some reason an empty `else: pass` doesn't show up as
+            # covering the `pass` line; so removed them
         if relabeled[-1] != previous:
             relabeled += [previous]
         else:

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -87,14 +87,16 @@ class ChannelAnalysis(StorableNamedObject):
                         self._results[c] += [(last_start[c], finish)]
                         last_start[c] = None
             prev_traj = traj
+            prev_result = result
         # finish off any extras
+        next_step = step_num + 1 # again, this can be changed
         for c in self._results:
             if last_start[c] is not None:
                 if len(self._results[c]) > 0:
                     if self._results[c][-1][1] != step_num:
-                        self._results[c] += [(last_start[c], step_num)]
+                        self._results[c] += [(last_start[c], next_step)]
                 else:
-                    self._results[c] += [(last_start[c], step_num)]
+                    self._results[c] += [(last_start[c], next_step)]
 
     @property
     def treat_multiples(self):

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -150,7 +150,7 @@ class ChannelAnalysis(StorableNamedObject):
 
         Returns
         -------
-        list of 3-tuples (int, int, frozenset)
+        list of 3-tuples (int, int, frozenset) :
             the "events": each event is the tuple of start step, finish
             step, and channel name (as a frozenset containing one string),
             sorted according to the start step.
@@ -162,6 +162,25 @@ class ChannelAnalysis(StorableNamedObject):
     @staticmethod
     def _labels_by_step_newest(expanded_results):
         """
+        Makes one channel per step, based on most recent channel entered.
+
+        See also
+        --------
+            _expand_results
+            _labels_by_step_oldest
+            _labels_by_step_multiple
+            labels_by_step
+
+        Parameters
+        ----------
+        expanded_results : list of 3-tuples (int, int, frozenset)
+            input events; the output of _expand_results (see details there)
+
+        Returns
+        -------
+        list of 3-tuples (int, int, frozenset)
+            events with ranges such that there is only one channel at any
+            given step number, and that channel is the most recent entered
         """
         relabeled = []
         previous = expanded_results[0]
@@ -173,6 +192,27 @@ class ChannelAnalysis(StorableNamedObject):
 
     @staticmethod
     def _labels_by_step_oldest(expanded_results):
+        """
+        Makes one channel per step, based on least recent channel entered.
+
+        See also
+        --------
+            _expand_results
+            _labels_by_step_newest
+            _labels_by_step_multiple
+            labels_by_step
+
+        Parameters
+        ----------
+        expanded_results : list of 3-tuples (int, int, frozenset)
+            input events; the output of _expand_results (see details there)
+
+        Returns
+        -------
+        list of 3-tuples (int, int, frozenset) : 
+            events with ranges such that there is only one channel at any
+            given step number, and that channel is the least recent entered
+        """
         relabeled = []
         previous = expanded_results[0]
         for current in expanded_results[1:]:
@@ -194,6 +234,26 @@ class ChannelAnalysis(StorableNamedObject):
 
     @staticmethod
     def _labels_by_step_multiple(expanded_results):
+        """Makes one channel label per step, combining all active channels.
+
+        See also
+        --------
+            _expand_results
+            _labels_by_step_newest
+            _labels_by_step_oldest
+            labels_by_step
+
+        Parameters
+        ----------
+        expanded_results : list of 3-tuples (int, int, frozenset)
+            input events; the output of _expand_results (see details there)
+
+        Returns
+        -------
+        list of 3-tuples (int, int, frozenset) : 
+            events such that there is only one event at any given step
+            number, with the channel label as the set of all active channels
+        """
         relabeled = []
         # start events are times when a channel is added to the active
         # finish events are when channel is removed from the active
@@ -222,6 +282,33 @@ class ChannelAnalysis(StorableNamedObject):
         return relabeled
 
     def labels_by_step(self, treat_multiples=None):
+        """
+        Prepare internally stored results for primary analysis routines.
+
+        Note
+        ----
+            The results of this depend on the value of ``treat_multiples``.
+            In fact, this method is just a switch for the specific
+            ``treat_multiples`` values.
+
+        See also
+        --------
+            _labels_by_step_newest
+            _labels_by_step_oldest
+            _labels_by_step_multiple
+
+        Parameters
+        ----------
+            treat_multiples : 'all', 'newest', 'oldest',  'multiple', or None
+                method to prepare output; see documentation on
+                ``treat_multiples`` for details. Default is `None`, which
+                uses the value in ``self.treat_multiples``.
+
+        Returns
+        -------
+        list of 3-tuples (int, int, frozenset) :
+            events such that there is only one event at any give step
+        """
         if treat_multiples is None:
             treat_multiples = self.treat_multiples
         expanded_results = self._expand_results(self._results)

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -180,17 +180,9 @@ class ChannelAnalysis(StorableNamedObject):
                 relabeled += [(prev_step_num, step_num,
                                frozenset(active_channels))]
 
-            try:
-                start_channel = start_events[step_num]
-            except KeyError:
-                start_channel = set([])
-            try:
-                finish_channel = finish_events[step_num]
-            except KeyError:
-                finish_channel = set([])
-
-            active_channels -= finish_channel
-            active_channels |= start_channel
+            # defaultdict gives empty if doesn't exist
+            active_channels -= finish_events[step_num]
+            active_channels |= start_events[step_num]
 
             prev_step_num = step_num
 

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -1,0 +1,90 @@
+import openpathsampling as paths
+
+class ChannelAnalysis(paths.StorableNamedObject):
+    """Analyze path sampling simulation for multiple channels.
+
+    User defines several channels (e.g., mechanisms) as :class:`.Ensemble`
+    objects. This checks which channels each path satisfies, and provides
+    analysis of switching and residence.
+
+    Parameters
+    ----------
+    steps : iterable of :class:`.MCStep`
+        the steps to analyze
+    channels: dict of {string: :class:`.Ensemble`}
+        names (keys) and ensembles (values) representing subtrajectories of the
+        channels of interest
+    replica: int
+        replica ID to analyze from the steps, default is 0.
+    """
+    def __init__(self, steps, channels, replica=0):
+        self.channels = channels
+        if steps is None:
+            steps = []
+        self.replica = replica
+
+        self.treat_multiples = 'unique'
+        self._results = {c: [] for c in self.channels}
+        self._analyze(steps)
+
+    # separate this because I think much of the code might be generalized
+    # later where step_num could be something else
+    @staticmethod
+    def _step_num(step):
+        return step.mccycle
+
+    def _analyze(steps):
+        """Primary analysis routine.
+
+        Parameters
+        ----------
+        steps : iterable of :class:`.MCStep`
+            the steps to analyze
+        """
+        # for now, this assumes only one ensemble per channel
+        # (would like that to change in the future)
+        prev_traj = None
+        prev_result = None
+        last_start = {c: None for c in self.channels}
+        for step in steps:
+            traj = step.active[replica].trajectory
+            # re-use previous if the trajectory hasn't changed
+            if traj is prev_traj:
+                result = prev_result
+            else:
+                result = {c: len(self.channels[c].split(traj)) > 0
+                          for c in self.channels}
+                changed = [c for c in result if result[c] != prev_result[c]]
+                for c in changed:
+                    if result[c] is True:
+                        # switched from False to True: entered this label
+                        last_start[c] = self._step_num(step)
+                    else:
+                        # switched from True to False: exited this label
+                        finish = self._step_num(step)
+                        self._results[c] += (last_start[c], finish)
+                        last_start[c] = None
+
+    @property
+    def treat_multiples(self):
+        return self._treat_multiples
+
+    @treat_multiples.setter
+    def treat_multiples(self, value):
+        self._treat_multiples = value
+
+    @property
+    def switching_matrix(self):
+        pass
+
+    @property
+    def residence_times(self):
+        pass
+
+    @property
+    def total_time(self):
+        pass
+
+    def status(self, step_number):
+        """Which channels were active at a given step number"""
+        pass

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -20,6 +20,13 @@ class ChannelAnalysis(StorableNamedObject):
         channels of interest
     replica: int
         replica ID to analyze from the steps, default is 0.
+
+    Attributes
+    ----------
+    treat_multiples
+    switching_matrix
+    residence_times
+    total_time
     """
     def __init__(self, steps, channels, replica=0):
         super(ChannelAnalysis, self).__init__()
@@ -113,6 +120,18 @@ class ChannelAnalysis(StorableNamedObject):
 
     @property
     def treat_multiples(self):
+        """
+        string :
+            method for handling paths that match multiple channels. Allowed
+            values are
+            * 'newest': use the most recent channel entered
+            * 'oldest': use the least recent channel entered
+            * 'multiple': treat multiple channels as a new type of channel,
+               e.g., 'a' and 'b' because 'a,b'
+            * 'all': treat each channel individually, despite overlaps. For
+              switching, this is the same as ???. For status, this is the
+              same as 'multiple'
+        """
         return self._treat_multiples
 
     @treat_multiples.setter
@@ -363,6 +382,11 @@ class ChannelAnalysis(StorableNamedObject):
 
     @property
     def switching_matrix(self):
+        """
+        pandas.DataFrame :
+            number of switches from one channel to another. Depends on
+            ``treat_multiples``, see details there.
+        """
         labeled_results = self.labels_by_step()
         labels_in_order = [ll[2] for ll in labeled_results]
         labels_set = set(labels_in_order)
@@ -383,6 +407,12 @@ class ChannelAnalysis(StorableNamedObject):
 
     @property
     def residence_times(self):
+        """
+        dict {string: list of int} :
+            number of steps spent in each channel for each "stay" in that
+            channel; allows calculations of distribution properties. Depends
+            on ``treat_multiples``, see details there.
+        """
         labeled_results = self.labels_by_step()
         durations = [(self.label_to_string(step[2]), step[1] - step[0])
                      for step in labeled_results]
@@ -393,6 +423,11 @@ class ChannelAnalysis(StorableNamedObject):
 
     @property
     def total_time(self):
+        """
+        dict {string: int} :
+            total number of steps spent in each channel for each "stay" in
+            that channel. Depends on ``treat_multiples``, see details there.
+        """
         residences = self.residence_times
         results = collections.defaultdict(int)
         for channel in residences:
@@ -404,7 +439,8 @@ class ChannelAnalysis(StorableNamedObject):
 
         Note
         ----
-            Results will depend on the value of ``treat_multiples``.
+            Results will depend on the value of ``treat_multiples``. See
+            details in the documentation for that.
 
         Parameters
         ----------

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -272,4 +272,29 @@ class testChannelAnalysis(object):
 
 
     def test_status(self):
+        analysis = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        analysis._results = self.toy_results
+
+        analysis.treat_multiples = 'newest'
+        assert_equal(analysis.status(4), 'b')
+        assert_equal(analysis.status(8), 'a')
+
+        analysis.treat_multiples = 'oldest'
+        assert_equal(analysis.status(4), 'a')
+        assert_equal(analysis.status(8), 'b')
+
+        analysis.treat_multiples = 'multiple'
+        assert_equal(analysis.status(4), 'a,b')
+        assert_equal(analysis.status(8), 'a,b,c')
+
+        analysis.treat_multiples = 'all'
+        assert_equal(analysis.status(4), 'a,b')
+        assert_equal(analysis.status(8), 'a,b,c')
+
+    @raises(RuntimeError)
+    def test_bad_status_number(self):
+        analysis = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        analysis._results = self.toy_results
+
+        analysis.status(10)
         raise SkipTest

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -1,0 +1,74 @@
+from nose.tools import (assert_equal, assert_not_equal, assert_items_equal,
+                        raises, assert_almost_equal)
+from nose.plugins.skip import SkipTest
+from test_helpers import make_1d_traj
+
+import openpathsampling as paths
+import numpy as np
+import random
+
+import logging
+logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
+class testChannelAnalysis(object):
+    def setup(self):
+        cv = paths.FunctionCV("Id", lambda snap: snap.xyz[0][0])
+        self.state_A = paths.CVDefinedVolume(cv, -0.1, 0.1)
+        self.state_B = ~paths.CVDefinedVolume(cv, -1.0, 1.0)
+        nml_increasing = paths.CVDefinedVolume(cv, 0.1, 1.0)
+        nml_decreasing = paths.CVDefinedVolume(cv, -1.0, -0.1)
+        increasing = paths.AllInXEnsemble(nml_increasing)
+        decreasing = paths.AllInXEnsemble(nml_decreasing)
+        self.ensemble = paths.SequentialEnsemble([
+            paths.LengthEnsemble(1) & paths.AllInXEnsemble(self.state_A),
+            paths.AllOutXEnsemble(self.state_A | self.state_B),
+            paths.LengthEnsemble(1) & paths.AllInXEnsemble(self.state_B)
+        ])
+        self.incr_1 = self._make_active([0.0, 0.5, 1.1])
+        self.incr_2 = self._make_active([0.05, 0.6, 1.2])
+        self.decr_1 = self._make_active([0.0, -0.5, -1.1])
+        self.both_1 = self._make_active([0.0, 0.5, -0.5, 1.1])
+        self.both_2 = self._make_active([0.0, -0.4, 0.4, -1.1])
+
+        self.channels = {
+            'incr': increasing,
+            'decr': decreasing
+        }
+
+    def _make_active(self, seq):
+        traj = make_1d_traj(seq)
+        sample = paths.Sample(replica=0,
+                              trajectory=traj,
+                              ensemble=self.ensemble)
+        sample_set = paths.SampleSet(sample)
+        return sample_set
+
+    def test_analyze_incr_decr(self):
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.decr_1)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        print results._results
+        pass
+
+    def test_analyze_incr_incr(self):
+        pass
+
+    def test_analyze_incr_both_decr(self):
+        pass
+
+    def test_analyze_incr_both_incr(self):
+        pass
+
+    def test_analyze_incr_same_decr(self):
+        pass
+
+    def test_analyze_incr_none_incr(self):
+        pass
+
+    def test_analyze_incr_none_decr(self):
+        pass

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -52,8 +52,7 @@ class testChannelAnalysis(object):
             paths.MCStep(mccycle=1, active=self.decr_1)
         ]
         results = paths.ChannelAnalysis(steps, self.channels)
-        print results._results
-        pass
+        assert_equal(results._results, {'incr': [(0,1)], 'decr': [(1,1)]})
 
     def test_analyze_incr_incr(self):
         pass

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -52,8 +52,16 @@ class testChannelAnalysis(object):
         self.set_b = frozenset(['b'])
         self.set_c = frozenset(['c'])
         self.toy_expanded_results = [(0, 5, self.set_a), (3, 9, self.set_b),
-                                     (7, 9, self.set_c), (8, 10, self.set_a)]
-
+                                     (7, 9, self.set_c), (8, 10, self.set_a)] 
+        self.expanded_results_simultaneous_ending = [
+            (0, 5, self.set_a), (3, 9, self.set_b), (7, 10, self.set_c),
+            (8, 10, self.set_a)
+        ]
+        self.expanded_oldest_skips_internal = [
+            (0, 5, self.set_a), (3, 9, self.set_b), (7, 8, self.set_c),
+            (8, 10, self.set_a), (10, 11, self.set_b)
+        ]
+    
     def _make_active(self, seq):
         traj = make_1d_traj(seq)
         sample = paths.Sample(replica=0,
@@ -136,23 +144,36 @@ class testChannelAnalysis(object):
         assert_equal(expanded, self.toy_expanded_results)
 
     def test_labels_by_step_newest(self):
-        relabeled = paths.ChannelAnalysis._labels_by_step_newest(
-            self.toy_expanded_results
-        )
+        test_set = self.toy_expanded_results
+        relabeled = paths.ChannelAnalysis._labels_by_step_newest(test_set)
+        assert_equal(relabeled, [(0, 3, self.set_a), (3, 7, self.set_b),
+                                 (7, 8, self.set_c), (8, 10, self.set_a)])
+
+        test_set = self.expanded_results_simultaneous_ending
+        relabeled = paths.ChannelAnalysis._labels_by_step_newest(test_set)
         assert_equal(relabeled, [(0, 3, self.set_a), (3, 7, self.set_b),
                                  (7, 8, self.set_c), (8, 10, self.set_a)])
 
     def test_labels_by_step_oldest(self):
-        relabeled = paths.ChannelAnalysis._labels_by_step_oldest(
-            self.toy_expanded_results
-        )
+        test_set = self.toy_expanded_results
+        relabeled = paths.ChannelAnalysis._labels_by_step_oldest(test_set)
         assert_equal(relabeled, [(0, 5, self.set_a), (5, 9, self.set_b),
                                  (9, 10, self.set_a)])
 
+        test_set = self.expanded_results_simultaneous_ending
+        relabeled = paths.ChannelAnalysis._labels_by_step_oldest(test_set)
+        assert_equal(relabeled, [(0, 5, self.set_a), (5, 9, self.set_b),
+                                 (9, 10, self.set_c)])
+
+        test_set = self.expanded_oldest_skips_internal
+        relabeled = paths.ChannelAnalysis._labels_by_step_oldest(test_set)
+        assert_equal(relabeled, [(0, 5, self.set_a), (5, 9, self.set_b),
+                                 (9, 10, self.set_a), (10, 11, self.set_b)])
+
+
     def test_labels_by_step_multiple(self):
-        relabeled = paths.ChannelAnalysis._labels_by_step_multiple(
-            self.toy_expanded_results
-        )
+        test_set = self.toy_expanded_results
+        relabeled = paths.ChannelAnalysis._labels_by_step_multiple(test_set)
         assert_equal(relabeled,
                      [(0, 3, self.set_a),
                       (3, 5, self.set_a | self.set_b),

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -52,22 +52,34 @@ class testChannelAnalysis(object):
             paths.MCStep(mccycle=1, active=self.decr_1)
         ]
         results = paths.ChannelAnalysis(steps, self.channels)
-        assert_equal(results._results, {'incr': [(0,1)], 'decr': [(1,1)]})
+        assert_equal(results._results, {'incr': [(0,1)], 'decr': [(1,2)]})
 
     def test_analyze_incr_incr(self):
-        pass
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.incr_2)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        assert_equal(results._results, {'incr': [(0,2)], 'decr': []})
 
     def test_analyze_incr_both_decr(self):
-        pass
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.both_1),
+            paths.MCStep(mccycle=2, active=self.both_2),
+            paths.MCStep(mccycle=3, active=self.decr_1)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        assert_equal(results._results, {'incr': [(0,3)], 'decr': [(1,4)]})
 
     def test_analyze_incr_both_incr(self):
-        pass
+        raise SkipTest
 
     def test_analyze_incr_same_decr(self):
-        pass
+        raise SkipTest
 
     def test_analyze_incr_none_incr(self):
-        pass
+        raise SkipTest
 
     def test_analyze_incr_none_decr(self):
-        pass
+        raise SkipTest

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -32,6 +32,8 @@ class testChannelAnalysis(object):
         self.decr_1 = self._make_active([0.0, -0.5, -1.1])
         self.both_1 = self._make_active([0.0, 0.5, -0.5, 1.1])
         self.both_2 = self._make_active([0.0, -0.4, 0.4, -1.1])
+        self.none_1 = self._make_active([0.0, 1.1])
+        self.nont_2 = self._make_active([0.0, -1.1])
 
         self.channels = {
             'incr': increasing,
@@ -52,7 +54,8 @@ class testChannelAnalysis(object):
             paths.MCStep(mccycle=1, active=self.decr_1)
         ]
         results = paths.ChannelAnalysis(steps, self.channels)
-        assert_equal(results._results, {'incr': [(0,1)], 'decr': [(1,2)]})
+        assert_equal(results._results,
+                     {'incr': [(0,1)], 'decr': [(1,2)], None: []})
 
     def test_analyze_incr_incr(self):
         steps = [
@@ -60,7 +63,8 @@ class testChannelAnalysis(object):
             paths.MCStep(mccycle=1, active=self.incr_2)
         ]
         results = paths.ChannelAnalysis(steps, self.channels)
-        assert_equal(results._results, {'incr': [(0,2)], 'decr': []})
+        assert_equal(results._results,
+                     {'incr': [(0,2)], 'decr': [], None: []})
 
     def test_analyze_incr_both_decr(self):
         steps = [
@@ -70,16 +74,45 @@ class testChannelAnalysis(object):
             paths.MCStep(mccycle=3, active=self.decr_1)
         ]
         results = paths.ChannelAnalysis(steps, self.channels)
-        assert_equal(results._results, {'incr': [(0,3)], 'decr': [(1,4)]})
+        assert_equal(results._results,
+                     {'incr': [(0,3)], 'decr': [(1,4)], None: []})
 
     def test_analyze_incr_both_incr(self):
-        raise SkipTest
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.both_1),
+            paths.MCStep(mccycle=2, active=self.incr_2)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        assert_equal(results._results,
+                     {'incr': [(0,3)], 'decr': [(1,2)], None: []})
 
     def test_analyze_incr_same_decr(self):
-        raise SkipTest
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.incr_1),
+            paths.MCStep(mccycle=2, active=self.incr_2)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        assert_equal(results._results,
+                     {'incr': [(0,3)], 'decr': [], None: []})
 
     def test_analyze_incr_none_incr(self):
-        raise SkipTest
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.none_1),
+            paths.MCStep(mccycle=2, active=self.incr_2)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        assert_equal(results._results,
+                     {'incr': [(0,1), (2,3)], 'decr': [], None: [(1,2)]})
 
     def test_analyze_incr_none_decr(self):
-        raise SkipTest
+        steps = [
+            paths.MCStep(mccycle=0, active=self.incr_1),
+            paths.MCStep(mccycle=1, active=self.none_1),
+            paths.MCStep(mccycle=2, active=self.decr_1)
+        ]
+        results = paths.ChannelAnalysis(steps, self.channels)
+        assert_equal(results._results,
+                     {'incr': [(0,1)], 'decr': [(2,3)], None: [(1,2)]})

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -44,8 +44,11 @@ class testChannelAnalysis(object):
         self.toy_results =  {'a': [(0, 5), (8, 10)], 
                              'b': [(3, 9)],
                              'c': [(7, 9)]}
-        self.toy_expanded_results = [(0, 5, 'a'), (3, 9, 'b'), 
-                                     (7, 9, 'c'), (8, 10, 'a')]
+        self.set_a = set(['a'])
+        self.set_b = set(['b'])
+        self.set_c = set(['c'])
+        self.toy_expanded_results = [(0, 5, self.set_a), (3, 9, self.set_b), 
+                                     (7, 9, self.set_c), (8, 10, self.set_a)]
 
     def _make_active(self, seq):
         traj = make_1d_traj(seq)
@@ -132,11 +135,15 @@ class testChannelAnalysis(object):
         relabeled = paths.ChannelAnalysis._labels_by_step_newest(
             self.toy_expanded_results
         )
-        assert_equal(relabeled,
-                     [(0, 3, 'a'), (3, 7, 'b'), (7, 8, 'c'), (8, 10, 'a')])
+        assert_equal(relabeled, [(0, 3, self.set_a), (3, 7, self.set_b),
+                                 (7, 8, self.set_c), (8, 10, self.set_a)])
 
     def test_labels_by_step_oldest(self):
-        raise SkipTest
+        relabeled = paths.ChannelAnalysis._labels_by_step_oldest(
+            self.toy_expanded_results
+        )
+        assert_equal(relabeled, [(0, 5, self.set_a), (5, 9, self.set_b),
+                                 (9, 10, self.set_a)])
 
     def test_labels_by_step_multiple(self):
         raise SkipTest

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -44,9 +44,9 @@ class testChannelAnalysis(object):
         self.toy_results =  {'a': [(0, 5), (8, 10)], 
                              'b': [(3, 9)],
                              'c': [(7, 9)]}
-        self.set_a = set(['a'])
-        self.set_b = set(['b'])
-        self.set_c = set(['c'])
+        self.set_a = frozenset(['a'])
+        self.set_b = frozenset(['b'])
+        self.set_c = frozenset(['c'])
         self.toy_expanded_results = [(0, 5, self.set_a), (3, 9, self.set_b), 
                                      (7, 9, self.set_c), (8, 10, self.set_a)]
 
@@ -146,4 +146,13 @@ class testChannelAnalysis(object):
                                  (9, 10, self.set_a)])
 
     def test_labels_by_step_multiple(self):
-        raise SkipTest
+        relabeled = paths.ChannelAnalysis._labels_by_step_multiple(
+            self.toy_expanded_results
+        )
+        assert_equal(relabeled, 
+                     [(0, 3, self.set_a), 
+                      (3, 5, self.set_a | self.set_b),
+                      (5, 7, self.set_b),
+                      (7, 8, self.set_b | self.set_c),
+                      (8, 9, self.set_b | self.set_c | self.set_a),
+                      (9, 10, self.set_a)])

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -33,12 +33,19 @@ class testChannelAnalysis(object):
         self.both_1 = self._make_active([0.0, 0.5, -0.5, 1.1])
         self.both_2 = self._make_active([0.0, -0.4, 0.4, -1.1])
         self.none_1 = self._make_active([0.0, 1.1])
-        self.nont_2 = self._make_active([0.0, -1.1])
+        self.none_2 = self._make_active([0.0, -1.1])
 
         self.channels = {
             'incr': increasing,
             'decr': decreasing
         }
+
+        # used in simplest tests of relabeling
+        self.toy_results =  {'a': [(0, 5), (8, 10)], 
+                             'b': [(3, 9)],
+                             'c': [(7, 9)]}
+        self.toy_expanded_results = [(0, 5, 'a'), (3, 9, 'b'), 
+                                     (7, 9, 'c'), (8, 10, 'a')]
 
     def _make_active(self, seq):
         traj = make_1d_traj(seq)
@@ -116,3 +123,20 @@ class testChannelAnalysis(object):
         results = paths.ChannelAnalysis(steps, self.channels)
         assert_equal(results._results,
                      {'incr': [(0,1)], 'decr': [(2,3)], None: [(1,2)]})
+
+    def test_expand_results(self):
+        expanded = paths.ChannelAnalysis._expand_results(self.toy_results)
+        assert_equal(expanded, self.toy_expanded_results)
+
+    def test_labels_by_step_newest(self):
+        relabeled = paths.ChannelAnalysis._labels_by_step_newest(
+            self.toy_expanded_results
+        )
+        assert_equal(relabeled,
+                     [(0, 3, 'a'), (3, 7, 'b'), (7, 8, 'c'), (8, 10, 'a')])
+
+    def test_labels_by_step_oldest(self):
+        raise SkipTest
+
+    def test_labels_by_step_multiple(self):
+        raise SkipTest

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -200,10 +200,10 @@ class testChannelAnalysis(object):
 
     def test_switching(self):
         analysis = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        analysis._results = self.toy_results
         #nan = float('nan')
         nan = 0  # self transitions are 0
 
-        analysis._results = self.toy_results
 
         analysis.treat_multiples = 'newest'
         df = analysis.switching_matrix
@@ -225,4 +225,51 @@ class testChannelAnalysis(object):
                              [1, 0, 0, 0, nan]])
         assert_array_almost_equal(df.as_matrix(), expected)
 
+        # TODO: define switching when using 'all'
 
+    def test_residence_times(self):
+        analysis = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        analysis._results = self.toy_results
+
+        analysis.treat_multiples = 'newest'
+        residence_times = analysis.residence_times
+        assert_equal(residence_times, {'a': [3, 2], 'b': [4], 'c': [1]})
+
+        analysis.treat_multiples = 'oldest'
+        residence_times = analysis.residence_times
+        assert_equal(residence_times, {'a': [5, 1], 'b': [4]})
+
+        analysis.treat_multiples = 'all'
+        residence_times = analysis.residence_times
+        assert_equal(residence_times, {'a': [5, 2], 'b': [6], 'c': [2]})
+
+        analysis.treat_multiples = 'multiple'
+        residence_times = analysis.residence_times
+        assert_equal(residence_times, {'a': [3, 1], 'b': [2], 'a,b': [2],
+                                       'b,c': [1], 'a,b,c': [1]})
+
+    def test_total_time(self):
+        analysis = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        analysis._results = self.toy_results
+
+        analysis.treat_multiples = 'newest'
+        total_time = analysis.total_time
+        assert_equal(total_time, {'a': 5, 'b': 4, 'c': 1})
+
+        analysis.treat_multiples = 'oldest'
+        total_time = analysis.total_time
+        assert_equal(total_time, {'a': 6, 'b': 4})
+        assert_equal(total_time['c'], 0)
+
+        analysis.treat_multiples = 'all'
+        total_time = analysis.total_time
+        assert_equal(total_time, {'a': 7, 'b': 6, 'c': 2})
+
+        analysis.treat_multiples = 'multiple'
+        total_time = analysis.total_time
+        assert_equal(total_time, {'a': 4, 'b': 2, 'a,b': 2, 'b,c': 1,
+                                  'a,b,c': 1})
+
+
+    def test_status(self):
+        raise SkipTest

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -41,13 +41,13 @@ class testChannelAnalysis(object):
         }
 
         # used in simplest tests of relabeling
-        self.toy_results =  {'a': [(0, 5), (8, 10)], 
+        self.toy_results =  {'a': [(0, 5), (8, 10)],
                              'b': [(3, 9)],
                              'c': [(7, 9)]}
         self.set_a = frozenset(['a'])
         self.set_b = frozenset(['b'])
         self.set_c = frozenset(['c'])
-        self.toy_expanded_results = [(0, 5, self.set_a), (3, 9, self.set_b), 
+        self.toy_expanded_results = [(0, 5, self.set_a), (3, 9, self.set_b),
                                      (7, 9, self.set_c), (8, 10, self.set_a)]
 
     def _make_active(self, seq):
@@ -149,8 +149,8 @@ class testChannelAnalysis(object):
         relabeled = paths.ChannelAnalysis._labels_by_step_multiple(
             self.toy_expanded_results
         )
-        assert_equal(relabeled, 
-                     [(0, 3, self.set_a), 
+        assert_equal(relabeled,
+                     [(0, 3, self.set_a),
                       (3, 5, self.set_a | self.set_b),
                       (5, 7, self.set_b),
                       (7, 8, self.set_b | self.set_c),

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -363,4 +363,3 @@ class testChannelAnalysis(object):
         analysis._results = self.toy_results
 
         analysis.status(10)
-        raise SkipTest

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -180,6 +180,24 @@ class testChannelAnalysis(object):
         assert_equal(obj.treat_multiples, 'all')
         obj.treat_multiples = 'bad_string'
 
+    def test_labels_as_sets_sort_function(self):
+        sort_key = paths.ChannelAnalysis._labels_as_sets_sort_function
+
+        inp_list = [self.set_b, self.set_c, self.set_a]
+        sorted_set_list = sorted(inp_list, key=sort_key)
+        sorted_labels = [paths.ChannelAnalysis.label_to_string(e)
+                         for e in sorted_set_list]
+        assert_equal(sorted_labels, ['a', 'b', 'c'])
+
+        inp_list = [self.set_a, self.set_a | self.set_b, self.set_b,
+                    self.set_c | self.set_b,
+                    self.set_a | self.set_b | self.set_c]
+        sorted_set_list = sorted(inp_list, key=sort_key)
+        sorted_labels = [paths.ChannelAnalysis.label_to_string(e)
+                         for e in sorted_set_list]
+        assert_equal(sorted_labels, ['a', 'b', 'a,b', 'b,c', 'a,b,c'])
+
+
     def test_switching(self):
         raise SkipTest
 

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -156,3 +156,30 @@ class testChannelAnalysis(object):
                       (7, 8, self.set_b | self.set_c),
                       (8, 9, self.set_b | self.set_c | self.set_a),
                       (9, 10, self.set_a)])
+
+    def test_empty(self):
+        obj = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        empty_results = {c: [] for c in self.channels.keys() + [None]}
+        assert_equal(obj._results, empty_results)
+
+    def test_treat_multiples(self):
+        obj = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        assert_equal(obj.treat_multiples, 'all')
+        obj.treat_multiples = 'oldest'
+        assert_equal(obj.treat_multiples, 'oldest')
+        obj.treat_multiples = 'newest'
+        assert_equal(obj.treat_multiples, 'newest')
+        obj.treat_multiples = 'multiple'
+        assert_equal(obj.treat_multiples, 'multiple')
+        obj.treat_multiples = 'all'
+        assert_equal(obj.treat_multiples, 'all')
+
+    @raises(ValueError)
+    def test_bad_treat_multiples(self):
+        obj = paths.ChannelAnalysis(steps=None, channels=self.channels)
+        assert_equal(obj.treat_multiples, 'all')
+        obj.treat_multiples = 'bad_string'
+
+    def test_switching(self):
+        raise SkipTest
+


### PR DESCRIPTION
This adds an analysis object to study how well multiple channels are sampled in path sampling simulations. This could be useful in several contexts: 

* Similar things have been done before to see how well the various final states are sampled in MSTIS. There should be plenty of switching between various final states, which can be seen as different "channels"
* Some TPS simulations can sample different channels (mechanisms) for the same physical transition. This will make it possible to study that as well.

The approach implemented here uses `Ensemble`s (and specifically the `Ensemble.split` function) to characterize channels, as I have previously done in the AD TPS example. The ensembles are the user input. Each path can be characterized as being in one, multiple, or no channels. Then `ChannelAnalysis` object can calculate switching matrices or lifetimes (in MC step) spent in each channel. 