### PR TITLE
DirectSimulation result storage

### DIFF
--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -165,7 +165,7 @@ class BootstrapPromotionMove(SubPathMover):
         # Bootstrapping sets numeric replica IDs. If the user wants it done
         # differently, the user can change it.
         self._ensemble_dict = {ens : rep for rep, ens in enumerate(ensembles) }
-        
+
         # Create all possible hoppers so we do not have to recreate these
         # every time which will result in more efficient storage
         mover = paths.LastAllowedMover([
@@ -187,7 +187,7 @@ class BootstrapPromotionMove(SubPathMover):
 
 class Bootstrapping(PathSimulator):
     """Creates a SampleSet with one sample per ensemble.
-    
+
     The ensembles for the Bootstrapping pathsimulator must be one ensemble
     set, in increasing order. Replicas are named numerically.
     """
@@ -950,6 +950,15 @@ class DirectSimulation(PathSimulator):
         self.transition_count = []
         self.flux_events = {pair: [] for pair in self.flux_pairs}
 
+    @property
+    def results(self):
+        return {'transition_count': self.transition_count,
+                'flux_events': self.flux_events}
+
+    def load_results(self, results):
+        self.transition_count = results['transition_count']
+        self.flux_events = results['flux_events']
+
     def run(self, n_steps):
         most_recent_state = None
         last_interface_exit = {p: -1 for p in self.flux_pairs}
@@ -965,12 +974,12 @@ class DirectSimulation(PathSimulator):
             for s in self.states:
                 if s(frame):
                     state = s
-            if state: 
+            if state:
                 last_state_visit[state] = step
                 if state is not most_recent_state:
                     # we've made a transition: on the first entrance into
                     # this state, we reset the last_interface_exit
-                    state_flux_pairs = [p for p in self.flux_pairs 
+                    state_flux_pairs = [p for p in self.flux_pairs
                                         if p[0] == state]
                     for p in state_flux_pairs:
                         last_interface_exit[p] = -1
@@ -1020,7 +1029,7 @@ class DirectSimulation(PathSimulator):
     @property
     def rate_matrix(self):
         transitions = self.transitions
-        rates = {t : 1.0 / np.array(transitions[t]).mean() 
+        rates = {t : 1.0 / np.array(transitions[t]).mean()
                  for t in transitions}
         rate_matrix = pd.DataFrame(columns=self.states,
                                    index=self.states)

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -360,6 +360,32 @@ class testDirectSimulation(object):
         assert_true(len(self.sim.transition_count) > 1)
         assert_true(len(self.sim.flux_events[self.flux_pairs[0]]) > 1)
 
+    def test_results(self):
+        self.sim.run(200)
+        results = self.sim.results
+        assert_equal(len(results), 2)
+        assert_equal(set(results.keys()),
+                     set(['transition_count', 'flux_events']))
+        assert_equal(results['transition_count'], self.sim.transition_count)
+        assert_equal(results['flux_events'], self.sim.flux_events)
+
+    def test_load_results(self):
+        left_interface = paths.CVDefinedVolume(self.cv, -0.3, float("inf"))
+        right_interface = paths.CVDefinedVolume(self.cv, float("-inf"), 0.3)
+        fake_transition_count = [
+            (self.center, 1), (self.outside, 4), (self.center, 7),
+            (self.extra, 10), (self.center, 12), (self.outside, 14)
+        ]
+        fake_flux_events = {(self.center, right_interface):
+                            [(15, 3), (23, 15), (48, 23)],
+                            (self.center, left_interface):
+                            [(97, 34), (160, 97)]}
+        results = {'transition_count': fake_transition_count,
+                   'flux_events': fake_flux_events}
+        self.sim.load_results(results)
+        assert_equal(self.sim.transition_count, fake_transition_count)
+        assert_equal(self.sim.flux_events, fake_flux_events)
+
     def test_transitions(self):
         # set fake data
         self.sim.transition_count = [


### PR DESCRIPTION
`DirectSimulation` keeps its results in the `DirectSimulation` object, using `@property` methods to calculate several quantities from a few simplified internal structures.

Previously, there was no way to save those simplified internal structures. This adds two methods, an `@property` called `results` and a method called `load_results`, which put those internal structures into a `dict` and load from that `dict`.

I chose to do it this way, rather than by modifying the `to_dict`/`from_dict`, because this allows the user to store the simulation object before the results are calculated.

One question: `load_results` is currently a separate method. The other option would be to make it the setter of the `results` property. I'm not sure which makes more sense:

```python
sim = DirectSimulation(...)
sim.load_results(results)
# which also allows
sim = DirectSimulation(...).load_results(results)
```

or

```python
sim = DirectSimulation(...)
sim.results = results
```

I think I prefer the `load_results` version, but either would work. I would rather not do both, under the principle of "there should be *one* obvious way to do it."