### PR TITLE
Faster TIS analysis

### DIFF
--- a/openpathsampling/high_level/transition.py
+++ b/openpathsampling/high_level/transition.py
@@ -257,10 +257,18 @@ class TISTransition(Transition):
         hist_data = {}
         buflen = -1
         sample_buf = []
+        prev_sample = {h: None for h in run_it}
+        prev_result = {h: None for h in run_it}
         for sample in in_ens_samples:
             for hist in run_it:
                 hist_info = self.ensemble_histogram_info[hist]
-                hist_data_sample = hist_info.f(sample, **hist_info.f_args)
+                if sample is prev_sample[hist]:
+                    hist_data_sample = prev_result[hist]
+                else:
+                    hist_data_sample = hist_info.f(sample,
+                                                   **hist_info.f_args)
+                prev_result[hist] = hist_data_sample
+                prev_sample[hist] = sample
                 try:
                     hist_data[hist].append(hist_data_sample)
                 except KeyError:


### PR DESCRIPTION
Just a few lines of code to provide a significant speed-up for TIS analysis.

Caching previous results of max_lambda, so we don't check it again if we have the same trajectory as before. For the toy model, this nearly doubles the speed (with 20k trajectories).

Before:

![image](https://cloud.githubusercontent.com/assets/8178546/23044195/769a5fae-f49f-11e6-9a30-17c947df740f.png)

After:

![image](https://cloud.githubusercontent.com/assets/8178546/23044202/7dc51b20-f49f-11e6-8412-f976e96d08b8.png)

Same results; we just get them faster.