### PR TITLE
Faster minus flux

### DIFF
--- a/openpathsampling/high_level/transition.py
+++ b/openpathsampling/high_level/transition.py
@@ -261,10 +261,10 @@ class TISTransition(Transition):
         prev_result = {h: None for h in run_it}
         for sample in in_ens_samples:
             for hist in run_it:
-                hist_info = self.ensemble_histogram_info[hist]
                 if sample is prev_sample[hist]:
                     hist_data_sample = prev_result[hist]
                 else:
+                    hist_info = self.ensemble_histogram_info[hist]
                     hist_data_sample = hist_info.f(sample,
                                                    **hist_info.f_args)
                 prev_result[hist] = hist_data_sample

--- a/openpathsampling/high_level/transition.py
+++ b/openpathsampling/high_level/transition.py
@@ -257,10 +257,18 @@ class TISTransition(Transition):
         hist_data = {}
         buflen = -1
         sample_buf = []
+        prev_sample = {h: None for h in run_it}
+        prev_result = {h: None for h in run_it}
         for sample in in_ens_samples:
             for hist in run_it:
                 hist_info = self.ensemble_histogram_info[hist]
-                hist_data_sample = hist_info.f(sample, **hist_info.f_args)
+                if sample is prev_sample[hist]:
+                    hist_data_sample = prev_result[hist]
+                else:
+                    hist_data_sample = hist_info.f(sample,
+                                                   **hist_info.f_args)
+                prev_result[hist] = hist_data_sample
+                prev_sample[hist] = sample
                 try:
                     hist_data[hist].append(hist_data_sample)
                 except KeyError:


### PR DESCRIPTION
Told you in https://github.com/openpathsampling/openpathsampling/pull/665#issuecomment-280488217 that I'd find a way to fix this. Didn't think I'd do it tonight, though!

Since `Ensemble`s are immutable, their strings should also be immutable. So we calculate the full string once, and then cache it.

The rate matrix speed is even better. Before it was ~40 seconds, now:

![image](https://cloud.githubusercontent.com/assets/8178546/23046399/82db8c7a-f4a9-11e6-980e-7763fd8b1408.png)


At this point, the performance bottlenecks for the rate matrix calculation are the chaindict (I don't think these CVs are cached on disk, so that's more expensive in this case) and within the `collection.Counter` that manages the histogram (there's room to improve the way data is sent to that, but I'll save that for the rewrite of analysis that I'm working on). Loading the data (opening the file as `AnalysisStorage`) is a much more significant cost than either of these for this system (about 2-3 minutes, compared to rate calculation analysis in 20 seconds -- both for 20k steps of the MSTIS toy model).

Note that this includes #665, and therefore merging this will also merge that.