### PR TITLE
Improvements on progress output

### DIFF
--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -908,15 +908,19 @@ class Ensemble(StorableNamedObject):
             the number of attemps on a trajectory to extend
         """
 
+        logger.info("Starting extend_sample_from_trajectories with level "
+                    + str(level))
         if level == 'native':
             sub_ensemble = self
         else:
             if not hasattr(self, 'extendable_sub_ensembles'):
+                logger.info("Missing ensemble.extendable_sub_ensembles")
                 return None
 
             sub_ensembles = self.extendable_sub_ensembles
 
             if level not in sub_ensembles:
+                logger.info("Missing level: " + repr(level))
                 return None
 
             sub_ensemble = sub_ensembles[level]
@@ -963,6 +967,7 @@ class Ensemble(StorableNamedObject):
                                 direction=-1
                             ).reversed + part[1:]
 
+                        logger.info("Candidate trajectory: " + str(part))
                         if self(part):  # make sure we found a sample
                             return paths.Sample(
                                 trajectory=part,
@@ -978,6 +983,7 @@ class Ensemble(StorableNamedObject):
                             # This should not happen!
                             pass
 
+        logger.info("Returning None because nothing worked")
         return None
 
     def _get_trajectory_parts_in_order(self, traj, unique='first'):

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -707,19 +707,13 @@ class PathSampling(PathSimulator):
 
                 paths.tools.refresh_output(
                     "Working on Monte Carlo cycle number " + str(self.step)
-                    + "\n"
-                    + "Running for %d seconds - %5.2f steps per second\n" % (
-                        elapsed,
-                        1.0 / time_per_step
-                    )
-                    + "Expected time to finish: %d seconds\n" % (
-                        1.0 * (n_steps - nn) * time_per_step
-                    ),
+                    + "\n" + paths.tools.progress_string(nn, n_steps,
+                                                         elapsed),
                     refresh=refresh,
                     output_stream=self.output_stream
                 )
 
-            time_start = time.time() 
+            time_start = time.time()
             movepath = self._mover.move(self.sample_set, step=self.step)
             samples = movepath.results
             new_sampleset = self.sample_set.apply_samples(samples)

--- a/openpathsampling/tests/test_tools.py
+++ b/openpathsampling/tests/test_tools.py
@@ -31,3 +31,11 @@ def test_pretty_print_seconds():
     # test separators
     assert_equal(pretty_print_seconds(93784, separator=", "),
                  "1 day, 2 hours, 3 minutes, 4 seconds")
+
+def test_progress_string():
+    assert_equal(progress_string(0, 100, 10),
+                 "Starting simulation...\nWorking on first step\n")
+    assert_equal(progress_string(1, 11, 9378.4),
+                 "Running for 2 hours 36 minutes 18 seconds - "
+                 + "9378.40 seconds per step\n"
+                 + "Estimated time remaining: 1 day 2.05 hours\n")

--- a/openpathsampling/tests/test_tools.py
+++ b/openpathsampling/tests/test_tools.py
@@ -1,25 +1,33 @@
 from nose.tools import assert_equal
 from openpathsampling.tools import *
 
+import logging
+logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
 def test_pretty_print_seconds():
     # test the basics with full reporting
     assert_equal(pretty_print_seconds(93784),
                  "1 day 2 hours 3 minutes 4 seconds")
     assert_equal(pretty_print_seconds(179990),
                  "2 days 1 hour 59 minutes 50 seconds")
+
     # test positive n_labels (including testing rounding)
     assert_equal(pretty_print_seconds(93784, n_labels=2),
                  "1 day 2 hours")
-    # assert_equal(pretty_print_seconds(179990, n_labels=2),
-                 # "2 days 2 hours")
-    # assert_equal(pretty_print_seconds(179990, n_labels=3),
-                 # "2 days 2 hours 0 minutes")
+    assert_equal(pretty_print_seconds(179990, n_labels=2),
+                 "2 days 2 hours")
+    assert_equal(pretty_print_seconds(179990, n_labels=3),
+                 "2 days 2 hours 0 minutes")
 
     # test negative n_labels
     assert_equal(pretty_print_seconds(93784, n_labels=-1),
                  "1.09 days")
     assert_equal(pretty_print_seconds(93784, n_labels=-2),
                  "1 day 2.05 hours")
+
     # test separators
     assert_equal(pretty_print_seconds(93784, separator=", "),
                  "1 day, 2 hours, 3 minutes, 4 seconds")

--- a/openpathsampling/tests/test_tools.py
+++ b/openpathsampling/tests/test_tools.py
@@ -13,6 +13,8 @@ def test_pretty_print_seconds():
                  "1 day 2 hours 3 minutes 4 seconds")
     assert_equal(pretty_print_seconds(179990),
                  "2 days 1 hour 59 minutes 50 seconds")
+    assert_equal(pretty_print_seconds(31),
+                 "31 seconds")
 
     # test positive n_labels (including testing rounding)
     assert_equal(pretty_print_seconds(93784, n_labels=2),
@@ -21,12 +23,16 @@ def test_pretty_print_seconds():
                  "2 days 2 hours")
     assert_equal(pretty_print_seconds(179990, n_labels=3),
                  "2 days 2 hours 0 minutes")
+    assert_equal(pretty_print_seconds(31, n_labels=2),
+                 "31 seconds")
 
     # test negative n_labels
     assert_equal(pretty_print_seconds(93784, n_labels=-1),
                  "1.09 days")
     assert_equal(pretty_print_seconds(93784, n_labels=-2),
                  "1 day 2.05 hours")
+    assert_equal(pretty_print_seconds(31, n_labels=-2),
+                 "31 seconds")
 
     # test separators
     assert_equal(pretty_print_seconds(93784, separator=", "),

--- a/openpathsampling/tests/test_tools.py
+++ b/openpathsampling/tests/test_tools.py
@@ -1,0 +1,25 @@
+from nose.tools import assert_equal
+from openpathsampling.tools import *
+
+def test_pretty_print_seconds():
+    # test the basics with full reporting
+    assert_equal(pretty_print_seconds(93784),
+                 "1 day 2 hours 3 minutes 4 seconds")
+    assert_equal(pretty_print_seconds(179990),
+                 "2 days 1 hour 59 minutes 50 seconds")
+    # test positive n_labels (including testing rounding)
+    assert_equal(pretty_print_seconds(93784, n_labels=2),
+                 "1 day 2 hours")
+    # assert_equal(pretty_print_seconds(179990, n_labels=2),
+                 # "2 days 2 hours")
+    # assert_equal(pretty_print_seconds(179990, n_labels=3),
+                 # "2 days 2 hours 0 minutes")
+
+    # test negative n_labels
+    assert_equal(pretty_print_seconds(93784, n_labels=-1),
+                 "1.09 days")
+    assert_equal(pretty_print_seconds(93784, n_labels=-2),
+                 "1 day 2.05 hours")
+    # test separators
+    assert_equal(pretty_print_seconds(93784, separator=", "),
+                 "1 day, 2 hours, 3 minutes, 4 seconds")

--- a/openpathsampling/tools.py
+++ b/openpathsampling/tools.py
@@ -143,7 +143,9 @@ def pretty_print_seconds(seconds, n_labels=0, separator=" "):
     if n_labels != 0 and abs(n_labels) < n_labels_real:
         n_labels_real = abs(n_labels)
 
-    max_label_index = first_key_index + (len(ordered_keys) - n_labels_real)
+    max_label_index = first_key_index + len(ordered_keys) - n_labels_real
+    if max_label_index >= len(ordered_keys):
+        max_label_index = len(ordered_keys) - 1
     max_label = ordered_keys[max_label_index]
 
     if first_key != "second" and n_labels > 0:

--- a/openpathsampling/tools.py
+++ b/openpathsampling/tools.py
@@ -86,3 +86,115 @@ def word_wrap(string, width=80):
 
         result.append(line)
     return '\n'.join(result)
+
+
+def pretty_print_seconds(seconds, n_labels=0, separator=" "):
+    """
+    Converts a number of seconds to a readable time string.
+
+    Parameters
+    ----------
+    seconds : float or int
+        number of seconds to represent, gets rounded with int()
+    n_labels : int
+        number of levels of label to show. For example, if n_labels=1,
+        result will show the first of days, hours, minutes, seconds with
+        greater than one. This allows you to round, e.g, 1 day 2 hours
+        3 minutes 4 seconds to 1 day 2 hours (with n_labels=2). Default
+        value of 0 gives all levels. If n_labels is negative, then the last
+        value is shown as a decimal, instead of an int, with 2 decimals of
+        precision.
+    separator : string
+        separator between levels of the time decomposition
+    on_zero : string
+        string to return in the case of 0 seconds
+    """
+    ordered_keys = ['day', 'hour', 'minute', 'second']
+    divisors = {
+        'day': 86400,
+        'hour': 3600,
+        'minute': 60,
+        'second': 1
+    }
+
+    s = int(seconds)
+
+    parts = {}
+    fractional_parts = {}
+    for k in ordered_keys:
+        fractional_parts[k] = float(s) / divisors[k]
+        parts[k], s = divmod(s, divisors[k])
+
+    part_labels = {k: k if parts[k] == 1 else k + "s"
+                   for k in ordered_keys}
+
+    decimalize_final = (n_labels < 0)
+
+    first_key = "second"
+    for key in ordered_keys:
+        if parts[key] > 0:
+            first_key = key
+            break
+    first_key_index = ordered_keys.index(first_key)
+
+    max_labels = len(ordered_keys) - first_key_index
+    if n_labels != 0 and abs(n_labels) < max_labels:
+        max_labels = abs(n_labels)
+
+    label_count = 0
+    output_str = ""
+    for key in ordered_keys[first_key_index:]:
+        part = parts[key]
+        label_str = part_labels[key]
+        frac = fractional_parts[key]
+        if part > 0 and label_count < max_labels - 1:
+            output_str += str(part) + " " + label_str + separator
+            label_count += 1
+        elif label_count == max_labels - 1:
+            if decimalize_final and key != 'second':
+                output_str += "%.2f %s" % (frac, key+'s')
+            else:
+                output_str += str(int(round(frac))) + " " + label_str
+            label_count += 1
+
+    return output_str
+
+
+def progress_string(n_steps_completed, n_steps_total, time_elapsed):
+    """
+    String to report on simulation progress.
+
+    Assumes that the average time per Monte Carlo/trajectory-level step is
+    constant throughout the simulation. These are trajectory-level steps in
+    to distinguish them from molecular dynamics (time) steps -- in path
+    sampling these are Monte Carlo steps; in order simulations (committor)
+    they might not be.
+
+    Parameters
+    ----------
+    n_steps_completed : int
+        number of (Monte Carlo/trajectory-level) steps already completed
+    n_steps_total : int
+        total number of (Monte Carlo/trajectory-level) step in simulation
+    time_elapsed : float-like
+        time elapsed in the simulation, in seconds
+
+    Returns
+    -------
+    str :
+        string to output describing simulation progress, including estimated
+        time remaining
+    """
+    try:
+        time_per_step = time_elapsed / n_steps_completed
+    except ZeroDivisionError:
+        return "Starting simulation...\nWorking on first step\n"
+    time_to_finish = (n_steps_total - n_steps_completed) * time_per_step
+    output_str = (
+        "Running for " + pretty_print_seconds(time_elapsed) + " - "
+        + "%5.2f seconds per step\n" % (time_per_step)
+        + "Estimated time remaining: %s\n" % (
+            pretty_print_seconds(time_to_finish, n_labels=-2)
+        )
+    )
+    return output_str


### PR DESCRIPTION
This PR fixes a few minor annoyances with the progress output during a path sampling simulation. In particular, it includes the following:

- [x] Switch the speed reporting from "steps per second" to "seconds per step": TPS simulations of large systems have less than 0.01 steps per second, so the old version was uninformative; even our fast systems are around  0.1-0.2 seconds per step
- [x] Convert times (elapsed and remaining) from seconds to days, hours, minutes, seconds (easier to interpret once you get to tens of thousands of seconds remaining)
- [x] Move the whole progress string generation into `paths.tools`, so that it can be re-used by other objects. Just needs the time elapsed, the steps completed, and the total number of steps
- [x] Unit tests for new code

New output looks something like this:

```
Working on Monte Carlo cycle number 215
Running for 1 minute 44 seconds -  0.91 seconds per step
Estimated time remaining: 5 hours 2.52 minutes
```

The time elapsed is always the full string (`1 day 2 hours 3 minutes 4 seconds`). The time remaining always contains the first two (occupied) "levels" (day, hour, minute, second) with the remainder to 2 decimal places in the last. So (`1 day 2.05 hours`, or as above, `5 hours 2.52 minutes`). I thought this would be the most readable (and it acknowledges that the time elapsed is exact, whereas the time remaining is a rough estimate).