### PR TITLE
Fast ensemble check

### DIFF
--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -2792,8 +2792,8 @@ class TISEnsemble(SequentialEnsemble):
         self.orderparameter = orderparameter
         # TODO: add max_orderparameter as a traj CV
         self.lambda_i = lambda_i
-        self._initial_volumes = volumes_a
-        self._final_volumes = volumes_b
+        self._initial_volumes = volume_a
+        self._final_volumes = volume_b | volume_a
 
     def __call__(self, trajectory, trusted=None, candidate=False):
         use_candidate = (candidate and self.lambda_i is not None
@@ -2801,9 +2801,17 @@ class TISEnsemble(SequentialEnsemble):
         if use_candidate:
             # as a candidate trajectory, we assume that only the first and
             # final frames can be in a state
-            return (self._initial_volumes(trajectory[0])
-                    & self._final_volumes(trajectory[-1])
-                    & max(self.orderparameter(trajectory)) >= self.lambda_i)
+            #logger.debug("initial: " +
+                         #str(self._initial_volumes(trajectory[0])))
+            #logger.debug("final: " +
+                         #str(self._final_volumes(trajectory[0])))
+            #logger.debug("max: " +
+                         #str(max(self.orderparameter(trajectory))))
+            return (
+                self._initial_volumes(trajectory[0])
+                & self._final_volumes(trajectory[-1])
+                & (max(self.orderparameter(trajectory)) > self.lambda_i)
+            )
         else:
             # it still works fine if we use the slower algorithm
             return super(TISEnsemble, self).__call__(trajectory, trusted)

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -2796,13 +2796,16 @@ class TISEnsemble(SequentialEnsemble):
         self._final_volumes = volumes_b
 
     def __call__(self, trajectory, trusted=None, candidate=False):
-        if candidate:
+        use_candidate = (candidate and self.lambda_i is not None
+                         and self.orderparameter is not None)
+        if use_candidate:
             # as a candidate trajectory, we assume that only the first and
             # final frames can be in a state
             return (self._initial_volumes(trajectory[0])
                     & self._final_volumes(trajectory[-1])
                     & max(self.orderparameter(trajectory)) >= self.lambda_i)
         else:
+            # it still works fine if we use the slower algorithm
             return super(TISEnsemble, self).__call__(trajectory, trusted)
 
     def trajectory_summary(self, trajectory):

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -2792,12 +2792,16 @@ class TISEnsemble(SequentialEnsemble):
         self.orderparameter = orderparameter
         # TODO: add max_orderparameter as a traj CV
         self.lambda_i = lambda_i
+        self._initial_volumes = volumes_a
+        self._final_volumes = volumes_b
 
     def __call__(self, trajectory, trusted=None, candidate=False):
         if candidate:
-            # we assume that initial and final frames are in appropriate
-            # states, and no other frames are in a state
-            return max(self.orderparameter(trajectory)) >= self.lambda_i
+            # as a candidate trajectory, we assume that only the first and
+            # final frames can be in a state
+            return (self._initial_volumes(trajectory[0])
+                    & self._final_volumes(trajectory[-1])
+                    & max(self.orderparameter(trajectory)) >= self.lambda_i)
         else:
             return super(TISEnsemble, self).__call__(trajectory, trusted)
 

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -956,6 +956,7 @@ class ReplicaExchangeMover(SampleMover):
         self.bias = bias
         self.ensemble1 = ensemble1
         self.ensemble2 = ensemble2
+        self._trust_candidate = True
 
         initialization_logging(logger=init_log, obj=self,
                                entries=['bias', 'ensemble1', 'ensemble2'])
@@ -986,11 +987,11 @@ class ReplicaExchangeMover(SampleMover):
         replica1 = sample1.replica
         replica2 = sample2.replica
 
-        from1to2 = ensemble2(trajectory1)
+        from1to2 = ensemble2(trajectory1, candidate=self._trust_candidate)
         logger.debug("trajectory " + repr(trajectory1) +
                      " into ensemble " + repr(ensemble2) +
                      " : " + str(from1to2))
-        from2to1 = ensemble1(trajectory2)
+        from2to1 = ensemble1(trajectory2, candidate=self._trust_candidate)
         logger.debug("trajectory " + repr(trajectory2) +
                      " into ensemble " + repr(ensemble1) +
                      " : " + str(from2to1))

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -132,6 +132,7 @@ class PathMover(TreeMixin, StorableNamedObject):
         self._out_ensembles = None
         self._len = None
         self._inout = None
+        self._trust_candidate = False
 
     #        initialization_logging(logger=init_log, obj=self,
     #                               entries=['ensembles'])
@@ -494,8 +495,7 @@ class SampleMover(PathMover):
     def __init__(self):
         super(SampleMover, self).__init__()
 
-    @classmethod
-    def metropolis(cls, trials):
+    def metropolis(self, trials):
         """Implements the Metropolis acceptance for a list of trial samples
 
         The Metropolis uses the .bias for each sample and checks of samples
@@ -519,7 +519,8 @@ class SampleMover(PathMover):
         """
 
         shoot_str = "MC in {cls} using samples {trials}"
-        logger.info(shoot_str.format(cls=cls.__name__, trials=trials))
+        logger.info(shoot_str.format(cls=self.__class__.__name__,
+                                     trials=trials))
 
         trial_dict = dict()
         for trial in trials:
@@ -531,7 +532,7 @@ class SampleMover(PathMover):
         # TODO: This isn't right. `bias` should be associated with the
         # change; not with each individual sample. ~~~DWHS
         for ens, sample in trial_dict.iteritems():
-            valid = ens(sample.trajectory)
+            valid = ens(sample.trajectory, candidate=self._trust_candidate)
             if not valid:
                 # one sample not valid reject
                 accepted = False
@@ -1267,6 +1268,7 @@ class PathReversalMover(SampleMover):
         """
         super(PathReversalMover, self).__init__()
         self.ensemble = ensemble
+        self._trust_candidate = True
 
     def _called_ensembles(self):
         return [self.ensemble]
@@ -1288,7 +1290,8 @@ class PathReversalMover(SampleMover):
 
         reversed_trajectory = trajectory.reversed
 
-        valid = ensemble(reversed_trajectory)
+        valid = ensemble(reversed_trajectory,
+                         candidate=self._trust_candidate)
         logger.info("PathReversal move accepted: " + str(valid))
 
         bias = 1.0

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -1282,7 +1282,7 @@ class testSequentialEnsembleCombination(EnsembleTest):
 
 class testTISEnsemble(EnsembleTest):
     def setUp(self):
-        self.tis = TISEnsemble(vol1, vol3, vol2, op) 
+        self.tis = TISEnsemble(vol1, vol3, vol2, op)
         self.traj = ttraj['upper_in_out_cross_out_in']
         self.minl = min(op(self.traj))
         self.maxl = max(op(self.traj))
@@ -1299,6 +1299,26 @@ class testTISEnsemble(EnsembleTest):
         teststr = ("initial_state=stateA final_state=stateA min_lambda=" +
                    str(self.minl) + " max_lambda=" + str(self.maxl) + " ")
         assert_equal(mystr, teststr)
+
+    def test_tis_ensemble_candidate(self):
+        tis = TISEnsemble(vol1, vol3, vol2, op, lambda_i=0.7)
+        test_f = lambda t: tis(t, candidate=True)
+        results = {}
+        upper_keys = [k for k in ttraj.keys() if k[:6] == "upper_"]
+        for test in upper_keys:
+            results[test] = False
+        # results where we SHOULD get True
+        results['upper_in_out_cross_out_in'] = True
+        results['upper_in_cross_in'] = True
+        # results where the input isn't actually a candidate trajectory, so
+        # it accepts the path even though it shouldn't
+        results['upper_in_cross_in_cross_in'] = True
+        results['upper_in_out_cross_out_in_out_in_out_cross_out_in'] = True
+        results['upper_in_in_cross_in'] = True
+
+        for test in results.keys():
+            failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
+            self._single_test(test_f, ttraj[test], results[test], failmsg)
 
 class EnsembleCacheTest(EnsembleTest):
     def _was_cache_reset(self, cache):

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -340,7 +340,8 @@ class testPathReversalMover(object):
         volA = CVDefinedVolume(op, -100, 0.0)
         volB = CVDefinedVolume(op, 1.0, 100)
         volX = CVDefinedVolume(op, -100, 0.25)
-        self.tis = paths.TISEnsemble(volA, volB, volX)
+        self.tis = paths.TISEnsemble(volA, volB, volX, orderparameter=op,
+                                     lambda_i=0.25)
         self.move = PathReversalMover(ensemble=self.tis)
         self.op = op
 

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -410,10 +410,12 @@ class testReplicaExchangeMover(object):
         state2 = CVDefinedVolume(op, 1, 100)
         volA = CVDefinedVolume(op, -100, 0.25)
         volB = CVDefinedVolume(op, -100, 0.50)
-        self.tisA = paths.TISEnsemble(state1, state2, volA)
-        self.tisB = paths.TISEnsemble(state1, state2, volB)
+        self.tisA = paths.TISEnsemble(state1, state2, volA,
+                                      orderparameter=op, lambda_i=0.25)
+        self.tisB = paths.TISEnsemble(state1, state2, volB,
+                                      orderparameter=op, lambda_i=0.50)
         self.traj0 = make_1d_traj([-0.1, 0.2, 0.3, 0.1, -0.2])
-        self.traj1 = make_1d_traj([-0.1, 0.1, 0.4, 0.6, 0.3, 0.2, -0.15]) 
+        self.traj1 = make_1d_traj([-0.1, 0.1, 0.4, 0.6, 0.3, 0.2, -0.15])
         self.traj2 = make_1d_traj([-0.1, 0.2, 0.3, 0.7, 0.6, 0.4, 0.1, -0.15])
         self.sampA0 = Sample(replica=0, trajectory=self.traj0, ensemble=self.tisA)
         self.sampB1 = Sample(replica=1, trajectory=self.traj1, ensemble=self.tisB)


### PR DESCRIPTION
This adds a new argument to `Ensemble.__call__`, called `candidate`. If `candidate is True`, then shortcuts can be used to calculate whether the trajectory is in the ensemble. The assumption is that this is a "candidate trajectory," as described in path ensemble theory; i.e., a trajectory that could have been generated by shooting. 

For example, this will allow us to assume that all frames except first and last are not in any state for a (flexible length) TPS ensemble or a TIS ensemble. For ensembles where there is no shortcut to be had, `candidate` just has no effect.

This is the first step toward using the generalized CVs of #662 in analysis (simply need to replace the `TISEnsemble`'s use of max(orderparameter(trajectory)) by a CV that stores that result). That will be a huge improvement on analysis speed. If the max lambda is known, a TIS `candidate` trajectory can be checked by looking at the first frame, the last frame, and the max lambda. Currently, we loop over all frames, find the max lambda, and check that only the first and last are actually in the state. This will also make a big difference for sampling speed for toy models.

Note that we'll still have the occasional `sanity_check` during simulation, which will *not* use the candidate assumption. This is just to make sure that nothing goes terribly awry during the sampling.

This `candidate` approach is very similar to what we already had as `trusted` for `can_append` and `can_prepend`. Unfortunately, there appear to be a couple cases where the `__call__` with `trusted=True` is being already being used in a way that would conflict with replacing `__call__`'s `trusted` with what I'm doing with `candidate`, so it looks like `candidate` might be separate from `trusted` (Annoying, because they're almost the same, and `__call__` with `trusted=True` almost never happens. When it does, it is deep in `SequentialEnsemble`, so there might be a way to fix it, but it'll take some thought.)

- [x] add `candidate` flag to `Ensemble.__call__`
- [x] add speed-up for `TISEnsemble` using `candidate`
- [x] tests for `TISEnsemble` using `candidate` (including where candidate is too trusting)
- [x] add the use of `candidate` in replica exchange checks, path reversal checks