### PR TITLE
`ShootFromSnapshotsSimulation`

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -128,7 +128,7 @@ from pathmover import (
 
 from pathsimulator import (
     PathSimulator, FullBootstrapping, Bootstrapping, PathSampling, MCStep,
-    CommittorSimulation, DirectSimulation
+    CommittorSimulation, DirectSimulation, ShootFromSnapshotsSimulation
 )
 
 from sample import Sample, SampleSet

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -768,6 +768,33 @@ class PathSampling(PathSimulator):
 
 class ShootFromSnapshotsSimulation(PathSimulator):
     """
+    Generic class for shooting from a set of snapshots.
+
+    This mainly serves as a base class for other simulation types
+    (committor, reactive flux, etc.) All of these take initial snapshots
+    from within some defined volume, modify the velocities in some way, and
+    run the dynamics until some ensemble tells them to stop.
+
+    While this is usually subclassed, it isn't technically abstract, so a
+    user can create a simulation of this sort on-the-fly for some weird
+    ensembles.
+
+    Parameters
+    ----------
+    storage : :class:`.Storage`
+        the file to store simulations in
+    engine : :class:`.DynamicsEngine`
+        the dynamics engine to use to run the simulation
+    starting_volume : :class:`.Volume`
+        volume initial frames must be inside of
+    forward_ensemble : :class:`.Ensemble`
+        ensemble for shots in the forward direction
+    backward_ensemble : :class:`.Ensemble`
+        ensemble for shots in the backward direction
+    randomizer : :class:`.SnapshotModifier`
+        the method used to modify the input snapshot before each shot
+    initial_snapshots : list of :class:`.Snapshot`
+        initial snapshots to use
     """
     def __init__(self, storage, engine, starting_volume, forward_ensemble,
                  backward_ensemble, randomizer, initial_snapshots):
@@ -801,6 +828,30 @@ class ShootFromSnapshotsSimulation(PathSimulator):
         # subclasses will often override this
         self.mover = paths.RandomChoiceMover([self.forward_mover,
                                               self.backward_mover])
+
+    def to_dict(self):
+        dct = {
+            'engine': self.engine,
+            'initial_snapshots': self.initial_snapshots,
+            'randomizer': self.randomizer,
+            'starting_ensemble': self.starting_ensemble,
+            'forward_ensemble': self.forward_ensemble,
+            'backward_ensemble': self.backward_ensemble,
+            'mover': self.mover
+        }
+        return dct
+
+    @classmethod
+    def from_dict(cls, dct):
+        obj = cls.__new__(cls)
+        obj.engine = dct['engine']
+        obj.initial_snapshots = dct['initial_snapshots']
+        obj.randomizer = dct['randomizer']
+        obj.starting_ensemble = dct['starting_ensemble']
+        obj.forward_ensemble = dct['forward_ensemble']
+        obj.backward_ensemble = dct['backward_ensemble']
+        obj.mover = dct['mover']
+        return obj
 
 
     def run(self, n_per_snapshot, as_chain=False):
@@ -920,65 +971,17 @@ class CommittorSimulation(ShootFromSnapshotsSimulation):
         elif self.direction < 0:
             self.mover = self.backward_mover
 
-    def run(self, n_per_snapshot, as_chain=False):
-        """Run the simulation.
+    def to_dict(self):
+        dct = super(CommittorSimulation, self).to_dict()
+        dct['states'] = self.states
+        dct['direction'] = self.direction
+        return dct
 
-        Parameters
-        ----------
-        n_per_snapshot : int
-            number of shots per snapshot
-        as_chain : bool
-            if as_chain is False (default), then the input to the modifier
-            is always the original snapshot. If as_chain is True, then the
-            input to the modifier is the previous (modified) snapshot.
-            Useful for modifications that can't cover the whole range from a
-            given snapshot.
-        """
-        self.step = 0
-        snap_num = 0
-        for snapshot in self.initial_snapshots:
-            start_snap = snapshot
-            # do what we need to get the snapshot set up
-            for step in range(n_per_snapshot):
-                paths.tools.refresh_output(
-                    "Working on snapshot %d / %d; shot %d / %d" % (
-                        snap_num+1, len(self.initial_snapshots),
-                        step+1, n_per_snapshot
-                    ),
-                    output_stream=self.output_stream,
-                    refresh=self.allow_refresh
-                )
-
-                if as_chain:
-                    start_snap = self.randomizer(start_snap)
-                else:
-                    start_snap = self.randomizer(snapshot)
-
-                sample_set = paths.SampleSet([
-                    paths.Sample(replica=0,
-                                 trajectory=paths.Trajectory([start_snap]),
-                                 ensemble=self.starting_ensemble)
-                ])
-                sample_set.sanity_check()
-                new_pmc = self.mover.move(sample_set)
-                samples = new_pmc.results
-                new_sample_set = sample_set.apply_samples(samples)
-
-                mcstep = MCStep(
-                    simulation=self,
-                    mccycle=self.step,
-                    previous=sample_set,
-                    active=new_sample_set,
-                    change=new_pmc
-                )
-
-                if self.storage is not None:
-                    self.storage.steps.save(mcstep)
-                    if self.step % self.save_frequency == 0:
-                        self.sync_storage()
-
-                self.step += 1
-            snap_num += 1
+    @classmethod
+    def from_dict(cls, dct):
+        obj = super(CommittorSimulation, cls).from_dict(dct)
+        obj.states = dct['states']
+        obj.direction = dct['direction']
 
 
 class DirectSimulation(PathSimulator):

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -844,6 +844,8 @@ class ShootFromSnapshotsSimulation(PathSimulator):
     @classmethod
     def from_dict(cls, dct):
         obj = cls.__new__(cls)
+        # user must manually set a storage!
+        super(ShootFromSnapshotsSimulation, obj).__init__(storage=None)
         obj.engine = dct['engine']
         obj.initial_snapshots = dct['initial_snapshots']
         obj.randomizer = dct['randomizer']
@@ -982,6 +984,7 @@ class CommittorSimulation(ShootFromSnapshotsSimulation):
         obj = super(CommittorSimulation, cls).from_dict(dct)
         obj.states = dct['states']
         obj.direction = dct['direction']
+        return obj
 
 
 class DirectSimulation(PathSimulator):

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -202,6 +202,18 @@ class testCommittorSimulation(object):
         assert_equal(len(sim.initial_snapshots), 1)
         assert_true(isinstance(sim.mover, paths.RandomChoiceMover))
 
+    def test_storage(self):
+        self.storage.tag['simulation'] = self.simulation
+        self.storage.close()
+        read_store = paths.Storage(self.filename, 'r')
+        sim = read_store.tag['simulation']
+        new_filename = data_filename("test2.nc")
+        sim.storage = paths.Storage(new_filename, 'w')
+        sim.output_stream = open(os.devnull, 'w')
+        sim.run(n_per_snapshot=2)
+        if os.path.isfile(new_filename):
+            os.remove(new_filename)
+
     def test_committor_run(self):
         self.simulation.run(n_per_snapshot=20)
         assert_equal(len(self.simulation.storage.steps), 20)
@@ -237,6 +249,7 @@ class testCommittorSimulation(object):
                                   randomizer=paths.NoModification(),
                                   initial_snapshots=self.snap0,
                                   direction=1)
