### PR TITLE
Fix deserialization of `openmmtools.integrator`s

### DIFF
--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -13,13 +13,13 @@ logger = logging.getLogger(__name__)
 
 def restore_custom_integrator_interface(integrator):
     """
-    Restore the interface to a custom integrator. 
+    Restore the interface to a custom integrator.
 
     When subclasses of CustomIntegrator are deserialized, they only show up
     as `CustomIntegrator`, and therefore lose any additional interface
     provided by the subclass.
 
-    So far, only subclasses of `openmmtools.ThermostatedIntegrator` are
+    So far, only subclasses of `openmmtools.RestorableIntegrator` are
     supported. Hopefully, we can establish some sort of more widely-used
     approach based on the tricks established in there.
     """
@@ -29,10 +29,9 @@ def restore_custom_integrator_interface(integrator):
     except ImportError:  # pragma: no cover
         pass  # if openmmtools doesn't exist, can't restore interface
     else:
-        ThermostatedIntegrator = \
-                openmmtools.integrators.ThermostatedIntegrator
-        if ThermostatedIntegrator.is_thermostated(integrator):
-            success = ThermostatedIntegrator.restore_interface(integrator)
+        RestorableIntegrator = openmmtools.integrators.RestorableIntegrator
+        if RestorableIntegrator.is_restorable(integrator):
+            success = RestorableIntegrator.restore_interface(integrator)
             logger.debug("Restored interface to integrator: " + str(success))
             # this return a bool based on success; we could error on fail,
             # but I think it is better to just log it and use the integrator


### PR DESCRIPTION
When OpenMM deserializes subclasses of `CustomIntegrator`, it creates a `CustomIntegrator`, meaning that any additional methods defined in the subclass are lost. So, for example, we lose the `getTemperature()` method in `openmmtools.integrator.VVVRIntegrator`.

Fortunately, @andrrizzi came up with a nice solution for that in https://github.com/choderalab/openmmtools/pull/130. So all this does is wrap around his solution, and put it into a function that could be extended for integrators other than `openmmtools` (keeping the code in one place for readability). 

If the restored integrator isn't a subclass of `openmmtools.integrators.ThermostatedIntegrator`, or if, for some reason, the interface can't be restored, then nothing is different. If the interface can be restored, we'll have access to it.