+        sim.output_stream = open(os.devnull, 'w')
         sim.run(n_per_snapshot=10)
         assert_equal(len(sim.storage.steps), 10)
         for step in self.simulation.storage.steps:
@@ -257,6 +270,7 @@ class testCommittorSimulation(object):
                                   randomizer=paths.NoModification(),
                                   initial_snapshots=self.snap0,
                                   direction=-1)
+        sim.output_stream = open(os.devnull, 'w')
         sim.run(n_per_snapshot=10)
         assert_equal(len(sim.storage.steps), 10)
         for step in self.simulation.storage.steps:
@@ -279,6 +293,7 @@ class testCommittorSimulation(object):
                                   states=[self.left, self.right],
                                   randomizer=paths.NoModification(),
                                   initial_snapshots=[self.snap0, snap1])
+        sim.output_stream = open(os.devnull, 'w')
         sim.run(10)
         assert_equal(len(self.storage.steps), 20)
         snap0_coords = self.snap0.coordinates.tolist()
@@ -306,6 +321,7 @@ class testCommittorSimulation(object):
                                   randomizer=randomizer,
                                   initial_snapshots=self.snap0,
                                   direction=1)
+        sim.output_stream = open(os.devnull, 'w')
         sim.run(50)
         assert_equal(len(sim.storage.steps), 50)
         counts = {'None-Right' : 0,


### PR DESCRIPTION
This refactors some of the committor simulation. It will already be useful for reactive flux, and also for some other things I'm playing with that won't go straight into OPS core.

There are a lot of simulation types that start from a user-provided list of snapshots, and then shoot from those snapshots (often doing something like randomizing the velocities before the dynamics) and run until some ensemble condition is satisfied. This refactors the reusable code from the `CommittorSimulation` into a base class. This was [already suggested by Andreas Singraber](https://gitlab.e-cam2020.eu/Classical-MD_openpathsampling/RF/issues/4), who is developing a reactive flux module for OPS.

- [x] Refactor `CommittorSimulation` into `ShootFromSnapshotsSimulation`
- [x] add `to_dict` and `from_dict`
- [x] return test coverage in `CommittorSimulation`
- [x] specialized tests of `ShootFromSnapshotsSimulation` when not subclassed