### PR TITLE
Resampling statistics

### DIFF
--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -411,7 +411,7 @@
    },
    "outputs": [],
    "source": [
-    "resampling = paths.numerics.BlockResampling(storage.steps, n_blocks=1)"
+    "resampling = paths.numerics.BlockResampling(storage.steps, n_blocks=n_blocks)"
    ]
   },
   {

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -23,7 +23,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mistis.nc\n"
+      "../toy_mistis_1k_OPS1.nc\n"
      ]
     }
    ],
@@ -370,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -382,13 +382,36 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "n_blocks = 2  # for testing code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#! skip\n",
+    "n_blocks = 10 # for real examples"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "resampling = paths.numerics.BlockResampling(storage.steps, n_blocks=10)"
+    "resampling = paths.numerics.BlockResampling(storage.steps, n_blocks=1)"
    ]
   },
   {

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "# if our large test file is available, use it. Otherwise, use file generated from toy_mistis_1_setup_run.ipynb\n",
     "import os\n",
-    "test_file = \"\" #\"../toy_mistis_1k_OPS1.nc\"\n",
+    "test_file = \"\"../toy_mistis_1k_OPS1.nc\"\n",
     "filename = test_file if os.path.isfile(test_file) else \"mistis.nc\""
    ]
   },
@@ -289,7 +289,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "trans = mistis.transitions.values()[2]\n",
@@ -381,7 +383,9 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "resampling = paths.numerics.BlockResampling(storage.steps, n_blocks=10)"

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -388,7 +388,7 @@
    },
    "outputs": [],
    "source": [
-    "n_blocks = 2  # for testing code"
+    "n_blocks = 1  # for testing code"
    ]
   },
   {

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -2,21 +2,38 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "# if our large test file is available, use it. Otherwise, use file generated from toy_mstis_2_run.ipynb\n",
+    "# if our large test file is available, use it. Otherwise, use file generated from toy_mistis_1_setup_run.ipynb\n",
     "import os\n",
-    "test_file = \"../toy_mistis_1k_OPS1.nc\"\n",
+    "test_file = \"\" #\"../toy_mistis_1k_OPS1.nc\"\n",
     "filename = test_file if os.path.isfile(test_file) else \"mistis.nc\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mistis.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "print filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -30,20 +47,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5min 6s, sys: 13 s, total: 5min 19s\n",
+      "Wall time: 5min 24s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "storage = paths.AnalysisStorage(filename)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -52,18 +77,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "True <openpathsampling.ensemble.TISEnsemble object at 0x126b23a10>\n",
-      "True <openpathsampling.ensemble.TISEnsemble object at 0x12b8903d0>\n",
-      "True <openpathsampling.ensemble.TISEnsemble object at 0x12b8bfad0>\n"
+      "True <openpathsampling.ensemble.TISEnsemble object at 0x14adf15d0>\n",
+      "True <openpathsampling.ensemble.TISEnsemble object at 0x14b764f50>\n",
+      "True <openpathsampling.ensemble.TISEnsemble object at 0x14c283890>\n",
+      "True <openpathsampling.ensemble.TISEnsemble object at 0x14c283d50>\n",
+      "True <openpathsampling.ensemble.TISEnsemble object at 0x14b764710>\n",
+      "True <openpathsampling.ensemble.TISEnsemble object at 0x149f58d10>\n"
      ]
     }
    ],
@@ -75,32 +101,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "mistis.hist_args['max_lambda'] = { 'bin_width' : 0.02, 'bin_range' : (-0.3, 0.5) }\n",
+    "mistis.hist_args['max_lambda'] = { 'bin_width' : 0.01, 'bin_range' : (-0.35, 0.5) }\n",
     "mistis.hist_args['pathlength'] = { 'bin_width' : 5, 'bin_range' : (0, 150) }"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ms_outer_shooting ran 4.250% (expected 4.67%) of the cycles with acceptance 13/17 (76.47%)\n",
-      "repex ran 19.250% (expected 21.03%) of the cycles with acceptance 48/77 (62.34%)\n",
-      "shooting ran 47.000% (expected 46.73%) of the cycles with acceptance 112/188 (59.57%)\n",
-      "minus ran 2.750% (expected 1.87%) of the cycles with acceptance 2/11 (18.18%)\n",
-      "pathreversal ran 26.750% (expected 25.70%) of the cycles with acceptance 48/107 (44.86%)\n"
+      "pathreversal ran 25.340% (expected 25.38%) of the cycles with acceptance 21227/25340 (83.77%)\n",
+      "ms_outer_shooting ran 2.515% (expected 2.54%) of the cycles with acceptance 1551/2515 (61.67%)\n",
+      "shooting ran 48.273% (expected 48.22%) of the cycles with acceptance 36226/48273 (75.04%)\n",
+      "minus ran 0.974% (expected 1.02%) of the cycles with acceptance 722/974 (74.13%)\n",
+      "repex ran 22.898% (expected 22.84%) of the cycles with acceptance 8332/22898 (36.39%)\n"
      ]
     }
    ],
@@ -111,17 +135,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Minus ran 1.500% (expected 0.93%) of the cycles with acceptance 0/6 (0.00%)\n",
-      "Minus ran 1.250% (expected 0.93%) of the cycles with acceptance 2/5 (40.00%)\n"
+      "Minus ran 0.486% (expected 0.51%) of the cycles with acceptance 236/486 (48.56%)\n",
+      "Minus ran 0.488% (expected 0.51%) of the cycles with acceptance 486/488 (99.59%)\n"
      ]
     }
    ],
@@ -131,7 +153,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ReplicaExchange ran 1.312% (expected 1.27%) of the cycles with acceptance 725/1312 (55.26%)\n",
+      "ReplicaExchange ran 1.246% (expected 1.27%) of the cycles with acceptance 334/1246 (26.81%)\n",
+      "ReplicaExchange ran 1.280% (expected 1.27%) of the cycles with acceptance 530/1280 (41.41%)\n",
+      "ReplicaExchange ran 1.372% (expected 1.27%) of the cycles with acceptance 269/1372 (19.61%)\n",
+      "ReplicaExchange ran 1.190% (expected 1.27%) of the cycles with acceptance 617/1190 (51.85%)\n",
+      "ReplicaExchange ran 1.274% (expected 1.27%) of the cycles with acceptance 519/1274 (40.74%)\n",
+      "ReplicaExchange ran 1.266% (expected 1.27%) of the cycles with acceptance 280/1266 (22.12%)\n",
+      "ReplicaExchange ran 1.307% (expected 1.27%) of the cycles with acceptance 366/1307 (28.00%)\n",
+      "ReplicaExchange ran 1.225% (expected 1.27%) of the cycles with acceptance 548/1225 (44.73%)\n",
+      "ReplicaExchange ran 1.320% (expected 1.27%) of the cycles with acceptance 550/1320 (41.67%)\n",
+      "ReplicaExchange ran 1.273% (expected 1.27%) of the cycles with acceptance 420/1273 (32.99%)\n",
+      "ReplicaExchange ran 1.275% (expected 1.27%) of the cycles with acceptance 322/1275 (25.25%)\n",
+      "ReplicaExchange ran 1.270% (expected 1.27%) of the cycles with acceptance 269/1270 (21.18%)\n",
+      "ReplicaExchange ran 1.277% (expected 1.27%) of the cycles with acceptance 612/1277 (47.92%)\n",
+      "ReplicaExchange ran 1.288% (expected 1.27%) of the cycles with acceptance 412/1288 (31.99%)\n",
+      "ReplicaExchange ran 1.221% (expected 1.27%) of the cycles with acceptance 651/1221 (53.32%)\n",
+      "ReplicaExchange ran 1.251% (expected 1.27%) of the cycles with acceptance 538/1251 (43.01%)\n",
+      "ReplicaExchange ran 1.251% (expected 1.27%) of the cycles with acceptance 370/1251 (29.58%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "scheme.move_summary(storage.steps, 'repex')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -148,26 +204,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "# got these from mistis_flux.ipynb\n",
-    "fluxes = {(stateA, inner_AB): 0.00134206626387,\n",
-    "          (stateA, inner_AC): 0.00130918783318,\n",
-    "          (stateB, inner_BA): 0.00129306050463}\n",
+    "fluxes = {(stateA, inner_AB): 0.00183239948364,\n",
+    "          (stateA, inner_AC): 0.00183054222139,\n",
+    "          (stateB, inner_BA): 0.00183376505796}\n",
     "mistis.set_fluxes(fluxes)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/dwhs/Dropbox/msm-tis/openpathsampling/numerics/wham.py:334: RuntimeWarning: invalid value encountered in divide\n",
+      "  addends_k = np.divide(numerator_byQ, sum_over_Z_byQ)\n",
+      "/Users/dwhs/Dropbox/msm-tis/openpathsampling/numerics/wham.py:407: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  output[val] = sum_k_Hk_Q[val] / sum_w_over_Z\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 16min 58s, sys: 7.36 s, total: 17min 6s\n",
+      "Wall time: 17min 15s\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -176,85 +248,74 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
-       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
-       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0.3, inf]})</th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
+       "      <th>B</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>0.000462027</td>\n",
        "      <td>NaN</td>\n",
+       "      <td>4.57922e-06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-inf, -0.3]})</th>\n",
-       "      <td>0.000722619</td>\n",
+       "      <th>A</th>\n",
+       "      <td>4.88144e-06</td>\n",
+       "      <td>6.03211e-06</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>0.000167723</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                                   ({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-inf, -0.3]})  \\\n",
-       "({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-in...                                                NaN          \n",
-       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-...                                        0.000722619          \n",
-       "\n",
-       "                                                   ({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-inf, -0.3]})  \\\n",
-       "({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-in...                                        0.000462027            \n",
-       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-...                                                NaN            \n",
-       "\n",
-       "                                                   ({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [0.3, inf]})  \n",
-       "({x|opX(x) in [0.3, inf]} and {x|opY(x) in [-in...                                                NaN         \n",
-       "({x|opX(x) in [-inf, -0.3]} and {x|opY(x) in [-...                                        0.000167723         "
+       "             B            C            A\n",
+       "B          NaN          NaN  4.57922e-06\n",
+       "A  4.88144e-06  6.03211e-06          NaN"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "%%time\n",
     "mistis.rate_matrix(storage.steps, force=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "trans = mistis.transitions.values()[0]\n",
+    "trans = mistis.transitions.values()[2]\n",
     "trans_hists = trans.histograms['max_lambda']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x132cbcc10>]"
+       "[<matplotlib.lines.Line2D at 0x1de203110>]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEACAYAAABI5zaHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAH0dJREFUeJzt3X98XHWd7/HXZzKZTH5OmrRNmqYFQmkRqbblN6wY5VFF\nWQuouMIKoohc94JcXZRdUYlcV9G7CHiVe3dh8frjepErK6KCtCjpfSxCQaC0CP1BW6C/f9O0aX7n\ne/+YlKY0yUzmnDNn5uT9fDzmwWTmnDOfL0ne+fZ7vud7zDmHiIhESyzsAkRExH8KdxGRCFK4i4hE\nkMJdRCSCFO4iIhGkcBcRiSBfwt3MzjezVWa2xsxu9OOYIiKSO/M6z93MYsAa4DxgC/AM8HHn3Crv\n5YmISC786LmfDqx1zr3mnOsD7gMu9OG4IiKSIz/CfTqwcdjXm4ZeExGRkOiEqohIBMV9OMZmYOaw\nr5uHXjuCmWkRGxGRHDjnbLz7+BHuzwCzzOwYYCvwceDSkTYMe5GydTv6mP3EM9zTeDKfOqvG12O3\ntbXR1tZG70AvS19dykOrH+JPm/7EoBv09XPCsvU3W5n2oWkZt3POMegGmbLrINc8vJPzVh7gnnOr\nuPvsMjoT4/75zIv9Sw5QvbAqL5/VO9DLKdNPZfEVS/LyeXD4ZzOqot4+s9x+bzyHu3NuwMyuBRaT\nHub5N+fcy16PG4Tjp5byWdfCf163hktPXUCy1P9RqURJgoXHL2Th8Qt9P3aY2ra20XZN2/h2+hqw\nZg03trVxY9v9MFiYf+janKPtD135+TDnWDp3GVyRn4+TicuXdHPO/d45N8c5d4Jz7lY/jhmUH17U\nQLIvzsd/cdTIkQRh9mz4+c+hvz8d7oX4uPnmvH3WpqcfY8a2PP0hkQltwp1QjcWM/3PGbB6qeY1l\nG7p9O25ra6tvxypEUW5fPttWOXMWU/f1Qx6HKKP8vYPoty9Xni9iyvqDzFzYY+7Dved/vcrq/gNs\n+czJYZciE8jAQD9dFaVU7NhLLFUbdjlSBMwspxOqE67nfsiv/2Ymu6o6+crvdoVdikwgJSVxtlUb\nna+uDbsUibgJG+415TFubZjNd7vXsm1ff9jlyASyszZB5+uvhF2GRJwfUyGL1hffM4n/ec8kpj3x\nJNZ/5L96SnriLDtjPgtmloVUnUTV3klJpm98NewyJOImdLgDvPSpOazb2XLU63/92/Xc1L6dR66Y\nOcJeIrnbV19F/6bXwy5DIm7Ch3u8xJjTmDjq9RtOnMbnN65mcHAGsVhhXnwjxalzcg1s2RJ2GRJx\nE3bMPZOrz67BxRw/WrY/7FIkYnqm1BHbui3sMiTiFO6jiMWMd3c38r2/6JdQ/NXbMJnEds3SkmAp\n3Mdwy7saeLlhB28cHAi7FIkQN20ayV1vhF2GRJzCfQxntSSZtLOamxfvDrsUiRBraqJqV0der1KV\niUfhnsHf1Dby8z0amhH/VNY1MFBisG9f2KVIhCncM7hl4WR2T+ngudd7wi5FIiJVlmL3pKRmzEig\nFO4ZTK4uYfb2KXy1fXvYpUhE1CZr2ZkqVbhLoBTuWbh+TiN/KN3G4KDGSMW7VDLFtmpTuEugFO5Z\nuOac9Jz3H2vOu/igNlnL5qpBhbsESuGehVjMOLe7gds05118kCpL8VplH2zdGnYpEmEK9yz913c1\n8tKwOe/OOVYcOMBN69dz8tNP87cvvcQT+/aFfp9YKXy1yVo2lPeo5y6BmvBry2TrrJYktUur+Ls/\nbGbWSQP83107OTg4wCWTp3LXrDk829nBlatWURmL8XfTp/O3DQ1UlpSEXXbedA4M8Gp3N693d3NM\nMsmJFRXEcryxb9Ql40k2VQ0y+NIm9a4kMAr3cfjM1Cb+W+c67I7JWPsceLmGOzBud3DZZSn+47Zm\nXojv5a7Nm/nH9eu5oL6eilh0f307BgbY0N3N+q4uOgYGODaZpLmsjPVdXezu6+PU6mrOqKnhzJoa\n3l5ZSVxhD8CkeJzOySncFt3HV4IzYW+z56fOzvQ9ln/6U7j1VrjyStjY082je/YwENE2A1SWlNBS\nXs5xySSNicQRPfWdvb08vX8/yzo6WNbRwaqDB4nu/4ns9Q4OclJlJTv+8BFWfGUjse4e0B89GUOu\nt9lTuPvo+efh6quhuhr+5V9g9uywK5JC88rBg7x/xQrqVl7Hk19aTXzdBqivD7ssKWC5hruGZXw0\nfz4sWwY/+AGcfTZ8/OP6vZUj9cbK2HRuL8eWpeieUkfVli36IZFAKNx9VlIC118PF1+cHqbp1+1Z\nZZiBzhL6DhqV5Q10TtlB1datMHdu2GVJBCncAzJzJtx0U9hVSKFxDm7/32X0lDayr24DDZoOKQGJ\n7lQOkQJkBvWUsatjMnsnlWuuuwRG4S6SZ8dWJdi5v46dtVo8TIKjcBfJs3c0lbGrs4YdNTGFuwTG\nU7ib2UfN7EUzGzCzBX4VJRJlc5sS9CWqWBfX4mESHK8995XAxcBSH2oRmRCml5VRPS3JC30DCncJ\njKfZMs651QBmusROJFvTy8oorS/lxf5u2L4dBgchwstUSDj0EyWSZ02JBH2Vxrbe/enLmXfrBuzi\nv4w9dzNbAjQMfwlwwE3Oud8EVZhIVDUmEhwwR3/JPvqmNlG6ZQtMmRJ2WRIxGcPdObfQrw9ra2t7\n83lrayutra1+HVqkaJTGYkyKx9lTa+xONNG4ZQu8851hlyUFor29nfb2ds/H8WXhMDN7HLjBOffs\nGNtEfuEwkWzN//MzLF96BX+65wzOuuFdcNVVYZckBSrXhcO8ToW8yMw2AmcCvzWzR7wcT2SiaC5L\nkihvYsXeyZoxI4HwOlvmQeBBn2oRmTCaEgkqqmawujtF9/otJMMuSCJHs2VEQtBUVka8vIGyE6vZ\n+5JulC3+U7iLhGB6IkGsbCo188rpfU3DMuI/hbtICJrKyhhM1FF7aoLkHoW7+E/hLhKCpkSC/ngN\nlXNjTOrbwb49A2GXJBGjcBcJwfSyMrpLqthvB+gsreWZh3eGXZJEjMJdJAT1paX0Ucqu7g566pr4\nyxINzYi/FO4iIYiZUW19bO7ppvTYJl5/SuEu/lK4i4SkLjbI9r5+Uic20fPqVg4cCLsiiRLdIFsk\nJJPjxs5+R3xmE/Mbt3DBBZBKZbfvddfBQt9WfZIoUriLhKQxEWf1YAyamvjoWc8z5bLs9nvpJfj6\n1xXuMjaFu0hIpifKeMaVQlMTqc7fsWhRdvt98INwxx2wdi2ccEKwNUrx0pi7SEiOKa+k08ph2rRx\nLR4Wj8Oll8JPfxpgcVL0FO4iITm2oobukkpoahr3ypCXX54O98HBgIqToqdwFwnJ7KpJ9MVroaEh\nfau9/v6s950/Hyor4YknAixQiprCXSQkLRU1uEQdPQxAfT3s2JH1vmZwxRXwk58EWKAUNYW7SEhq\n4nHA2Hxwb05DM5ddBg88AF1dwdQnxU2zZURCYmaU9r/B6v17aGluhk9/Gurqst6/GXjcwf5TobzQ\n76+dSMA3vwmnnx52JROGwl0kRGUDB9jQ1QE//CG88sq499++GO57HL7d5n9tvlq/Hi64AO66Cy65\nJOxqJgSFu0iIKl0Xr3V1wqxmaG4e9/5nnwofuwu+cBJMnRpAgX5pbU2fBb7wQlizBr7ylfSJAwmM\nxtxFQlRDL5u7u3Pev6oKFi2C++7zsaigzJ8PTz0FDz6YPhvc0xN2RZGmcBcJ0aTYIFv7+jwd4/LL\ni2jWTFMTLF2aPgt83nnpk8hdXUc+PPyxk8MU7iIhmlwCu/qdp2O8972wdWt6zZmiUFEB998P7353\nev2EurojH5WV8Mc/hl1l0VO4i4SoMRFn94C3X8OSEvjEJ4psOYJYDP7pn6Cz8+ie+1VXpRfOEU90\nQlUkRE2JMjq6Sz0f5/LL4X3vg8ZGH4oKQEUFfPKT6RmRGc2YARs3Bl5T1CncRUI0s7yCzp4yBp0j\n5mH2yMknww03pGccFqKlS9PnT6+9NouNm5vTO4gnCneREE1Opoi7Xnb19TE1q27t6L74RZ+KCsDy\n5fCBD8CVV6Zn+IypuRk2bcpHWZGmMXeRENUmaynt72BLxKcFzpsH73lPeh36jBTuvlC4i4QolUwR\n693D5t7esEsJ3C23pMN99+4MGzY3p8fcnbdZRBOdwl0kRLXJWlzPzsj33AFmzYKPfQxuvTXDhtXV\nUFoKb7yRl7qiylO4m9l3zexlM1tuZg+YWY1fhYlMBKmyFP3d29kyAXruAF/7Gtx7bxajLhqa8cxr\nz30x8Hbn3DxgLfCP3ksSmThSyRQ9BzezaQL03CF9R8HPfha+8Y0MGyrcPfMU7s65x5xzh2709RTp\nVUhFJEvxWJxEfwcbuw6GXUrefPnL6eVlVq0aYyPNdffMzzH3TwOP+Hg8kQmhxvrY3DNx7rgxaVJ6\nTv7XvjbGRuq5e5ZxnruZLQEahr8EOOAm59xvhra5Cehzzv18rGO1tbW9+by1tZXW1tbxVywSMbWx\nfrb0els8rNhcd116WZk//xlOPXWEDZqbJ+wNYtvb22lvb/d8HHMepxuZ2ZXA1cB7nXOjDhyamfP6\nWSJRdPa9f8UzLd/k4LnnUhqbOBPY7roLHnsM/v3fR3jz0Ufhtttg8eK811VozAzn3LgvX/Y6W+Z8\n4EvAorGCXURGV1tWQyo2yLYJMmPmkIsvhvZ2GBwc4U2NuXvmtZvw34EqYImZPWdmd/lQk8iEUpus\nJWX9bJ4gM2YOmTYNamth9eoR3tSFTJ55WlvGOXeCX4WITFSpshQpurhg5UqSWQ7LfLKxkW+1tARc\nWfDOPjs9tP62t73ljZqa9LLAHR2QSoVSW7HTwmEiIatN1nKRW8VVp/+XrLbvGhhg0YsvMi2R4Loc\n7rtaSM45B/70J/jMZ0Z489CMGYV7ThTuIiFLJVPs7drD9LKyrPd5eO5czn7+eY5JJlk0eXKA1QXH\nOccpZw1yxx0lI29waGjm7W/Pb2ERMXFOzYsUqNpkLft69o1rn2PLy/n1ySdz1erVPLt/f0CVBWdd\nVxfnvfACn+j5M1v3DrBz5wgbzZihue4eKNxFQpYqS/FG9/gXyTqtpoa7Z89m0cqVvFYkN5UecI47\nN23ijGef5YL6ek6rrmbSl9fz5JMjbKwLmTzRsIxIyHLpuR9y0ZQpvNbTwwUrVvDEggWk4oX7K72q\ns5OrVq+mxIwnFyzghIoK9vb1cczcZ/j58sksWjTpyB2am2HZsnCKjYDC/UkQmSBSydx67odc39zM\nuq4uPrRyJRcW6Pj79t5e7t26lW8cdxyfa2p685aCk0pL+Yf4HG6ZvYqO/tOoGf7HqbkZfvnLkCou\nfgp3kZDVJmvZ151bz/2Q22fN4p83bizYdeFLzXjmlFM4rrz8qPeuO72em79VxxfmrOPfTppz+A2N\nuXuicBcJWa5j7sOVmHHjzJk+VZRf1dXwtseP5+H3P8MjDbv5QH19+g2NuXuiE6oiIfMy5h4V7zol\nzoVrTuSza9awt29oEbVUCgYG0hcyybgp3EVCVlFaQe9AL30DE2tlyOHOOQd2PjqJiydP5vOvvJJ+\n0Uy9dw8U7iIhMzNSZakJ3Xs/55z0MgTfPq6Fpzo6ePjQXbQ17p4zhbtIAfA6Y6bYzZwJJSWw7bUS\nvnf88dy4fj0Dzqnn7oHCXaQApMpSnmfMFDOzw+vM/HV9PbXxOD/bvl3h7oHCXaQA1CZrJ3TPHQ6v\nEGlmfKelha9v2EC3hmVypqmQIgVgSuUULv/V5VQlqsIuJRBl8TIe/+TjTK4Y/SKrc86Be+9NPz87\nlWJ+VRU/PPZY/v5Xv8pTldGicBcpAHd/6G62HdgWdhmB+cj9H2HD3g1jhvu8ebB+PbzxRvomHt9q\naaF1zx6u2r2b2jzWGhUKd5ECUFNWQ01ZTdhlBGZGzQy2d24fc5vS0vTNspctg/e/H06qrGRRbS3f\nOeMMvp2nOqNEY+4iEriGqga2Hxg73OHwuPshbXPm8K8LF7J5z54Aq4smhbuIBK6hsiFjzx0Oz5g5\npDmZ5OonnqBt7doAq4smhbuIBK6hMrue+1lnwdNPQ3//4ddufPFFHjx4kJc7OwOsMHo05i4igWuo\namDZ5sxrs9fVpae2X3tt+qQqwCWvT+b8pXs5b98qZu45+tTqNfPq+dQCnXJ9K/XcRSRw2Q7LANx5\nJxx7bDrca2uhZ3IzVyx7mVPeaKA2Hj/i8cbGOI//XjE2EvXcRSRw2Z5QBVi4MP14U6oZli9n4ZXN\nR237y1/Cz37mU5ERoz95IhK48fTcjzLGVapz5sDq1R4KizCFu4gErr6ino6ejtyWNR5jfZlZs2DD\nhiNPwEqawl1EAhezGPXl9ezo3DH+nccI9/JyaGyEV1/1Vl8UKdxFJC8aqnIcmqmvh4MH048RzJkD\na9Z4LC6CFO4ikhfZznU/SoY7Ms2erXH3kXgKdzO7xcxeMLPnzez3ZtboV2EiEi0599xhzHDXSdWR\nee25f9c5907n3Hzgd8DNPtQkIhGUc88dMoa7hmWO5incnXMHhn1ZCQx6K0dEosrTdMjmZti4ccS3\nNCwzMs9j7mb2TTN7HbgM+Lr3kkQkioIalpkxA/buhf37PRQXQRmvUDWzJUDD8JcAB9zknPuNc+6r\nwFfN7EbgOqBttGO1tR1+q7W1ldbW1pyKFpHi01DZkNtUSEgn+O9/P+JbsRiccAKsXQsLFngosEC0\nt7fT3t7u+TjmnPNeDWBmM4CHnXNzR3nf+fVZIlJ8lm9bzhW/uoIVn1sx/p2few6uugqef37Ety+5\nBD78Ybj0Uo9FFiAzwzln493P62yZWcO+vAh42cvxRCS6PI25T5kCO3eO+rZmzBzN68Jht5rZbNIn\nUl8D/pP3kkQkiqZUTmFP1x4GBgcoiZWMb+eamjEH1efMgUce8VhgxHgKd+fcR/0qRESiLR6LU5us\nZdfBXTRUNWTeYbiqKjhwAJxLX9T0FrNnwx13+FRoROgKVRHJm5yHZkpKIJmEUe7GdGiuu07rHaZw\nF5G8Gc+67keprh51aKa2FioqYOtWD8VFjMJdRPLG00nVMcIddDHTWyncRSRvPC1BkCHctQzBkRTu\nIpI3nq5SVc99XBTuIpI3UyunBhbumut+JIW7iOSNhmXyR+EuInkT5LBMS0t64cje3hyLixiFu4jk\nTZA990Qivb7YunU5FhcxCncRyZuplVPZeXAngy6HWz9kCHfQ0MxwCncRyZuyeBlViSr2dO0Z/85Z\nhLtmzBymcBeRvMp5Xfcse+4K9zSFu4jkVc5LEGhYZlwU7iKSVzkvQaBhmXFRuItIXuU8YyaLcJ82\nDbq70/dUnegU7iKSVznPdc8i3M3SvXcNzSjcRSTPguy5g4ZmDlG4i0heBdlzB51UPUThLiJ5FeQJ\nVdB0yEMU7iKSVzlPhayogJ4e6O8fczMNy6Qp3EUkrw4t++vGe8NTs6ynQ77yCgzmsMJBlCjcRSSv\nKkorSJQk2Nezb/w7ZxHuVVVw553Q15djgRGhcBeRvAt6xszVV0NZWQ6FRYjCXUTyLugZM6JwF5EQ\nBN1zF4W7iIQg6OmQonAXkRAEuTKkpCncRSTvglzTXdJ8CXcz+3szGzSzOj+OJyLRphOqwfMc7mbW\nDCwEXvNejohMBBpzD54fPffbgS/5cBwRmSA05h48T+FuZouAjc65lT7VIyITgHruwYtn2sDMlgAN\nw18CHPBV4Cukh2SGvzeqtra2N5+3trbS2tqafaUiEhlViSqccxzoPUBVoir7HSdAuLe3t9Pe3u75\nODbuxXsO7Wh2MvAYcJB0qDcDm4HTnXNHnQY3M5frZ4lI9Bx353E8dvljHF93fPY7Pfoo3HYbLF4c\nXGEFxsxwzo3ZcR5JzsMyzrkXnXONzrkW59xxwCZg/kjBLiLyVjkNzUyAnrtf/Jzn7sgwLCMickhO\nJ1UV7lnLOOaeLedci1/HEpHoU889WLpCVURCMbVyqnruAVK4i0goPPXcNTkjI9+GZURExqOhqoHv\nP/19rn342nHtdzuDfOnXn6M/kY6vi0+8mPNazguixKKmcBeRULzv+Pex6+AuBt34bnbaX1nOyeXH\n0D2pGoC6ci1pNZKc57mP+4M0z11E/NDSAo89lv7vBJD3ee4iIqGoroaOjrCrKHgKdxEpLpoxkxWF\nu4gUF4V7VhTuIlJcFO5ZUbiLSHFRuGdF4S4ixUXhnhWFu4gUF4V7VhTuIlJcFO5ZUbiLSHFRuGdF\n4S4ixUXhnhWFu4gUF4V7VhTuIlJcFO5ZUbiLSHFRuGdF4S4ixUXhnhWFu4gUF4V7VhTuIlJcFO5Z\n0c06RKS4DA5CaSn09UEs+v1T3axDRCaGWAzKy6GzM+xKCprCXUSKj4ZmMlK4i0jxUbhnpHAXkeKj\ncM9I4S4ixaemRuGegcJdRIpPdTV0dIRdRUHzFO5mdrOZbTKz54Ye5/tVmIjIqDQsk1Hch2N8zzn3\nPR+OIyKSHYV7Rn4My4x7cr2IiCcK94z8CPdrzWy5md1jZikfjiciMjaFe0YZw93MlpjZimGPlUP/\n/RBwF9DinJsHbAM0PCMiwVO4Z5RxzN05tzDLY90N/GasDdra2t583traSmtra5aHFhEZJsLh3t7e\nTnt7u+fjeFo4zMwanXPbhp5/ATjNOXfZKNtq4TAR8ccvfgEPPAD33x92JYHLdeEwr7Nlvmtm84BB\n4FXgGo/HExHJLMI9d794Cnfn3BV+FSIikjWFe0a6QlVEio/CPSOFu4gUH4V7Rgp3ESk+CveMFO4i\nUnwU7hkp3EWk+CST0N+fvo+qjEjhLiLFx0y99wwU7iJSnBTuY1K4i0hxUriPSeEuIsVJ4T4mhbuI\nFCeF+5gU7iJSnBTuY1K4i0hxqqlRuI9B4S4ixam6Gjo6wq6iYCncRaQ4aVhmTAp3ESlOCvcxKdxF\npDgp3MekcBeR4qRwH5PCXUSKk8J9TAp3ESlOCvcxKdxFpDgp3MekcBeR4qRwH5PCXUSKk8J9TAp3\nESlOCvcxKdxFpDhVV8OBA+Bc2JUUJIW7iBSneBxKS6GrK+xKCpLCXUSKl4ZmRqVwF5HipXAflcJd\nRIqXwn1UnsPdzK4zs5fNbKWZ3epHUSIiWVG4j8pTuJtZK/AhYK5zbi7wz34UVYza29vDLiFQUW5f\nlNsGEW9fdTXtTzwRdhUFyWvP/XPArc65fgDn3C7vJRWnSP8CEe32RbltEPH2VVfT/uyzYVdRkLyG\n+2zgXDN7ysweN7NT/ShKRCQr1dXQ0xN2FQUpnmkDM1sCNAx/CXDAV4f2n+ScO9PMTgPuB1qCKFRE\n5Cg1NbBxY9hVFCRzHq7uMrOHge8455YOff0KcIZzbvcI2+oyMhGRHDjnbLz7ZOy5Z/Ag8F5gqZnN\nBkpHCvZcixMRkdx4DfcfAfea2UqgB7jCe0kiIuKVp2EZEREpTIFdoWpmk8xssZmtNrNHzSw1xrYx\nM3vOzB4Kqh6/ZdM+M2s2sz+a2V+GLvL6fBi1ZsvMzjezVWa2xsxuHGWb75vZWjNbbmbz8l2jF5na\nZ2aXmdkLQ4//MLO5YdSZq2y+f0PbnWZmfWb24XzW51WWP5+tZva8mb1oZo/nu8ZcZfGzWWNmDw39\n3q00syszHtQ5F8gD+A7w5aHnN5KeDz/atl8AfgY8FFQ9YbQPaATmDT2vAlYDJ4Zd+yjtiQGvAMcA\npcDyt9YKfAD43dDzM4Cnwq7b5/adCaSGnp8ftfYN2+4PwG+BD4ddt8/fvxTwF2D60NeTw67bx7b9\nI/DtQ+0CdgPxsY4b5NoyFwI/Hnr+Y+CikTYys2bgg8A9AdYShIztc85tc84tH3p+AHgZmJ63Csfn\ndGCtc+4151wfcB/pNg53IfATAOfcMiBlZg0Uh4ztc8495ZzbN/TlUxTu92ok2Xz/AK4DfgnsyGdx\nPsimfZcBDzjnNkNRXVSZTdscUD30vBrY7YYuHh1NkOE+1Tm3HdIhB0wdZbvbgS+RLr6YZNs+AMzs\nWGAesCzwynIzHRg+YXgTR4fbW7fZPMI2hSqb9g33GeCRQCvyV8b2mVkTcJFz7n+Qvl6lmGTz/ZsN\n1A1dUPmMmV2et+q8yaZtPwBOMrMtwAvA9ZkO6mm2TIYLnN7qqPA2swuA7c655UPr1BTUD5zX9g07\nThXp3tL1Qz14KWBm9h7gU8BfhV2Lz+4gPYR4SEH9vvkgDiwgPT27EnjSzJ50zr0Sblm+eD/wvHPu\nvWZ2PLDEzN4xVp54Cnfn3MLR3jOz7WbW4JzbbmaNjPzPwHOARWb2QaAcqDaznzjnCmJKpQ/tw8zi\npIP9p865XwdUqh82AzOHfd089Npbt5mRYZtClU37MLN3AP8KnO+c25un2vyQTftOBe4zMyM9bvsB\nM+tzzhXDRIZs2rcJ2OWc6wa6zez/Ae8kPZ5dyLJp26eAbwM459aZ2QbgRODPox41wJME3wFuHHo+\n5gnVoW3eTfGdUM3YPtJj1N8Lu94s2lPC4ZM6CdIndd72lm0+yOETqmdSXCccs2nfTGAtcGbY9QbR\nvrds/yOK64RqNt+/E4ElQ9tWACuBk8Ku3ae2/RC4eeh5A+lhnLoxjxtgwXXAY6RniCwGaodenwb8\ndoTtiy3cM7aP9L9MBoa+Wc8Dz5HuEYZe/yhtOn+oPWuBfxh67Rrgs8O2+cHQD+ILwIKwa/azfcDd\npGchPDf0/Xo67Jr9/v4N2/beYgr3bNsH3EB6xswK4Lqwa/arbUO58uhQu1YAl2Y6pi5iEhGJIN1m\nT0QkghTuIiIRpHAXEYkghbuISAQp3EVEIkjhLiISQQp3EZEIUriLiETQ/wel9z4FsJkU4AAAAABJ\nRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD8CAYAAAB0IB+mAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsnXVcVtcfx9/3SbobBERRxMDu7po6Y9bCTec2nQt16qab\ny9/apbrUhTpd2jV1dhcmKqiUNEjHE/f3x+PcGEjJQ8h5v17PS7invhfhc88953u+X0mWZQQCgUBw\n76OobgMEAoFAUDUIwRcIBII6ghB8gUAgqCMIwRcIBII6ghB8gUAgqCMIwRcIBII6ghB8gUAgqCMI\nwRcIBII6ghB8gUAgqCOoqtuAf+Pi4iL7+/tXtxkCgUBQqzhx4kSyLMuupdWrUYLv7+/P8ePHq9sM\ngUAgqFVIkhRZlnpiSUcgEAjqCELwBQKBoI4gBF8gEAjqCELwBQKBoI4gBF8gEAjqCGYXfEmSBkqS\ndEmSpHBJkuaZezyBQCAQFI9ZBV+SJCWwGBgEBAPjJUkKNsdY+fn55uhWIBAI7hnM7YffHgiXZfkq\ngCRJq4HhwIXKHOTFqY+xdMUaZg96CC/HUs8e3EZjPItKTiq2LN9KSVhre5CkYsvbGN3xwbbE/mUk\nwlz6k2blX2abyo0k0SfIjZB6DuYbQyAQ3BOYW/C9geh/fR8DdPh3BUmSpgJTAXx9fSs0yJ59B0nP\nzeGLv9Yxe+S3qJWa0htJCuTc5oQcfQOFrC9U9Pdrzw7nFEIDigq+LElE6cL48UZiiUMoJBm/6N8Z\nXPAO6diU9XbKhSzDZ7uuMK6dL3MGNMbRugz3LhAI6iTmFvzipseFsqbLsvwV8BVA27ZtK5RRfdvR\nYzQOqE9scjwX9Wv48pvvS20TfSGV9Z+exvDZJpr3LfygMRYUEN69B29ndMRn0kdF2q64sIJ3j71L\n2DMHCXYuYYXqxim8vunH6ZD1MHbFHd8W7oasfD0f/3mZ5Qev8+eFeL59pJ2Y7QsEgmIx96ZtDFDv\nX9/7ADcqexBbW1t+/u03FJLEV9//wMb160ptUy/YCd+mThzffJ28bF2hMoVGg/3wYWTu3Ik+NbVI\n22ENh2GpsmTNpTUlD+LVCvouhLCNcPzbct1TWbHRqlgwNJiNM7pioVYy/uvD7Llc/DKVQCCo25hb\n8I8BgZIk1ZckSQOMA9abY6Cu3Xsw+7lnAZj86KPodLpSWkDnkQ0pyNVzfPP1ImX2o0aBTkf6+qLm\n2mnsGFx/MJuvbiY9P73kQTpOh4Z9YetLEHuyTPdSEZp42vH7U53xc7Zm8nfH+Pl4dOmNBAJBncKs\ngi/Lsh54GtgGXAR+lmX5vLnG+9/7H+Dr6UFiahrfLyt9Ru3sbUOTLl6c3R1DRkpuoTKLRo2waNGC\n9N9+Q5aLrjSNCxpHniGPdeGlvE0oFHD/l2DjDqsnQmZ8ue6pPLjZWbDmiY50DHBmzq9nWLjuHDqD\n0WzjCQSC2oXZ/fBlWd4sy3IjWZYbyLL8ljnHUiqVzJo9G4D33nm7WKH+L+2G+IMMoTuKzogdRo8i\n/0o4eWfOFCkLcgqipWtL1lxag1EuRVStXWD8T5CXbhJ9XV6Z7qci2Fmo+e7RdjzerT7fH4pk3FeH\nORGZZrbxBAJB7eGeO2k7ddp07G2suXI9ij+3byu1vo2jBY3au3PhwA3ysgovA9kNHoxkaUnazz8X\n23ZCkwlEZUaxM2pn6YZ5NIP7v4DY47DxeZN7jZlQKRXMHxLMJ+Naci05m1FLD/LwsqNcjMsw25gC\ngaDmc88JvoWFBY8/+igAb7z8cpnatOrvh77AyJndMYWuK21ssL/vPjI2bkKfVnSW3N+vP/Xt67Pk\n9BIMRkPpAwUPg54vQugqOLy0TLbdDcNberNvTi9eHBTEudh0hn2+n8V/haMXyzwCQZ3knhN8gDkv\nv4JapWL/seOcP3+u1PpOXtb4t3Dh7F8x6AoKC7fjgxOR8/O5+euvRdopFUqmhUwj/GY42yO3l824\n7nOgyX2wfT5E7Cpbm7vAWqviiR4N2DGzB/2bevD+tkvcv+QgOy4kYDSa7y1DIBDUPO5JwXd1dWX0\nsKEAzH3uuTK1adXfl7xsHRcPFPYatWjUCKuOHUlb9ROyXl+kXX///jR0aFj2Wb5CASO+ANcm8Muj\nkBFXJvvuFidrDYsntOaz8a1IzS5gyg/HGfDxXlYcjiQzr3SPJoFAUPu5JwUf4O0PP0KlVLB5x05C\nT58utb5XQwc8G9pzYkskuvzCwu300IPo4+LI3FF0rV4hKZjecjrXM66z+drmshmntYGxP4IuF7bO\nLVubSuK+EC92v9CTj8e2RK1UsGDtOdq/tZMXfgnlZFRamTa6BQJB7eSeFXw/f3/GjxqFDMya8XSZ\n2nS6vyE5GQWE7owqdN2mZ0/U3t6krvix2Ha9fXsT6BjIsnPLyi6Yzg2gxwtwYR1c2lq2NpWEWqlg\nRCtvNj3TlXXTuzCilRebz8YxcslBBn68j5+ORpGvL8PbikAgqFXcs4IP8M5HH6NWKdm5/wBHDh8u\ntb5nA3sCWrpycnsUuZkFt69LSiWODz5I7vET5Bw7VqSdQlLwcPDDhN8M51DcobIb2PlZ09LO5tmQ\nn1X2dpWEJEmE1HPg7ZEtODK/L++MbI5aJfHi72fp9u5fLPrzMn9eSCAyJVus9wsE9wBSTXqFb9u2\nrXz8+PFK7fOJSY/w1fc/0KVta/YfO1Fq/bT4bH56/SjNenjTfWyj29eNublEDB6C0tGB+r/8gqRU\nFmpXYCig/6/9aeLchKV9y+GBE3UYlg2AkAkwYolZ4u2UB1mWORiRwpLd4RwIT7l93VKtpJG7DUEe\ndjT2sCXI05bG7rY422ir0VqBQAAgSdIJWZbbllrvXhf8pKQk6nl7k6/TceL4MVq3KfVnwu6VYVw8\nEMeDb3bC1sni9vX0jZu4MXs2nm+9icOoUUXaLQ1dypLTS1g3fB0BDgFlN/Kvt2HPO9D1eej7atnb\nmZnMPB1XErO4kpDJpfgswuIzCIvPJDX7n7cfZ2sN/i7W2GhV2GhV2FqosLNU42ClxtvBEm8HSzzs\nLXC3s0CtvKdfKAWCakMI/r94dMJ4vvtpNUP69mHjnztKrZ+RksuPCw7RZqAfHYc3uH1dlmUix0+g\nICaGBlu3oLQpHPI4JTeF/r/2Z3jD4bzS6ZWyGyjLpsNYJ5ZD/7egc9n2HKoDWZZJysrnYlwmVxIy\nuZyQSUxaLtn5erLy9WTm6cnI05GnK+zrL0ngZqvF18mKeo5W2FioUCkUaNUKbLQqrDVKlLceCJZq\nJfUcLfFztsbNVotCUb1vPQJBTUcI/r+4fv06DQJMM+6Iq1fx9/cvtc2mJWdIuJbOI293Qan6Z2aa\ne+YM1x8Yi/OTT+BWjMvnwoML2Xx1M1tGbcHF0qXsRhoN8Oujpk3coR9B28fK3rYGkp2v58bNXGJv\n5hKfnkdceh6xN3OJTs0hJi2XnAI9OoNMns6AvoT9AY1KQT1H01uCVqVEqzI9IOws1VhplEiShEIC\nK40SG60aC7Xi9qqYhIRCIaGUJCTJFKu7rCtmGpUCrUqJSiEhmXmZrb6LNa62YmlMUHHKKvjmjodf\nI/D392dQn15s2rGL1+e/xLKVq0pt06yHN9fPJHP1VBKB7dxvX7ds0QLb/v1JW7kK5ymPo7SxLtRu\ncrPJrI9Yz2enPuO1zq+V3UiFEkZ+bYqzs/F5kBTQZlLZ29cwrLUqAt1tCXQvJSuYLJOvN5Kdr+dv\n3c/O1xOVmkNkag7RqTlEpeSQlJVPRq6ePJ2BrHw9Gbk6sgvuDU+ikHoOrJvepbrNENQB6sQMH+DE\n8WO0bdcerVpNXEICjo6OJdaXjTIrXjmEtYOWkbPbFCrLPXuW62MewG3uXJwfnVSk7fvH3ufHCz+y\nZugamjg3KZ+h+nxY8yBc2Q73fVKrRb+qMBplcnQGsvJMDwQwZdmRZRmjLGMwgoxc5vBFsgw6g7HU\nt4/K4LcTMWw4c4Pzrw1EoxJ7HIKKIWb4/6FN23Z0bBXC4VOhvDJvLp99+VWJ9SWFRLPuPhz8PZyU\n2Cycvf9Zr7ds3hyrdu1I/f57nCZOQNIUTiv4RMgTrI9Yz3vH3mPZgGXlWxJQaeGBH02iv+FZMOig\n/ePlute6hkIh3d40rm2kZBfw+6lYwhOzCPayq25zBPc4dWpK8f7HnwLwxbfLiIiIKLV+k86eKNWK\nIkHVAJynTEYfH0/65qKna+00djzd8mmOJxxnR1Tpm8RFUFvAuJXQeIjJR//Ap2aNrimoPoI9TUte\nIpKpoCqoU4LftXt3BnTrjN5g4NmnS/eEsbBR07iDB5cOxZOTUVCozLp7d7SBgaR+W/zp2lGNRtHY\nsTGvH3qd+OwKJD1RaeGB76Hp/fDny6Y4+lklJ00X1D7qu9hgoVYIwRdUCXVK8AE+++IrNColm7Zu\nZceO0mffrfr5YjAYOfNX4QQpkiThPGUy+VeukLWzaIwdlULF+z3ep8BQwOw9s9EZKxCgTKmGUd+a\nXDXDd8DiDnB1d/n7EdRYlAqJxu62XBCCL6gC6pzgBwY3ZeLQQQA888yMUnPfOrhbEdDSlXN7YinI\nKxwt027IEDR+fiR9+hmysWiM+fr29Xmty2uEJoXy0YmPKmawQmnyy39ynylN4pqHIDGsYn0JaiTB\nXnZcjMsQgesEZqfOCT7Amx9+hLO1FRcvhrF0aelhEFr19yU/R8/FA4VDGUsqFS5PTyf/8mUytxcf\nD3+g/0DGB43nxws/8uvlojH1y4xrY5j4C6gs4KdxkJNa8b4ENYomnnak5eiIzzBf6kuBAOqo4HsF\nNOTph8YD8PKCBSQmlrw27lHfHq9AB07viMKgLzyTtxs8GE2DBiR9/jmyoXi/8BfavUBX7668cfgN\ndkXdRdITh3qmzdyMWJPox5YeG0hQ82niafLOEev4AnNTJwUf4MVFn9LMrx4ZmZnMmT2r1PptBvmR\nlZbP6R2FQydLSiWuT0+nIDyCjM1bim2rVqj5sMeHBDsFM2fvHE4lnqq44fXaw4ilEH8Ovu4NX/aA\nixuEF08tJsjD5Klz4YYQfIF5qbOCr7W04qvly1EqJH5YsYLjxYQ9/je+wc4EtHTl+KbrZKTkFiqz\nHTAAbWAgKV99dcd1WCu1FYv7LsbD2oNndz1LbFZsxY1vPhpmhcHgD0CXY/LZXzkaUkp3NRXUPGwt\n1Pg6WXExLrO6TRHc49RZwQfo1KsPE0fejyzDzBnTS63f9YFAkGD/z1cKXZcUCpwmP0b+lStk79t3\nx/ZOFk583vtz9LKep3c+TbYuu+LGW9iZDmQ9dRAGvA1RR2BpFzh7F/sEgmoj2NNOLOkIzE6dFnyA\n9xcvRatWs+/IMfbuKupe+W9snSxoN6Q+10KTuX4muVCZ/eDBqDw8SPnm2xL78Lf354MeH3At/Rrz\n9s7DKBf17ikXSjV0mgZPHwOvlvDbZNjxGhTjNSSouTTxtONaSjY5BUXzJgsElUWdF3w3NzemTpkM\nwAvPzCi1fkifeji4W3FobQTyv+KsSBoNTg8/TM7Ro+SePVtiH529OvNCuxfYHbObH87/cHc38Dd2\nnvDwemj9COxfBGsmVksWLUHFCPayQ5YRyzoCs1LnBR9g/sJX0Wo0HD1/kQ2rVpRYV6lS0HaQH6k3\nsrl+LqVQmcMDY1DY2pLy7bJSx5wQNIE+vn345OQnnEs+d1f230alMQVcG/QeXN4KywdC+l3sFQiq\njL/j6IgDWAJzIgQfcHd356lp0wBYuPCVUg/ANGznjq2zBSe2XC9UV2ljg+O4sWRu307e5csl9iFJ\nEq91fg1nS2fm7J1zd+v5hTuGDk/AhJ8h9Tos7Qzrn4GIXaaY+4IaiZe9BfaWauGpIzArQvBvMXfu\nXCy0Wk6FX2P18pJn6Eqlgtb9fUm4lsGNyzcLlTk99hgKGxsS3n671AeHvdaed7q9Q2xWLLP2zCJP\nX4kHbwL7wZQ/oWEf00buj/fDt/0gqeQHkaB6kCSJpl52XLiRXt2mCO5hhODfwsPDgwXz5wPwwrx5\n5Ofnl1g/qLMnlnYaTmy9Xui6ytER1xkzyDl0uNgYO/+lrUdbFnZayMHYgzy146nKm+kDuDWB0ctg\nToTJdz/1KnzZzRR9U1/y/QmqnmBPO8LiM9EbxIa7wDwIwf8XL8ydSz1Pd2KTknnnrbdKrKtSK2nZ\npx7RF9OIv1p4VuY4fhzawIYkvPsexlIeHAAjA0fyTrd3OJV4ise3P05WQSVvtqotoeUEmHYEAnqZ\nom9+2gqOfQP5YpOwptDU2458vZGryZX40BcI/oXZBF+SpPclSQqTJOmMJEl/SJLkYK6xKguNRsMn\nH30MwDvvvUd0dHSJ9Zv18MbSVs2R9VcLXZdUKtxfeglddDSpy5eXaezBAYNZ1HMRF1Mu8vSupyt3\needvbN1h/E/w0Fqw94FNs+AdX5P//sbnIXQNpF0Xp3ariaZe9gCcF8s6AjNhzhn+n0AzWZZbAJeB\nF804VqVx/9hxdGzWhLz8fD75+OMS62osVLQe4EdMWBqxl9IKlVl36oTtgAEkL/2CgsjIMo3d27c3\n/+v2P04mnGTWnlkVC6lcGpIEDXrBY9tg0mboPgds3ODML/DHVPgkBD5uAeueNl1LvSYeAFVEgIs1\nWpWC87Fi41ZgHqokp60kSfcDo2VZnlhSPXPmtC0P639awfAJD2FvZ0tCYhJarfaOdfU6AytePoyd\niwX3z2pdKJ2hLiGRq0OGYNG8Gb7Lyp7q8JfLv/D6oddp59GON7u8iZeN113fU6kYDZB4AaIOw7U9\ncG0v5N2aaVq5QOuHoOtM0wlfgdkY/vl+rLUqVj3esbpNEdQiyprTtqrW8B8Dio0sJknSVEmSjkuS\ndDwpKamKzCmZ+8ZNpL6nB+kZmfy0amWJdVVqJW0H+xMXnk7UhcIhi9XubrjNmknOocNkrF9f5vHH\nNBrDm13e5HzyeUauH8na8LXmj5WuUIJHc1O4hrErYM41eGIfDP0I/DrD/o9M6/77PzYlYUmPERu/\nZiDYy57zN0RsfIF5uKsZviRJOwCPYormy7K87lad+UBbYKRcymA1ZYYP8MH/3uKF+Qto0bgRoWGX\nSqxr0BtZufAwljZqRs9rW2gmLxuNRE6YSMH169Rfvw61m1uZbYjJjGHBgQWcSDjBkIAhvNzxZazV\n1hW+p7si9iRsXwCRBwpfV6hBY20K8aDUgHRrDqHUgK2H6WPpBBb2oLECSWmq8/fPSKEGKydTHeWt\nJOSS0tSnxhoU/0pM/ncbja2pP1Xh5PH3Aj8ejuTltefYP7cXPo5W1W2OoJZQ1hm+WZd0JEl6BHgS\n6CPLck5p9WuS4GdmZuLu6kpufj5H9u+jfZeuJda/cOAGf/0YxuCnmlM/xLVQWX5EBNdGj8GyWTN8\nly9DUqnu0EtRDEYD35z9hiWhS/C19eWDHh/Q2Klxhe7prpFlyIyD5CuQGmFKwlKQBQXZYNCZPtz6\nfdLlQma8qX7eTdPy0N3GDfovChVQtmWyOyJJoLUDK2fTA6aMy26VSuAA6DkXgJNRaYxccpCvHmpD\n/6bFzaUEgqJUu+BLkjQQWAT0kGW5TGs1NUnwASZPeoRl3//AsB7dWLd7b4l1jQYjq149gkqrZOxL\n7ZAUhYUjfd06bsydh/MTT+D2/HPltuVY/DHm7p1Len468zrMY3Tg6DLvCdQIZBn0eaZ/5X+d+NUX\nQG4q5KaB8VbgMIPOFPa5IPtfp4Plf/opyDI9RApKnUOUwS4j5GdAToppvKom9SpkJsC8SFCqySnQ\n03ThNp7pHcjz/RpVvT2CWklNEPxwQAv8HXDmsCzLT5bUpqYJfmhoKC1btkSrUnHu+FEahrQqsf6l\nI/HsWH6BAY83o2Gboks3cS+/zM1ffsVn6RJse/Uqtz0puSm8tP8lDt44SH+//sxsOxNvG+9y9yOo\nQVzcYMpn8OhW8OsEQJ8Pd+PnbM2ySe2q2ThBbaHaN21lWW4oy3I9WZZb3vqUKPY1kZCQELp160q+\nXs/rc2aVupEW2M4dRw8rjm68hqGY05Lu8+djERxM7MxZ5Jwsf9YrZ0tnlvZdyrOtn2V39G6G/j6U\nVw++Snx2fLn7EtQQ/Lua9jSu7r59qU8Td3aFJfJXWMmpNwWC8iJO2pbCCy/MAWDD/sNcPHjn5CYA\nCoVExxENSIvL5uBv4UXLLSyo99WXqN3ciH7ySfIulbwZXOwYkoIpzaeweeRmRjcazfqI9QxfO5zv\nz3+P3ihiqdc6LB3Bs6XJFfYWM/s1oomnHc//fJrYm7klNBYIyocQ/FIYMmQIjRs35mZOLh+9sRCD\nvuTDUAEtXQnpU48zu2IIOxRXpFzl4oLv8mUorKyImjIFQ0bFDtm4W7szv+N81o9YTxv3Nnxw/AMm\nbJpAXFbRMQU1nICeEHPsdpgLC7WSJRNbozfITF95kj8vJHAwIpkrCZnk60XEU0HFEYJfCgqFgpkz\nZwKw9egpzu0uPSBa55EN8G7syO6Vl0i4XlTQ1V5e+Hz+OYakZNJWluznXxo+tj4s7rOYRT0XEZMZ\nw4TNE7iQcuGu+hRUMQE9TBvWkQdvX6rvYs27o1pwJuYmj/9wnAlfH6HfR3tp8vJWen2wm/l/nOWv\nsETydOIBICg7VXLStqzUtE3bv8nNzcXPz4+kpCRmjRjEe79uQKFUltwmq4Bf3j6OQW9kzLy22Dha\nFKkT/dQ0ck+epMHOnSht7t6/PjwtnGk7p3Ez/ybTQqYxJGAIrlaupTcUVC+6PHjXD9o+BgPfLlQU\nn55HUmY+Wfl6EjLyuJqUxYW4TA5GJJNTYMDNVssLAxozqrUPCkUt8toSVCrV7qVTEWqq4AO89dZb\nLFiwAC8HO7at/Z1mPfqU2iYlNovf3juBvZslI2e3Qa0t/JDIDQ3l+thxuL0wG+fJkyvFzqScJObu\nm8ux+GMoJAVdvLowtcVUWrq1rJT+BWbih+GQlQTTDpZeF8jTGTgUkcInO69wOvomQR62dGnogr+L\nNc7WGiTAUqOkW6ArSvEguOcRgl/J5OTkEBQURHR0NJP69WDZ1l1IitJXxK6fTWbzkjPUb+nKwKnN\nivjORz02mbxLl2i4cwcKi6JvARXlavpVNkZs5Lcrv5Gal0oXry7MaD2Dps5NK20MQSWy/yPY8SrM\numyKalpGjEaZDWdu8PW+q4QnZpGnK+wdNqCpO5+Ma4WFuuQ3UkHtRgi+GVi9ejXjx4/HRqth75ZN\ntOrVt0ztTm6P5NDvEQyc2owGrQv75+ccO0bkQw/jOmsmLo8/Xuk25+hyWHNpDcvPLSctP40hAUN4\nptUzVROQTVB2Yk7AN71hzPfQdESFujAaZRIy80jPNTkW7L2cxNtbwmjn58Sn41tha6FCq1KgUoqt\nu3sNIfhmQJZlunbpwsFDhxjerRNr95bt9dtoMLLmrWMY9EbGL+yA8j9/cNHTnyZr9258v/4K686d\nzWE6WQVZLDu3jB8u/IBRNjIqcBRTmk/B3brss0mBGdHlwf88odss6L2g0rrdEHqDmT+fRmcw/Z1b\na5R8+VBbuga6VNoYgupHCL6ZOHbsGO3bt0ejVHLtagRevn5lanf9bDKbFp+h+7hGNO/pU6jMkJVF\n5PgJ6BIS8F+9Gm1AfXOYDkB8djxfnvmStVfWopAUtHZvTWPHxjR2akxTl6b42/mjkMQMsFr4vD04\nNzAlqalEzsWmc/RaKjqDkZ+PR3MzR8eWZ7vhZld5S4iC6kUIvhnp2a0be/bvZ+bUKXz45ddlaiPL\nMmsXnSItPpsH3+iExqJwALWCmFiuP/AASltb/H/7rVK8dkoiJjOGHy/8SGhSKFfSrlBgLADARm3D\nAP8BTG4+mXq29cxqg+A//PqYyR//ubNmG+JKQibDPj9ASD17Vk7pKDZ07xGE4JuRDRs2MGzYMFwd\n7IlLTkFZiovm3yRcy+DXd4/TdrA/HYYFFCnPOXaMyEcm4TBqJJ5vvFHZZt8RvVHP1fSrnE8+z4mE\nE2y5tgWDbKCHTw+CnILwt/fHw9oDF0sX3K3c0SjvvbDENYJ9H8LO12FelCn8s5n49UQMs38JpXeQ\nG239HQl0s6VnY1fUYm2/1iIE34wYjUZ8vTyJTUhk9YoVjJ1YYiKvQmz/5hzXQpOZ8FpHbJ2KvlIn\nfriIlK+/rnCAtcogMSeR789/z47IHcRlxyHzz++ItdqaBxo9wEPBDwkf/8rm8nZYNaZQIDVz8d7W\nMH49EUNipimJTX0Xa2b3b8zg5h61KwqrABCCb3beXPgKL7/+Bu1CWnD0dGiZ22Uk57Lq1SM0bONG\n30eDi5QbCwq4PuYB9CkpBKxfh8rJqTLNLjd5+jyiMqNIzEkkKSeJQzcOsS1yG0pJibOlMwB2Gju6\n+3SnV71euFuZNoE1Sg0OWgchHuUhPRY+CobBH5gyj1UBWfl6DoYn8+H2y1xKyMTBSo2HnQX1Xax5\naXAT6jmJJCy1ASH4ZubmzZt4uLmSr9MTGhpKixYtytz20B8RnNwWyZgX2+LmVzRHbN6lS1wbPQaL\nJk2ot3QJKmfnyjT9ronOiOaXy7+Qlm9K3H4j6wYnEk5gkAsf89cqtbhbuaNVmXICKyUlFkoLLFWW\nKG6dYdAoNLhZueFq6YpWWTR3sFqpxkJpgVqpRrqV7EQhKVApVCgl5e1rZUGpUNLeoz1W6hoqYrIM\n79WH4OFw3ydVOrTBKLMh9AbHI1OJT8/jyNVUbC1UrHy8I/VdqinLmqDMCMGvAsYMGsCvW7czYtgw\n/li3rsztCnL1rHjlEA7uVtw/s3WRZCkAmTt3EjtzFip3d3y//gqNX9m8gaqL9Px0DsUdIqsgCzC9\nGcRnx5OQk4DOaPILNxgN5BpyydXn3g41navPJSk3ifT89Cqx08Pag7nt5tLHt0/NfPv4bqgpW9jj\npcdsMicXbmTw4LdHUCkkVkzpQCN322q1R1AyQvCrgHPHj9GqQ0f0RiOnT58mJCSkzG3/TokY3MWT\nnhODihX9nFOniHlqGgCe/3sL2969K832mkaBoaBIeGcZmQJDAfmGfHQG3e1rBtmA3qjHWM6UiYk5\niXx88mM4oNz7AAAgAElEQVQup13G19YXrUqLSlIxwH8A44PG14yZ/5a5cPIHeDEWynCS25xcSchk\nwjdHSM/RMblbfab3aoiNtuzpOQVVhxD8KmJA21ZsP3Ga4cOHs3bt2jK3k2WZoxuucXzzdYK7etFz\nQuNiRb8gMpKY554n/+JFHMaOxX3eXBSWlpV5C3UKvVHPz5d+5mj8UQDS8tI4mXgSJwsnBtUfhFqh\nLrUPSZLQKDRolBrsNHbYa+2xUllV+I2hoUPDf04+n/wR1j8NM06afPKrmYSMPN7dGsbvJ2NxtdUy\nu38jRrepJ9w5axhC8KuIrT8uY9ijj6MzGDl27Bht25b6M7+NLMscWX+VE1siaX9ffdoNKf7AlbGg\ngKRPPiH122U4jBldpS6bdYHTiadZfHoxoUll23w3GA23zy1UBk2dm7J66GrTN7En4ete8MAPprX8\nGsKpqDTe2HiBk1GmQG1v3d+MNn7V61Ag+Ach+FVEZmoyw7p0YHfYVYYMGcLGjRvL1V6WZbZ+dY7o\ni6k8/FZnLKzvPMOMf+NN0tasocHWrWh8RC7b6kSWZXRGHRkFGaTnp5Orr1hmqlUXV/Fn5J8cmXjE\ndMJZlwv/84LuL0CvlyrZ6rtDlmU2nY3j7c1hJGXls3Ria/o0EaE5agLVntO2rmDr5MKDw+9Do1Ky\nadMmzp07V672kiTRfmh9dHkGQndGl1jXecpkkCRSvv3mbkwWVAKSJKFRanCxdKGBQwOauTSr0Kel\nW0vyDHkk5tzKX6u2BOeGEHuiem+wGCRJYmgLLzbO6EqQhy1P/HiCDaE3qtssQTkQgl8JtB8wmLb+\npvg4H374YbnbO3vb0KC1K2d2RZOXfecUimpPTxzuv5/0X39Dl5BQYXsFNQd/O38Armdc/+di40EQ\nvgO2v2xy1axhOFprWDmlA619HZnx0ykmfH2YdadjRfatWoAQ/EogsH1negU3QiFJrFy5khs3yj/r\naTekPgVlmeVPfRzZaCTl228raq6gBuFnZ3K3jUyP/Odin4XQbgoc/BTWTTdF0qxh2Fqo+f6x9szu\n34jotByeXX2aAR/v5URkWnWbJigBIfiVgIW1DW27dqdlfV90Oh2ffvppuftw9rahQSvTLL8gT3/H\nehofH+yHDSPtp9UkfrgIQ1bW3ZguqGbcrNywVFkWnuErlKbTtj1fhNMr4bM2cGolGGvWDNpSo+Tp\n3oHsmd2L5ZPaoTfIjPniIIv+vIzRWPPeTARC8CuNRh270KW+aSP1iy++IDMzs9x9hPT1pSDPQMTJ\nxBLruc+dg/3gQaR8/TURAwaStno1su7OS0GCmoskSfjZ+RGZEfnfAug5Dx5eDzausG4avOMHizvA\nilGwbT6ErobEMDCW7zxCZaNQSPQKcmPLc90Y0dKbT3deYc3xkt9UBdWDOEVRSTRo0576bq40bxTI\n2ctXeO211/jggw/K1YdHgB0O7laEHYqnSec7Z6RSOjjg9e67OD74IAnvvEv8q6+Ruvw7nKdOxSK4\nCep6vmYPryyoPPzs/LiYcrH4woAe8PhfcHEDRB6A9Bi4GQXX9oHBFPgMrR14tQJHP7D1Ags7QAKl\nGhr2AaeikVnNgZ2Fmg8fCCHmZi7vbg1jYFMPHK1FZNWahBD8SkJrZY1/SCuG6oycD49g0aJF3H//\n/XTp0qXMfUiSRFAnDw6vvUp6Ug72riWf/LRs3hy/FT+S9ddukj5aRNz8+f+UtWqF4/hx2A4YgEJb\nNEaNoObgZ+fHjsgd6Aw61Mpi3HIlCYKHmT5/Y9BDyhW4ccoUQ//GKbi0FbKTgP8sp3i3hXrtAckU\ndrnTNNCaJ1SCJEm8MbwZgz/dx3vbLvH2yOZmGUdQMYQffiVy7q8/2fbFJ0Q51+PTpV/QsGFDQkND\nsbIq+5H9rLR8fnjpAG0GFR8z/07IBgP5ly5REBVFfkQEGes3UBAZidLREccJE3CcOKHaI28KimdD\nxAZe2v8S60asI8D+Lmfj+gLQ5Zi+zk2Di+vh7C+Qet10rSATWj0Iwxff3Til8MbGCyw7cI0/pnWh\nZT0Hs44lEH741UKDdh1RKJUM69CaZs2aER4ezrx588rVh42jlnpNnAg7HIdcjo0vSanEIjgYu4ED\ncZ0+nYCtW/BdvgzLVq1IXryY8F69iVv4KvnXrpX3tgRmplhPnYqi0oClg+njVB+6PAtP7oeXYkyf\nrjPh1Aq4tOXuxyqB5/oG4mqjZcHas+gN1bvHIPgHIfiViKWNLfWatuD6yaN89913qFQqPvvsMzZt\n2lSufoI6e5KVmk/M5Yq7uEmShHWnTtRbspiAzZuwH3Yf6X/8wdXBQ4idOQu5oPJCAwjujtuC/9+N\nW3PQ80Vwbw7rn4HsFLMNY2uh5pX7gjkXm8EPh6rgvgRlQgh+JRPUpQc34+OwzsvizTffBGDSpEnl\n8s2vH+KC1krFuT2xlWKTNiAAzzfeoOGunThPmULG5s0kvPNupfQtuHvstfY4WTgVds00FyoN3P+F\nabnnu8Fw4BNIDoesJNNHn19pQw1p7knPxq58uP0ScekVCz0hqFzMLviSJM2WJEmWJMnF3GPVBIK7\n9cKjQSC7vvuK6U9MpV+/fiQnJ/PQQw9hMJTNj1qlVtKshzdXTyeRFp9dabapXFxwmzUTp0cfJW3V\nKtI3bKi0vgV3R7GumebCoxmM/tYUxuHPV+DzNvBBQ9PnLU/4vD38Ohli7i68w98buAZZ5tX15yvJ\neMHdYNZNW0mS6gHfAEFAG1mWk0uqX9s3bf8mKeo6K+Y9R+NOXWk95kFCQkJITExk/vz5t2f9pZGT\nUcAP8w/SqL07vR9qUqn2yTodkY8+St658zg98giSUgGSAkmrRaHVmA7+AJJKidLeHqWDAwp7e5T2\nDqhcXYTXjxl4+cDLHIg9wK4HdlXtwGnX4eoeMNxa4suMh8SLEHXQ9BbQZBj0e+2uXDuX7o7g3a1h\nzOrXiBl9AivHbkEhyrppa263zI+AOUDZ00HdA7j6+tPh/jEc+vUngrr0YOXKlQwYMIC33nqLli1b\nMnr06FL7sLLT0KSzJxf236D90ABsHCtPZCW1Gu9Fi4h6ZBIpX31luljGB7/CygqnSZNweuxRlDY2\nlWZTXcfPzo+14WvJ1mVjra7CMxSO/tDGv+j1/Ew4+Dkc+hyu74MHfwfv1hUaYmr3AMITs/jwz8vk\n643M6t+oZmYbqwOYbYYvSdIwoI8sy89KknQdaFvcDF+SpKnAVABfX982kZH3xgaPQa/jx7nPUpCb\ny6RFS/h8yVJmzZqFlZUVhw4dKlMO3IzkXFa8cpiQPvXoMqqhWe2VjUZknQ45Lw/51slNWafDmJ6O\n4eZNDBkZGG6mk7VnD5nbt6O0t0cTaF6byoqkUGLdpQsOo0fVuPy/ZWVH5A6e3/08a4auIdi5aHL7\naiP1GvwwHHJSYeLP4Ne5Qt0YjTLz157lp6PRtPVzpJGHLd4OlqgUEgpJomdjVwJFGsUKUyXx8CVJ\n2gF4FFM0H3gJ6C/LcnpJgv9v7pUlnb+JvXSR1a+8QOvBw+n58BQeeeQRfvzxR/z9/Tl27BguLqVv\na2z/9jzXzyQz4dWOlTrLvxtyz54jZdm3GFJrRqAsY3Y2eefOgVqNVatWSKo7vLgqFFgEB2PduTMW\nwU1upRCUUFhXPFtVZRGZEcnQP4ayoMMCxgaNrVZbipBxwyT6qVfBqQHY+0CDXtB+KqjK/jtpNMp8\n/lc4O8MSiUrJJi3nn3AgnRs4s+rxjuawvk5QrQlQJElqDuwEbp0AwQe4AbSXZTn+Tu3uNcEH2PHN\nYs7s2MbE/y3CztOb7t27c/z4cXr27Mn27dtRq0tOqXczMYc1bx7Fq6EDQ2eEVLsw1VTyIyJIW72G\nvLNn71jHWJBP/qXL8J/Nc4W1NWpfX9PbQTX8fG169sBxwgQG/T6IQMdAPuv9WZXbUCpZSabonWnX\nTLP+hHMm8R/0LgT2q1CXeToDBqPMe1vDWH0smjOv9kerUlay4XWDGpXxqq7O8AHysrP4buZTWDs4\nMfHtRcTFxdO2bVvi4+OZNm0aixeXfuLx7O4Y9q6+TI8JjWnWXWS6uhsMWVnkHD1KQWTUrQt6dPEJ\nFERHYUi7WeX26KKjUdjZ0nDbNt48/CbrI9azf9x+NMoaHoPmyp+wdR6khEOD3tDvDZP3TwX480IC\nj/9wnNVTO9IxoHYuyVU3NWXTts5jYW1Dz4ensOnT9wk7sJfgbr1Yu3YtPXr0YMmSJXTv3p2xY0t+\nhW/Ww5troUkc+C0cJ09rPALsUCjFEYqKoLSxwbZ37+o24zYJ775H2k8/IcsyXb27subSGk4mnqSj\nZw1f3gjsB/V7wLGvYc978EVXcAsGSQFqC1MSlxbjwL70CUp7fyckCQ5fTRGCb2aqRDVkWfYvbXZ/\nL9O4Uzdc/QM49MsqDHo9HTp04OOPPwbgmWeeIS2t5LVwSZLo/XATlCqJPz48yTez9rFpyRmiL6ZS\nk2IhCcqP2sMdOS8PY3o67T3ao1aoORB7oLrNKhsqDXSaDs+ehq7Pmzx+HHxNZTtfh4+awvYFpXZj\nb6WmqZcdhyLMd/JXYEJME6sASaGgywMPcjMhjvN7dgIwdepUunXrRmJiInPmzCm1DxtHCya+2pH+\nk5vSuL0HidczWP/JaX7+3zEO/hbOqT+juBaahFHELalVqNxNPg+6hASs1Fa0dm/N/tj91WxVObF0\nhL4LYfwq02fKDnjmFISMg4Ofwfm1pXbRKcCZU1E3RZpEMyMEv4oIaN0Oz4aNOfz7avQ6HQqFgi+/\n/BK1Ws0333zDvn37Su3D0lZDYDt3ekxozMNvdabXQ0HIMpz5K4aDv4WzeelZVi48zNndMRh0Qvhr\nAyp3NwD0t3IUd/PuRvjNcOKz7+jbUDtwCoBhn5lCM294xhTDvwQ6BjhTYDByUqRINCtC8KsISZLo\nMvYhMpOTOLXVFNKgSZMmvPTSSwA8+OCDREeXPUuQUq0guIsX4xa054nPejDlo+4MerI5lrYa9q6+\nzO5VYWa5D0Hlova4NcOPNwl8V++uAOyLLX0CUONRqk0hHGQZfptiCt18B9rVd0Jxax1fYD6E4Fch\nvs1DaNC2I/tWfce1UyZvpBdffJFOnToRFRVFv379SEpKKne/kiShtVQR0NKVUXPa0KqfL2GH4rkR\nXvVeJ4LyoXJxAYUCfbxphh9gH4CHtQcbIzaSp695ycvLjaM/3PcxRB+B1eOhIKfYanYWapp723NI\nCL5ZEYJfhUiSxOAZs3D1q8+Gj94h4Wo4Wq2WTZs20aJFCy5dusSAAQNIT0+/qzHaDa2PjZOWvT9d\nEmv6NRxJrUbl7IwuwTTDlySJR5s+ysnEkzy4+cGqC6hmTpqNgvs+hfCdsGIkpESYUjVmxBWa9XcM\ncOZ09E3e3HiBt7dc5GxMxf8OBMUjMl5VA1lpqaxaMIv87Cxc/QJwcPfAu01HRj74MOHh4XTt2pVt\n27aVK1PWf7l6KoktX56ly+iGtOzrW4nWCyqba2MeQGlvj+83X9++tjdmLy/uexGDbODLfl8S4hpS\njRZWEud+g9+nglFf+LqFAwT251zzuUz6+Rq5BQby9UZsLVRse747brYW1WNvLaJGHbwqK3VF8AFS\nb8RydN0v3IyPIzn6Ogqlih5Pz2bg0GHExMQwcOBA1q1bh0ZTsQM4siyz8fMzRJ1PwdHDCnd/Oxq0\ndsOvmTOSQpzWrUnEzJhBwfXrBPwnXHVcVhyPbXuMPEMeq4esxt3avZosrERunIb4M6avDTrISYGb\nkXDmZ9BYw8B3IWQs4YlZDPl0H50bOLNsUjtxwrwUhODXIlJioln50vO4+PkTMvYRevXuQ1JSEoMG\nDWLlypU4OjpWqN+8LB3n9saQcC2D+KsZ5GXrcHC3os0gP4I6elbyXQgqSvwbb5K+fj2Njx0tUhae\nFs7EzRMJsA9g+cDlWKju0dluYpjJmyf6CDzwAwQP57sD13h1wwXeur8ZEzv4VbeFNRqR07YW4exT\nj/5PPkPc5TASjh9k27ZtODo6smXLFlq3bk1FH4IWNmraDq7PkOkhTHqvC/0nN0WtVbLzu4vEXxXr\nozUFlYc7xsxMjNlFk900dGzI293e5lzKOWbsmsH5lHs0kYhbEEzaDJ4hsPkFyE3j4U7+dAt0YeG6\n83R5ZxeDPtnHyiP3wJ5GNSIEv4YQ1Lk7rQbdx6ktG3DRqjhx4gRt27bl+vXrdOnShQ8++ACjseIb\nsEqlgsB27oyY2QpLOw2H/ogQp3RrCLddMxMSiy3v7dubBR0WcD75POM2jmPK9ikciD1w7/3/KVUm\n3/3sZNi+AIVC4qOxLZncrT4dApxQKmDB2nPsu1J+TzaBCSH4NYhu4x/B1sWVXcu/xM/Xl/379zN9\n+nQKCgp44YUX6NOnD1FRJR9gKQ2NhYp2g/25ceUmkeeEC1xNQOVmWpvXJ9z5sNXYoLFsH72dmW1m\ncvXmVZ7c8SSjNoxi1cVVXE2/eu+Iv2cIdJ4Bp1ZA+E5cbLS8OKgJix5oyc9PdCLQzYZnV5/mxk2R\nI7ciiDX8GsblIwfYsOhtej/2JK0GDAVg06ZNPPbYYyQmJlKvXj3279+Pr2/FPW8MeiOrXj2MWqvk\ngfntUYhN3GqlIDKSiAED8XznbRxGjCi1vs6gY/O1zXx/4XuupF0BwMnCCTcrN+w0dmiUGiQkJEnC\nWm1d6JqlypKJTSbiaFGxfaEqQZcLX3Y3nc4d+jG0HH+7KCIpi2Gf7aeRhy3fPdoee8uSw4vXFcSm\nbS1FlmV+fXMBidciePSjL7CydwAgKSmJESNGcPDgQRo3bsy+fftwdXWt8DiXj8Xz57cXcPKyRqVW\nYGWvpeOIAJy9RNrCqsaYl8ellq1wfe45XJ58osztZFkmJjOGI/FHOJ14mvT8dDIKMsg35Jv6lY1k\n67LJKMig4FbO2jxDHj42Pizusxh/e39z3E7lkJUIvz5mSq8YMgHcbuV1bjyILXE2PP3TKVxttLw7\nugU9GlX87+BeQQh+LSYlJoof5swAwNHTG4+Gjeh4/1iwsKRnz56EhobSpEkTOnXqhEajYeDAgQwb\nNqxcrmuyUebQ2ghSYk0bhQnX09HlGmjZ3xe/ZncOUWvjoMXOxfLublBQhMsdO2E7aCCeCxeadZzT\niad5ZtczGDEyr/08Onp2xMWy9Mxr1YJBDzsWwuElIN/av7J2gyf2cCbDilk/h3IlMQtfJysUEigk\nCTtLNY5WaiZ1qV+nHgRC8Gs5sWEXuHb6OMnRkUSdDcVo0NNq0DDqd+lJ7379iYiIKFR/wIABfPbZ\nZwQGBlZovNzMAg7+Fk7Y4ZKDdkkKiS6jGtKit4/wja5Erg4fgdrLi3pLl5h9rOjMaJ7e+TRX068C\n4Gntedvd01Zji4+ND9423thp7LBSW2GpskStUKNWqOHWf3kz52ZVdy5Al2c6rJV6FZYNBPdgmLSZ\nPFnJ13uvEp6UBYDeKJORq+NEZBrdA1354qE2VWNfDUAI/j1EVmoK+1f/wPk9O/Fo2Ii+02exc/ce\ncnNziYuL48MPP+TmzZtotVq+++47xo0bV+GxUmKzyMm4Q5ArGc7uieFaaDKNOrgT3MWrTH0qVQpU\nGiVKlSQeEsVg7aglbsY0DEnJ1P/9tyoZU2fUcT75PKcTTxOWFobeqEeWZdLz04nJiiEuOw6jfGev\nsBDXEFYMXlElthbi/B/wyyRoNwWGfFhslQe/OUJWvp6107tUrW3ViMh4dQ9h4+TMwGnP06BdRzYs\neps9X3/OmBdfRa0xJZCeOnUqs2bNYsWKFYwfP57Y2FhmzpxZIXF19rbBuYQkRT5Bjhzfcp2jG69x\n+UhCRW9J8C+8GznQwd2DvHNV52OvVqhp6daSlm4tiy03ykZy9blk67LJ1+dTYCxAZzQlHd98bTPL\nzy0nOiOaenb1qsxmAJreDzHH4dDn0PoR8GxRpIq7nQUREXU231KJCMGvRQS268Sg6TPZ/PmH/Pzq\nPJx9/jl9OKFja7TZGXz7x3pmz57NudOn+PLbZRUOzXAnJIVEuyH1adjGjez0O4e7vY0sY9DL6AsM\nGPQikNt/uXQ4noTIDFQBbhhSUjAWFKCo5P+ziqCQFFirrbFWWxcps9fYs/zccjZf28wTIWXfZK40\nus2CI1+YYvMUI/ie9hYkZuZjMMoohQdaIYTg1zKadO2JQa/n8O+riTofWqisvacTUr/uLN+5n+9W\nrORSxFV+/vlnfHx8Kt0ORw9rHD2KioGgfGTdzCfqQiqysynUhT4xCY1PzU5U72njSRv3Nmy6tomp\nLaZW/TKdlRME9ITzv0PfV+E/47vbW2AwyiRn5eNud4+GoqggQvBrIc169qVZz77Flk0FOr33P2a9\n9gaHDh2iVatWzJkzhyeeeAI7O7uqNVRQKva3PJ5yrUweJfr4uBov+ABDAobw+qHXuZh6kWDn4Ko3\noOlIWDcNYk+CT+HNWY9bIh+fnicE/z+Ik7b3IGOnPsXMgT1p2zSY5ORk5syZg6+vL++++y56vb70\nDgRVxt8urnka00GogsjaESumv19/VAoVm69urh4DggaDQm2a5f8HT/tbgp9xDySQqWSE4N+DWDs4\n0qpbTx5u15QN69fRo0cP0tPTmTdvHp07d+bChQvVbaLgFnauJsHPlmyQrKzIC7tUzRaVDXutPV29\nu7Ll2hYMxmpIPG7pCA37mBKk/yfGlPu/ZviCwgjBv0cJ6T+Ygpwc/G0s2b17N9u2baNevXocO3aM\nli1bMmXKFK5cuVLdZtZ5tJYqtNYqMlLysQgMJD+s9uQiHt5gOIm5iUz9c2r1ZOZqOhIyYiDmWKHL\nztYa1EpJzPCLQQj+PYpPk2Y4+/hydN0v7F31HZbJN9i8ehWPP/44er2eb7/9lqCgIIYMGcKKFSvI\nyMiobpPrLPYulmQk56INCiLv0qVaEwitj28fXun0ChdTLjJq/Shm7JrBc389x8KDC0nNSzW/AY0H\ngVILp34odFmhkHCztSBBzPCLIAT/HkWSJNoNG0VmSgonN6/j+MY/2PbJO3RzsuTP335m8uTJKJVK\nNm/ezEMPPYS7uztjxozhjz/+ID8/v7rNr1PYuViSkZSLRVBjjBkZ6OPiqtukMiFJEmMajWHtiLX0\n9etLbFYsUZlRbIzYyIydM8jVmzmipYUdtJtsiqwZsatQkYe9BXFC8IsgTtrWEfQ6HRf3/cWx9b+S\nFh/Ho4uWoldp+PXXX1m9ejX79u27XdfNzY0nn3ySqVOn4u1d8z1GajuH/ojg9J9RPPSYPdEPTsRn\nyRJse/eqbrMqzM6onTz/1/P0rNeTj3p+hFKhNN9gf0fWzM+Epw6aXDaB6StPcjEug12ze5pv7BqE\nyHglKIRKraZ57/6MffVdlCoVJzauxc3NjWnTprF3716ioqJ4//33ad68OYmJibz++uv4+Pjg7e3N\ngAEDeOWVV9i5cyc5OTnVfSv3HHYuFhiNMno3fwDyL9Wedfzi6OPbh7nt5/JX9F98ceYL8w6mtoSR\nX0F2EqybDhfWwYX1+FvnE5+RV2uWx6oKMcOvg2z/6jMu7N3F1MXLb4df/htZltm/fz+ffvopmzdv\nLiLwSqWS4OBgWrduTVBQEAEBAfj6+uLk5ISjoyO2trZotVoRM6ccRIelsv7j04x4vhW5M8ZhERSE\nz6efVLdZd83U7VNJyElg3Yh15h9s3yLY+drtb1OtG9A5ZQFHFt5XJ2Lmi1g6gjvSduj9nN21nVPb\nNtLlgQcLlUmSRLdu3ejWrRtGo5Fr164RGhrK/v372bNnD6dPn+bs2bOcPXv2jv0rlUqcnJxo3Lgx\nTZo0wdfXFy8vL7y8vPD29sbb2xtra2tUKhVKpRlf92sJfx++Sk/Oxa5xY/Jq+Qz/b9q4t+Hz05+T\nUZCBncbMh/66zYTg4aDPg8SLOP42hVdV35OQ0a9OCH5ZEYJfB3Hy8qFBmw6c3raJ9sNGo7Yo/jSi\nQqGgQYMGNGjQgJEjRwKQk5PDmTNnOHXqFOHh4Vy9epWYmBjS0tJIS0sjKyuLgoICkpKSSEpKYv/+\n/SXaolKpsLOzw87ODpXK9OtoYWGBj48Pvr6+tx8Qrq6uaLVaNBoNdnZ2ODg4YG1tjUKhQKFQYGFh\ngZWVFQpF7VultHHUIikkMpJzcQ1qTOaOHRizs1FY1+7QFS1cTXFuziadpYt3FUSudG5g+te9KXFX\nTjDuzBLCTq+BAVPMP3YtwayCL0nSDOBpQA9skmV5jjnHE5SddveNJOL4Yb6a/ihKlQq1hQUeDRrh\n1SgISzv7O7ZzcPOgY8eOdOzY8Y51dDodCQkJhIWFERYWRmxsLDdu3ODGjRu3v87Ly0On06HX60lN\nTSU1tbAb37lz5yp0X2q1+vZykiRJtx8IkiTd/vwXpVKJWq2+Xe/vfjQaDSqVyuzLU506daKHx2Nk\nJOdhERQEskze5ctYtWpl1nHNTXOX5khInEk6UzWC/y8M3V/k6OmdtD66ABxlaPsYmHPzuJZgNsGX\nJKkXMBxoIctyviRJbuYaS1B+vIOC6TZhEum3EmfnZmYQfeEsYQf2lNxQkhj89CyadO15xypqtRof\nHx98fHzo27f4mD9/U1BQQEZGBhkZGRgMphOb2dnZREdHExUVRWxsLLGxsaSkpKDT6cjPzycjI4Ob\nN2+SlZWFLMsYjUby8vLIyclBp9OV6+dQE7h48SLtXhpGRrIW7YAgAPIvXar1gm+jsaGBQwNCk0NL\nr1zJuDlYM7LgGX5z+h7fzbPh5A/QdAS3M7hUFAs7aDIcbGpnNi1zzvCfAt6RZTkfQJblRDOOJagA\n7YePLvS9LMtkpaZQkFu8/7QsG9m17Au2LF6ExtKSBm063LUNGo0GFxcXXFwKp9lr2bL4OO0lYTQa\nCwn+3w8Dg8GALMvFemzIsozBYECv199+4MiyjF6vJz8/3+yxh2bMmMGuXbu4kRGBpsAJtbcXCltb\nctHMkg8AABexSURBVM+cxXbAACS1GqVN7c0zHOIawvbI7RhlIwqp6pbbtColRmt3vvD9kP/1DYft\nC2Dn65XT+ZZ50GQoeDQvXzt7X2gxpnJsqCDmFPxGQDdJkt4C8oDZsiwf+28lSZKmYgryiK+vrxnN\nEZTG/9u78/Aoq3uB49/fO8lkHbJBFgjIYgKGsAmCKC4gV0EeFfWqSFGrVFrRPlaf9iKltiLFq3i7\neN0QlVsqpe5VKKCCgCt7Iawl7BI2kZCwhUCSc/+YAQKEZLZ3FvL7PE+ezPLOe34nA785c855zxER\nXBn17296y6+e5L1xY5jxp2dp07VHw90dAjl5HWh/eR+aNLP3S55lWcTFxdlaRrD16dOHefPmsX1P\nMVkZXTlRWU18hw6Uf/gh5R+6FwZr9X+TSerdO8yR+qdLsy58sPEDth3cRtuUtiEtO6tJPHsPVkLh\nbVAwGKq92L+hIQe2ub8tFE1z777lq7z/gITUho+zSUDTMkVkLpBdx1NjgPHAPOBR4DLgHaCtqadA\nnZYZHY4eLOfTV//MwX0Nf2mrOnGcsj3uK0dTs3KwdFbOGVZs3saLMz6lfYvmjLjqOpo0jccyVdRU\nuK8SrS47gMQ6ic3JCXrZOXntGTDysaCft7bNZZsZ/PFgxl05jsEXD7a1rLM98Jel7Ck/xqxHrwr+\nyWtqoMaH7sNV78L0R+Dn/zo9uBxEIZmWaYw5bwetiDwEfOhJ8EtEpAZoCuwLpEwVfolNUrh11O+8\nPr5s7x42LPyK77dtsTGq6HRpagbM+JSS/aVgZZCYkoLLM00T4PiWLVRu2EBSQUesegbT/ZGSWVdb\nLbjapLTBFeuiaF9RyBN+dko8RTvK7Dm5ZYHlw7fJZM+G70dLbUn43rKzS+cjoB+wQETyASegG002\nQqlZ2fQaHN6+y0g2euJk9uzZQ7WrNynNOzBo5Olt+6oPHmTTtX1JPlRFi9+OCmOU/rHEolOzTqza\ntyrkZWc3iWf/kePMWbcXR63hg0xXPIUtgvvh2SDPkg9UhGBRuXrYmfAnA5NFZA1wHLivvu4cpRqr\n7t27M3PmTI4m7OK7dc2orKgiLsH9X9PRpAmpd9xB6dSpZD7+mC1dO3br3Kwzk1ZN4siJI3XukWuX\nNk3dZT3413O7iV8Y0pVbuoZwnagE9wY3HN0fujLrYFvCN8YcB4Y1eKBSjdzJhP/9ka00tTqzrWgf\n7S8/ndjT772H0qlT2fVfo4hr377Oc1gJ8TT92c8i8mKtK5pfwcSiiby68lV+edkvQ1buoE45tGuW\nzInq0xukGOCZmesZ9cEq8jJdFDQP0bafiRnu30cv3Ba+UsoL3bu792T99+Y19Ox5J5v+dWbCj23R\ngrQfDaX84+kcKy4+9wQ1NdQcOkRcfj4pN90UqrC91i2zG3e1v4sp66ZwefPL6dOiT0jKtSypM6G/\n9KNu3PTi1/x06jLeuPcy4mIsmiTEkp7ktC+Y+BQQR9i7dHTxNKXCbOfOneTm5pKamsr01xaz5sud\nPPD8Vae6dRpiqqrYcFlPUm+/nezfjLE5Wv8cqzrG3TPvpvRYKVMGTKFJXBNirVhcTldY4lm+/QBD\nJi3kRLU7/zljLBY+0Y+MZBun9T5/MXQYBDcFf2E8XTxNqSjRvHlzsrKy2Lt3L7HNjlJTZc7p1qmP\nxMSQ0LEjFatCPzDqrfiYeJ6/+nnunnk3N310+ltIZmImBekFDCsYRq+cwC/k81b3i9L4+OE+bNh7\nkJLSCv4wp5gV35XRvyDLvkIT0sPepaMtfKUiwKBBg5g1axZv//1tjhXlcqKymsQm3ncxVO0vpbq8\nHGeb1j6v/WM5LHLbp9Gma1OatnT5vPhATJwDy/LuVev2r6Non3uphYqqCooPFLN091IqqiuYPng6\nTRPqv/DPDhXHqyl86lMevrYdj19f9xhJUEwe4O7WuX9m0E+tLXylokj37t2ZNWsWK1au4Cd39GXz\nv3xbieSE4zAVO0tISm6JI9W3KzkrK6pY8+VOiubt8Ol1J90xugeZF3k3+FmQUUBBRsEZj20t38rt\n029nwtIJTLh6gl8xBCLB6SA/y8XKknJ7C0rMgNLwXouiCV+pCNClSxcAVq1axcXPZnJxd9+WoTix\nN5NN1/ycrFsySb/vPp/LP36siu/WlnL4gO/7wCalBtbv3SalDQ92fpBXVr7Cze1uDtmgbm1dW6Yw\na/UejDH2rY6akBb2Lh1N+EpFgE6d3Atx+b0sdFYmMdnZVBT514/vjI/x+UMmmIYXDmf21tn87pvf\n0TOn53mPG9R2kC0fCJ1zU/n7kh1s33+U1k1tmtqamO6eh28MhGlHOE34SkWAdu3akZCQwI4dOygr\nKyPVx24ZgIQuXagoCv1SxMHgdDgZf+V4nlr4FCu/X1nnMWWVZaz4fgUzb50Z9I3Ru+S6/95FJWU2\nJvwM9/o7xw9DXHhmJ2nCVyoCnNwrePny5axZs4Y+fXxvxSZ07syhTz+l6ocfiGka+sHPQHVq1okP\nbv7gvM/P2T6Hxxc8zoKSBVzX6rqglp2flUx8rEXRjnL7rsBN8CyvcLQ0bAk/+vaDU+oCdbJbp779\nguuT0NU9DhDJ0zMD0bdlX3KScvjb+r8F/dwxDovC5ikUldi02BqcXk8njMsraMJXKkIEmvDjCwrA\n4eDosuVUHz5MzTHfB2AjWYwVw5AOQ1i6ZykbSjcE/fxdWqayZmf5GUsxBNXJ5RXCeLWtJnylIkRh\nYSHgf8K3EhKI79CB0smTKe5xGRsu60nZ++8HM8Swuz3vduId8Uz797Sgn7tLy1Qqq2oo3nso6OcG\nanXpHLDn/F7QPnylIkTtmTr+Tg/MGfc0RxYvAeDwl1+w+zdPYqqqSBsyJKixhktKXAo3tbuJDzd+\nyOLdiwG4v+P93NXhroDP3SXXvWTyjKLdHKw4vbWlCHRqkUJSXIDp8tQCauHr0tGEr1SEyM7OJiMj\ng/37959aX8dX8QUF7q4dIG3o3ex89BfseWosR5csQRITsRISyfjJcGKzbFxCwGYjOo+g2lRTVVPF\nol2LmLV1VlASfqv0RDJdcUz8YjMTv9h8xnO3dWvBH+/yfZ/lMySkAhLWLh1N+EpFCBGhU6dOLFiw\ngNWrV/uV8Guz4uLI/d8X2P27pzjy7bcAVB84wKFPPiH35ZdI6Ny5gTNEpuykbMZeMRaAcQvHMXvr\n7KBcMCUifDjyCnaUVpzx+DtLv+Ofq3YzZtAlgS2uZjncq2ZqC18pBZyR8AcOHBjw+cTppPl/P3Pq\n/rHiYkoeGsn2YfeQcvttWM44rKREMkaMwIqPD7i8UMtPy+fd4nfZc2QPOcmBbw6Tm5ZIblriGY9l\nJDv5aOUu3l9ewk+vCXB7wsSMsF5tq4O2SkWQQGfqNCQ+P5/W779HYq9eHJw+gwPvvccPr7zKoc8/\nt6U8u+Wn5wOwsWyjfWVkuejZOp1pS76jpibAxSYT03WWjlLKze6EDxCTlkar1yfRfvky2i9ZjOVy\ncXTRItvKs9PFqRcDUHygjo1hguhHl7di+/6jfL0pwG25E9K1S0cp5daxY0cA1q9fz549e8jOzra1\nPImJIbFXT4588629C4fZxOV00SK5BcWl9ib8AYXZZCQ5+cu327goI7HhF5xHq8R0ZO/aIEbmG034\nSkUQl8vFgAED+OSTTxg6dChz5szB4QjuujFnS+rdm8NzP+fEjh04W7WytSw75KXl2d7Cj4txcOdl\nLXl1wWbm/du3patr23h1GrE6S0cpddLkyZPp1q0b8+fPZ+zYsTz99NO2lpfU+woAjny7MCoTfn5a\nPl+VfMXx6uM4HfbtS/tI34vpkO2iOoB+fOvQejhxFE5UQGxCEKPzjiZ8pSJMTk4O06ZNo3///vz+\n979n/vz5uFwusrKyyM/P55JLLuHqq68mPT09KOU527QmJiuLI4sWkTYk8PnsoZaXlke1qWZL+RY6\npHewrZykuJjAF1ZbdvLiq1JIsWmRtnpowlcqAvXr14/x48fz61//mq+//vqc5x0OB1deeSVDhgxh\n+PDhOJ3+t2xFxN2tM38+pqYGsaJrLkd+mnumTvGBYlsTflDUXkAtDAk/ut5ZpRqR0aNHU1xczIIF\nC5gxYwYTJ07kscceo2/fvogIX375JSNHjqSwsJCPP/6YyspKv8tKuqI31eXlHFu/Pog1CI1WrlbE\nOeJsH7gNijAvoKYtfKUiWF5eHnl5eec8Xl5ezsyZMxk7dizFxcUMHjwYy7Jo1aoVmZmZ7lZ7UhJP\nPvkk1157bYPlJF5+OQCHPpuDw+XCSkggplmzYFfHFjFWDO1S29k+cBsUtdfEDwNt4SsVhVJSUhg6\ndChr1qzhhRdeOPWhsG3bNpYsWcLixYuZN28e119/Pe+8806D54vNzCQuP5/9r73G5utvYONVV/P9\nn/+MqbFpqeAgy0/Lt/Xiq6AJ85r4YkyAV44FUY8ePcyyZcvCHYZSUen48eNs2bKFsjL3Jh7Tpk3j\nxRdfREQYMWIE2dnZNG3alPvuuw+X69wdlyq3bOXYavfmKUcWLqL8o49I7n8d2U8+iZxnjMByOrGS\nbNoS0AdvrXuLCUsn4HK6ECL8WoKKA2DFguPMDpZhLfrxUL/n/TqliCw3xvRo6Djt0lHqAuF0OunQ\n4fSgZa9evcjNzWXUqFG89tprpx6fMWMGs2fPxjprcDaubRvi2rYBoMnNNxNfUMDeZ59l09x6ll2I\njaXd7Nk4c0M/AFnbwDYD2XtkLydqToQ1Dq+s+QAOnnvFbofUctuL1ha+Uhe4+fPns3DhQiorK3n5\n5ZfZv38/zzzzDKNHj27wtRVFRVSsXlPnc8e3b+fAW2/R6q9TSOrZM9hhKx9428LXhK9UIzJ79mxu\nvPFGLMti7ty59O3b1+9zVaxew7Y77iD3lVdw9fP/PCpw3iZ82wZtRaSriCwSkZUiskxEtAmgVJgN\nHDiQUaNGUVNTQ79+/cjIyKBPnz5MnTqVGh8HaE/23dccOWJHqMoGds7SmQCMNcZ0BX7rua+UCrNx\n48Zx7733kpycTGlpKd988w333HMPl156Ka+//jqfffYZa9eu5dCh+vd2tZJPJvzDoQhbBYGdCd8A\nTTy3U4BdNpallPJSbGwsU6ZM4eDBg+zevZs333yTli1bUlRUxIgRI7jhhhsoLCzkueeeq/c8jpMt\n/MOa8KOFnbN0fgF8KiL/g/uD5Yq6DhKREcAIgFZRuHCTUtFKRMjOzuaBBx5g6NChvPHGGyxZsoSd\nO3dSUlJC27Zt6399YiKIUK1dOlEjoIQvInOBuhbsHgNcBzxmjPlARO4E3gT6n32gMWYSMAncg7aB\nxKOU8k98fDyPPPKIT68REaykJGoOa8KPFgElfGPMOQn8JBH5K/Co5+57wBuBlKWUijxWcrIO2kYR\nO/vwdwHXeG73A6LgumellC/cLXztw48WdvbhPwi8ICIxwDE8/fRKqQuHlZykLfwoYlvCN8Z8DXS3\n6/xKqfBzaAs/quhqmUopv1lJydQc1RZ+tNCEr5Tym5WcTLXO0okamvCVUn6zkrQPP5powldK+c1K\ndvfhR9IijOr8NOErpfxmJSVBTQ3m2LFwh6K8oAlfKeU3R3IyoOvpRAtN+Eopv+kSydFFE75Sym+W\np4WvM3WigyZ8pZTfrERt4UcTTfhKKb+dbOHrJijRQRO+UspvVlIioC38aKEJXynlN52lE1004Sul\n/KazdKKLJnyllN8kIQEsi2pt4UcFTfhKKb+d2ubwyNFwh6K8oAlfKRUQKzlZ+/CjhCZ8pVRArKRE\n7cOPEprwlVIBcSRpCz9aaMJXSgVE18SPHprwlVIBsZKTqdYrbaOCJnylVEB0lk700ISvlAqIztKJ\nHprwlVIBOTlLR7c5jHya8JVSAXEkJ7u3OayoCHcoqgGa8JVSATm5no4urxD5NOErpQJyek18nZoZ\n6TThK6UCcmrFTN3mMOJpwldKBcRK0hZ+tNCEr5QKyOk18bUPP9JpwldKBcSRrJugRIuAEr6I3CEi\na0WkRkR6nPXcaBHZJCIbROSGwMJUSkUqnaUTPWICfP0a4DbgtdoPikgBMAToCDQH5opIvjGmOsDy\nlFIRRmfpRI+AWvjGmPXGmA11PHUL8LYxptIYsxXYBPQMpCylVGSS+HhwOHSWThSwqw+/BbCj1v0S\nz2PnEJERIrJMRJbt27fPpnCUUnY5vc2hJvxI12CXjojMBbLreGqMMebj872sjsfqXGjDGDMJmATQ\no0cPXYxDqShkJSfpAmpRoMGEb4zp78d5S4CWte7nArv8OI9SKgo4kpI4NGcOm9es9ul1LV96CWfr\n1vYEpc4R6KDt+UwHponIH3EP2uYBS2wqSykVZun3P8DhL77w+XXidNoQjTqfgBK+iNwKvAg0A2aK\nyEpjzA3GmLUi8i6wDqgCHtYZOkpduFJvu5XU224NdxiqAQElfGPMP4B/nOe58cD4QM6vlFIqePRK\nW6WUaiQ04SulVCOhCV8ppRoJTfhKKdVIaMJXSqlGQhO+Uko1EprwlVKqkRBjImf5GhHZB2z33G0K\n/BDGcIJF6xFZtB6R40KoA0RGPS4yxjRr6KCISvi1icgyY0yPho+MbFqPyKL1iBwXQh0guuqhXTpK\nKdVIaMJXSqlGIpIT/qRwBxAkWo/IovWIHBdCHSCK6hGxffhKKaWCK5Jb+EoppYIoYhK+iKSLyBwR\n2ej5nVbPsU1EZKeIvBTKGL3hTT1EpKuILBSRtSKySkTuCkesZxORASKyQUQ2icgTdTwfJyLveJ5f\nLCKtQx9lw7yox+Miss7zt/9cRC4KR5wNaagetY77TxExIhKRM0W8qYeI3Ol5T9aKyLRQx+gNL/5d\ntRKR+SKywvNv68ZwxFkvY0xE/AATgCc8t58Anqvn2BeAacBL4Y7bn3oA+UCe53ZzYDeQGua4HcBm\noC3gBIqAgrOOGQlM9NweArwT7r+3n/XoCyR6bj8UrfXwHOcCvgQWAT3CHbef70cesAJI89zPDHfc\nftZjEvCQ53YBsC3ccZ/9EzEtfOAWYIrn9hRgcF0HiUh3IAv4LERx+arBehhjio0xGz23dwHf4941\nLJx6ApuMMVuMMceBt3HXpbbadXsfuE5E6tqwPpwarIcxZr4x5qjn7iLcey5HGm/eD4BxuBsZx0IZ\nnA+8qceDwMvGmAMAxpjvQxyjN7yphwGaeG6nEIH7eEdSws8yxuwG8PzOPPsAEbGAPwC/CnFsvmiw\nHrWJSE/cLYbNIYitPi2AHbXul3geq/MYY0wVUA5khCQ673lTj9qGA7Ntjcg/DdZDRLoBLY0x/wxl\nYD7y5v3IB/JF5BsRWSQiA0IWnfe8qcdTwDARKQFmAT8PTWjes2sT8zqJyFwgu46nxnh5ipHALGPM\njnA2LINQj5PnyQHeAu4zxtQEI7YA1PUHPXsKlzfHhJvXMYrIMKAHcI2tEfmn3np4Gj9/An4cqoD8\n5M37EYO7W+da3N+2vhKRQmNMmc2x+cKbetwN/MUY8wcR6Q285alHuP9vnxLShG+M6X++50Rkr4jk\nGGN2exJhXV/regNXichIIBlwishhY8x5B7TsEIR6ICJNgJnAb4wxi2wK1RclQMta93M59yvpyWNK\nRCQG99fW0tCE5zVv6oGI9Mf9AX2NMaYyRLH5oqF6uIBCYIGn8ZMNTBeRm40xy0IWZcO8/Xe1yBhz\nAtgqIhtwfwAsDU2IXvGmHsOBAQDGmIUiEo97nZ3I6aIK9yBCrQGP5zlzsHNCA8f/mMgctG2wHri7\ncD4HfhHueGvFFANsAdpwelCq41nHPMyZg7bvhjtuP+vRDXcXWl644w2kHmcdv4DIHLT15v0YAEzx\n3G6Ku+skI9yx+1GP2cCPPbcvwf2BIOGO/YwYwx1ArT9WhicJbvT8Tvc83gN4o47jIzXhN1gPYBhw\nAlhZ66drBMR+I1DsSYZjPI89DdzsuR0PvAdsApYAbcMds5/1mAvsrfW3nx7umP2px1nHRmTC9/L9\nEOCPwDpgNTAk3DH7WY8C4BvPh8FK4Ppwx3z2j15pq5RSjUQkzdJRSillI034SinVSGjCV0qpRkIT\nvlJKNRKa8JVSqpHQhK+UUo2EJnyllGokNOErpVQj8f9PqfDT1A/HVQAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x130690490>"
+       "<matplotlib.figure.Figure at 0x1e091e290>"
       ]
      },
      "metadata": {},
@@ -265,17 +326,448 @@
     "for hist in trans_hists:\n",
     "    cross_prob = trans_hists[hist].reverse_cumulative()\n",
     "    plt.plot(cross_prob.x, np.log(cross_prob))\n",
-    "plt.plot(trans.tcp.x, np.log(trans.tcp))"
+    "plt.plot(trans.tcp.x, np.log(trans.tcp), '-k', lw=2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['{x|opX(x) in [-inf, -0.1]}', '{x|opX(x) in [-inf, -0.2]}', '{x|opX(x) in [-inf, -0.24]}', '{x|opX(x) in [-inf, -0.27]}', '{x|opX(x) in [-inf, -0.3]}', '{x|opX(x) in [-inf, -0.35]}']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print [str(e.interface) for e in trans_hists.keys()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100001"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(storage.steps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "#import logging.config\n",
+    "#logging.config.fileConfig(\"../resources/debug_logging.conf\", disable_existing_loggers=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resampling = paths.numerics.BlockResampling(storage.steps, n_blocks=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "rate_df_func = lambda steps: mistis.rate_matrix(steps, force=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2min 9s, sys: 1 s, total: 2min 10s\n",
+      "Wall time: 2min 10s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "rates = paths.numerics.ResamplingStatistics(function=rate_df_func, inputs=resampling.blocks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.18014e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>5.32682e-06</td>\n",
+       "      <td>9.96266e-06</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             B            C            A\n",
+       "B          NaN          NaN  6.18014e-06\n",
+       "A  5.32682e-06  9.96266e-06          NaN"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000005</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>0.000004</td>\n",
+       "      <td>0.000012</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          B         C         A\n",
+       "B       NaN       NaN  0.000005\n",
+       "A  0.000004  0.000012       NaN"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.std"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.30477e-07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>6.00702e-07</td>\n",
+       "      <td>6.38863e-07</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             B            C            A\n",
+       "B          NaN          NaN  6.30477e-07\n",
+       "A  6.00702e-07  6.38863e-07          NaN"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.percentile(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3.83769e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>2.69625e-06</td>\n",
+       "      <td>2.04616e-06</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             B            C            A\n",
+       "B          NaN          NaN  3.83769e-06\n",
+       "A  2.69625e-06  2.04616e-06          NaN"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.percentile(25)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.15924e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>4.97539e-06</td>\n",
+       "      <td>4.75777e-06</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             B            C            A\n",
+       "B          NaN          NaN  6.15924e-06\n",
+       "A  4.97539e-06  4.75777e-06          NaN"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.percentile(50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>7.6309e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>6.43053e-06</td>\n",
+       "      <td>1.12021e-05</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             B            C           A\n",
+       "B          NaN          NaN  7.6309e-06\n",
+       "A  6.43053e-06  1.12021e-05         NaN"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.percentile(75)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>A</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>B</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.82659e-05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>A</th>\n",
+       "      <td>1.69719e-05</td>\n",
+       "      <td>3.85193e-05</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             B            C            A\n",
+       "B          NaN          NaN  1.82659e-05\n",
+       "A  1.69719e-05  3.85193e-05          NaN"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates.percentile(100)"
+   ]
   },
   {
    "cell_type": "code",
@@ -303,9 +795,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "# if our large test file is available, use it. Otherwise, use file generated from toy_mistis_1_setup_run.ipynb\n",
     "import os\n",
-    "test_file = \"\"../toy_mistis_1k_OPS1.nc\"\n",
+    "test_file = \"../toy_mistis_1k_OPS1.nc\"\n",
     "filename = test_file if os.path.isfile(test_file) else \"mistis.nc\""
    ]
   },

--- a/openpathsampling/high_level/network.py
+++ b/openpathsampling/high_level/network.py
@@ -547,8 +547,8 @@ class MSTISNetwork(TISNetwork):
         """
         # for each transition in from_state:
         # 1. Calculate the flux and the TCP
-        self._rate_matrix = pd.DataFrame(columns=self.states,
-                                         index=self.states)
+        names = [s.name for s in self.states]
+        self._rate_matrix = pd.DataFrame(columns=names, index=names)
         for stateA in self.from_state.keys():
             transition = self.from_state[stateA]
             # set up the hist_args if necessary
@@ -568,7 +568,9 @@ class MSTISNetwork(TISNetwork):
 
         for trans in self.transitions.values():
             rate = trans.rate(steps)
-            self._rate_matrix.set_value(trans.stateA, trans.stateB, rate)
+            self._rate_matrix.set_value(trans.stateA.name,
+                                        trans.stateB.name,
+                                        rate)
             #print trans.stateA.name, trans.stateB.name,
             #print rate
 
@@ -800,8 +802,10 @@ class MISTISNetwork(TISNetwork):
 
 
     def rate_matrix(self, steps, force=False):
-        self._rate_matrix = pd.DataFrame(columns=self.final_states,
-                                         index=self.initial_states)
+        initial_names = [s.name for s in self.initial_states]
+        final_names = [s.name for s in self.final_states]
+        self._rate_matrix = pd.DataFrame(columns=final_names,
+                                         index=initial_names)
         for trans in self.transitions.values():
             # set up the hist_args if necessary
             for histname in self.hist_args.keys():
@@ -818,6 +822,8 @@ class MISTISNetwork(TISNetwork):
                 # probability automatically
 
             rate = trans.rate(steps)
-            self._rate_matrix.set_value(trans.stateA, trans.stateB, rate)
+            self._rate_matrix.set_value(trans.stateA.name,
+                                        trans.stateB.name,
+                                        rate)
 
         return self._rate_matrix

--- a/openpathsampling/numerics/__init__.py
+++ b/openpathsampling/numerics/__init__.py
@@ -6,3 +6,4 @@ from wham import WHAM
 from lookup_function import (LookupFunction, LookupFunctionGroup,
                              VoxelLookupFunction)
 
+from resampling_statistics import ResamplingStatistics, BlockResampling

--- a/openpathsampling/numerics/__init__.py
+++ b/openpathsampling/numerics/__init__.py
@@ -6,4 +6,4 @@ from .wham import WHAM
 from .lookup_function import (LookupFunction, LookupFunctionGroup,
                              VoxelLookupFunction)
 
-from resampling_statistics import ResamplingStatistics, BlockResampling
+from .resampling_statistics import ResamplingStatistics, BlockResampling

--- a/openpathsampling/numerics/resampling_statistics.py
+++ b/openpathsampling/numerics/resampling_statistics.py
@@ -8,7 +8,12 @@ import numpy as np
 # numpy arrays and using the numpy functions. However, you'd have to be very
 # careful that the rows and columns still correspond to the same things,
 # i.e., that there's no permutation of index order. Using pandas protects us
-# from such problems.
+# from such problems. Alternatively, it may be possible to bunch these into
+# a pandas.Panel, and use pandas functions. All requires some performance
+# testing; the advantange of the approach below is that when we want both
+# mean and std, the mean can be calculated first and passed to the std to
+# speed it up. (However, performance probably won't matter much for the
+# things we'll be doing).
 
 def mean_df(objects):
     """Basic calculation of mean (average) of a list of objects.
@@ -78,7 +83,9 @@ class BlockResampling(object):
     """Select samples according to block resampling.
 
     If neither n_blocks nor n_per_block are set (as is the default
-    behavior) then n_blocks=20 is used.
+    behavior) then n_blocks=20 is used. The blocks are always of the same
+    size, if the number of samples doesn't divide evenly, then the extra
+    samples are placed in the `unassigned` attribute.
 
     Parameters
     ----------

--- a/openpathsampling/numerics/resampling_statistics.py
+++ b/openpathsampling/numerics/resampling_statistics.py
@@ -1,5 +1,13 @@
 """
 Tools for resampling functions that output pandas.DataFrame objects.
+
+Typically, you use these tools in 3 steps:
+
+1. Create resampling groups of data, using, e.g., BlockResampling
+2. Create a function that maps a list of input data into the desired output
+   DataFrame
+3. Create a ResamplingStatistics object using the `input` from step 1 and
+   the `function` from step 2.
 """
 
 import numpy as np
@@ -18,7 +26,7 @@ import pandas as pd
 # things we'll be doing).
 
 def mean_df(objects):
-    """Basic calculation of mean (average) of a list of objects.
+    """Basic calculation of mean (average) of a list of DataFrames.
 
     Parameters
     ----------
@@ -27,7 +35,7 @@ def mean_df(objects):
         have to be DataFrames. They must be closed on the `sum` operation
         and over division by a float.
 
-    Returns
+Returns
     -------
     pandas.DataFrame :
         the mean of each element in the DataFrame
@@ -35,7 +43,8 @@ def mean_df(objects):
     return sum(objects) / float(len(objects))
 
 def std_df(objects, mean_x=None):
-    """
+    """Standard deviation of a list of DataFrames.
+
     Parameters
     ----------
     objects : list of pandas.DataFrame
@@ -57,11 +66,16 @@ def std_df(objects, mean_x=None):
 
 class ResamplingStatistics(object):
     """
+    Contains and organizes resampled statistics.
+
     Attributes
     ----------
     results : list of pandas.DataFrame
+        the result DataFrames after applying the function
     mean : pandas.DataFrame
+        DataFrame containing mean of the result DataFrames
     std : pandas.DataFrame
+        DataFrame containing standard deviation of the result DataFrames
 
     Parameters
     ----------

--- a/openpathsampling/numerics/resampling_statistics.py
+++ b/openpathsampling/numerics/resampling_statistics.py
@@ -170,9 +170,9 @@ class BlockResampling(object):
         if n_blocks is None and n_per_block is None:
             n_blocks = 20
         if n_blocks is None and n_per_block is not None:
-            n_blocks = self.n_total_samples / n_per_block
+            n_blocks = self.n_total_samples // n_per_block
         elif n_blocks is not None and n_per_block is None:
-            n_per_block = self.n_total_samples / n_blocks
+            n_per_block = self.n_total_samples // n_blocks
 
         self.n_blocks = n_blocks
         self.n_per_block = n_per_block

--- a/openpathsampling/numerics/resampling_statistics.py
+++ b/openpathsampling/numerics/resampling_statistics.py
@@ -92,30 +92,10 @@ class ResamplingStatistics(object):
     def __init__(self, function, inputs):
         self.function = function
         self.inputs = inputs
-
-        # DEBUG
-        #self.results = []
-        #for inp in self.inputs:
-            #logger.debug("Starting input # " + str(self.inputs.index(inp)) +
-                         #"\n")
-            #self.results.append(self.function(inp))
-        # END DEBUG
-
         self.results = [self.function(inp) for inp in self.inputs]
-        #self.mean = mean_df(self.results)
-        #self.std = std_df(self.results, mean_x=self.mean)
         self._mean = None
         self._std = None
         self._sorted_series = None
-
-        # index and columns should always be the same; take them from mean
-        #self.index = self.mean.index
-        #self.columns = self.mean.columns
-
-        #self.sorted_series = {
-            #loc: pd.Series(df.loc[loc] for df in self.results).sort_values()
-            #for loc in itertools.product(self.index, self.columns)
-        #}
 
     @property
     def mean(self):

--- a/openpathsampling/numerics/resampling_statistics.py
+++ b/openpathsampling/numerics/resampling_statistics.py
@@ -1,0 +1,68 @@
+"""
+Tools for resampling functions that output pandas.DataFrame objects.
+"""
+
+def mean_df(objects):
+    """Basic calculation of mean (average) of a list of objects.
+
+    Parameters
+    ----------
+    objects : list of objects
+        the objects to be averaged; must be summable (i.e., sum(objects)
+        must work and return an object of the same type) and dividable by
+        float (i.e., dividing by a float must work and return an object of
+        the same type).
+    """
+    return sum(objects) / float(len(objects))
+
+def std_df(objects, mean_x=None):
+    """
+    Parameters
+    ----------
+    objects : list of pandas.DataFrame
+        the DataFrames to calculate the standard deviation
+    mean_x : pandas.DataFrame
+        (optional) pre-calculated mean of the `objects` list. If None
+        (default), then the mean will be calculated.
+
+    Returns
+    -------
+    pandas.DataFrame
+        the standard deviation of each element in the dataframe
+    """
+    if mean_x is None:
+        mean_x = mean_df(objects)
+    sq = [o**2 for o in objects]
+    variance = mean_df(sq) - mean_x**2
+    return variance.applymap(math.sqrt)
+
+class ResamplingStatistics(object):
+    """
+    Parameters
+    ----------
+    function : callable
+        the function to apply the statistics to.
+        Must take one item from the list `inputs` and return a pandas.DataFrame
+    inputs : list
+        each element of inputs is can be used as input to `function`
+    """
+    def __init__(self, function, inputs):
+        self.function = function
+        self.inputs = inputs
+        self.results = [self.function(inp) for inp in self.inputs]
+        self.mean = mean_df(self.results)
+        self.std = std_df(self.results, mean=self.mean)
+
+    def percentile_range(self, min_percentile, max_percentile):
+        pass
+
+class BlockResampling(object):
+    def __init__(self, all_samples, n_blocks=20, n_samples_per_block=None):
+        self.n_samples = len(all_samples)
+        if n_samples_per_block is not None:
+            n_blocks = self.n_samples / n_samples_per_block
+        else:
+            n_samples_per_block = self.n_samples / n_blocks
+
+        self.blocks = [all_samples[i:i+n_samples_per_block]
+                       for i in range(n_blocks)]

--- a/openpathsampling/numerics/resampling_statistics.py
+++ b/openpathsampling/numerics/resampling_statistics.py
@@ -63,6 +63,7 @@ def std_df(objects, mean_x=None):
     """
     if mean_x is None:
         mean_x = mean_df(objects)
+    n_obj = float(len(objects))
     sq = [o**2 for o in objects]
     variance = mean_df(sq) - mean_x**2
     return variance.applymap(np.sqrt)

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pandas.util.testing import assert_frame_equal
 from nose.tools import (assert_equal, assert_not_equal, assert_items_equal,
                         assert_almost_equal, raises)
 from nose.plugins.skip import Skip, SkipTest
@@ -18,21 +19,59 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 class TestResamplingStatistics(object):
     # NOTE: we test the mean_df and std_df functions within this
     def setup(self):
-        pass
+        # order of the column/index labels should not matter
+        self.df1 = pd.DataFrame([[1.0, 2.0], [2.1, 3.0]],
+                                columns=['A', 'B'], index=['A', 'B'])
+        self.df2 = pd.DataFrame([[2.5, 1.5], [3.5, 2.4]],
+                                columns=['B', 'A'], index=['A', 'B'])
+        self.df3 = pd.DataFrame([[2.25, 3.25], [1.25, 2.25]],
+                                columns=['A', 'B'], index=['B', 'A'])
+        self.df4 = pd.DataFrame([[3.25, 2.25], [2.25, 1.25]],
+                                columns=['B', 'A'], index=['B', 'A'])
+        self.inputs = [self.df1, self.df2, self.df3, self.df4]
 
     def test_initialization(self):
-        pass
+        stats = paths.numerics.ResamplingStatistics(
+            function=lambda x: x,
+            inputs=self.inputs
+        )
+
+        for (truth, beauty) in zip(self.inputs, stats.results):
+            assert_frame_equal(beauty, truth)
+
+        expected_mean = pd.DataFrame([[1.25, 2.25], [2.25, 3.25]],
+                                     columns=['A', 'B'], index=['A', 'B'])
+        assert_frame_equal(stats.mean, expected_mean)
+        # TODO: add test for std
+        expected_std = pd.DataFrame(
+            [[0.17677669529663689, 0.17677669529663689],
+             [0.10606601717798207, 0.17677669529663689]],
+            columns=['A', 'B'], index=['A', 'B']
+        )
+        assert_frame_equal(stats.std, expected_std)
 
     def test_percentile_range(self):
-        pass
+        raise SkipTest
 
 class TestBlockResampling(object):
     def setup(self):
-        # create set of 100
-        pass
+        self.samples = list(range(100))
 
     def test_default_initialization(self):
-        pass
+        resampler = paths.numerics.BlockResampling(self.samples)
+        assert_equal(resampler.n_total_samples, 100)
+        assert_equal(resampler.n_blocks, 20)
+        assert_equal(resampler.n_per_block, 5)
+        assert_equal(len(resampler.blocks), 20)
+        assert_equal(resampler.n_resampled, 100)
+        assert_equal(resampler.unassigned, [])
+        assert_items_equal(resampler.blocks[0], list(range(0, 5)))
+        assert_items_equal(resampler.blocks[1], list(range(5, 10)))
+        assert_items_equal(resampler.blocks[10], list(range(50, 55)))
+        assert_items_equal(resampler.blocks[-1], list(range(95, 100)))
 
     def test_n_blocks_initialization(self):
-        pass
+        raise SkipTest
+
+    def test_n_per_block_initialization(self):
+        raise SkipTest

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -20,9 +20,11 @@ class TestResamplingStatistics(object):
     # NOTE: we test the mean_df and std_df functions within this
     def setup(self):
         # order of the column/index labels should not matter
-        self.df1 = pd.DataFrame([[1.0, 2.0], [2.1, 3.0]],
+        self.list_AB = ['A', 'B']
+        self.list_BA = ['B', 'A']
+        self.df1 = pd.DataFrame([[1.5, 2.0], [2.1, 3.0]],
                                 columns=['A', 'B'], index=['A', 'B'])
-        self.df2 = pd.DataFrame([[2.5, 1.5], [3.5, 2.4]],
+        self.df2 = pd.DataFrame([[2.5, 1.0], [3.5, 2.4]],
                                 columns=['B', 'A'], index=['A', 'B'])
         self.df3 = pd.DataFrame([[2.25, 3.25], [1.25, 2.25]],
                                 columns=['A', 'B'], index=['B', 'A'])
@@ -42,7 +44,6 @@ class TestResamplingStatistics(object):
         expected_mean = pd.DataFrame([[1.25, 2.25], [2.25, 3.25]],
                                      columns=['A', 'B'], index=['A', 'B'])
         assert_frame_equal(stats.mean, expected_mean)
-        # TODO: add test for std
         expected_std = pd.DataFrame(
             [[0.17677669529663689, 0.17677669529663689],
              [0.10606601717798207, 0.17677669529663689]],
@@ -50,7 +51,34 @@ class TestResamplingStatistics(object):
         )
         assert_frame_equal(stats.std, expected_std)
 
-    def test_percentile_range(self):
+    def test_percentile(self):
+        # TODO: this would benefit from more tests (with more input frames)
+        stats = paths.numerics.ResamplingStatistics(
+            function=lambda x: x,
+            inputs=self.inputs
+        )
+
+        assert_frame_equal(
+            stats.percentile(0),
+            pd.DataFrame([[1.0, 2.0], [2.1, 3.0]],
+                         index=self.list_AB, columns=self.list_AB),
+            check_dtype=False  # better if this wasn't needed
+        )
+
+        assert_frame_equal(
+            stats.percentile(100),
+            pd.DataFrame([[1.5, 2.5], [2.4, 3.5]],
+                         index=self.list_AB, columns=self.list_AB),
+            check_dtype=False
+        )
+
+        assert_frame_equal(
+            stats.percentile(50),
+            pd.DataFrame([[1.25, 2.25], [2.25, 3.25]],
+                         index=self.list_AB, columns=self.list_AB),
+            check_dtype=False
+        )
+
         raise SkipTest
 
 class TestBlockResampling(object):

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -32,6 +32,16 @@ class TestResamplingStatistics(object):
                                 columns=['B', 'A'], index=['B', 'A'])
         self.inputs = [self.df1, self.df2, self.df3, self.df4]
 
+    def test_std(self):
+        # extra test to get the one line that isn't otherwise used
+        from openpathsampling.numerics.resampling_statistics import std_df
+        expected_std = pd.DataFrame(
+            [[0.17677669529663689, 0.17677669529663689],
+             [0.10606601717798207, 0.17677669529663689]],
+            columns=['A', 'B'], index=['A', 'B']
+        )
+        assert_frame_equal(std_df(self.inputs), expected_std)
+
     def test_initialization(self):
         stats = paths.numerics.ResamplingStatistics(
             function=lambda x: x,

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from nose.tools import (assert_equal, assert_not_equal, assert_items_equal,
+                        assert_almost_equal, raises)
+from nose.plugins.skip import Skip, SkipTest
+from test_helpers import (
+    true_func, assert_equal_array_array, make_1d_traj, data_filename
+)
+
+import openpathsampling as paths
+from openpathsampling.high_level.interface_set import GenericVolumeInterfaceSet
+
+import logging
+logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
+class TestResamplingStatistics(object):
+    # NOTE: we test the mean_df and std_df functions within this
+    def setup(self):
+        pass
+
+    def test_initialization(self):
+        pass
+
+    def test_percentile_range(self):
+        pass
+
+class TestBlockResampling(object):
+    def setup(self):
+        # create set of 100
+        pass
+
+    def test_default_initialization(self):
+        pass
+
+    def test_n_blocks_initialization(self):
+        pass

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -89,8 +89,6 @@ class TestResamplingStatistics(object):
             check_dtype=False
         )
 
-        raise SkipTest
-
 class TestBlockResampling(object):
     def setup(self):
         self.samples = list(range(100))

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -1,10 +1,11 @@
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
-from nose.tools import (assert_equal, assert_not_equal, assert_items_equal,
+from nose.tools import (assert_equal, assert_not_equal,
                         assert_almost_equal, raises)
 from nose.plugins.skip import Skip, SkipTest
 from test_helpers import (
-    true_func, assert_equal_array_array, make_1d_traj, data_filename
+    true_func, assert_equal_array_array, make_1d_traj, data_filename,
+    assert_items_equal
 )
 
 import openpathsampling as paths

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -3,7 +3,7 @@ from pandas.util.testing import assert_frame_equal
 from nose.tools import (assert_equal, assert_not_equal,
                         assert_almost_equal, raises)
 from nose.plugins.skip import Skip, SkipTest
-from test_helpers import (
+from .test_helpers import (
     true_func, assert_equal_array_array, make_1d_traj, data_filename,
     assert_items_equal
 )

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -71,7 +71,57 @@ class TestBlockResampling(object):
         assert_items_equal(resampler.blocks[-1], list(range(95, 100)))
 
     def test_n_blocks_initialization(self):
-        raise SkipTest
+        resampler = paths.numerics.BlockResampling(self.samples, n_blocks=10)
+        assert_equal(resampler.n_total_samples, 100)
+        assert_equal(resampler.n_blocks, 10)
+        assert_equal(resampler.n_per_block, 10)
+        assert_equal(len(resampler.blocks), 10)
+        assert_equal(resampler.n_resampled, 100)
+        assert_equal(resampler.unassigned, [])
+        assert_items_equal(resampler.blocks[0], list(range(0, 10)))
+        assert_items_equal(resampler.blocks[1], list(range(10, 20)))
+        assert_items_equal(resampler.blocks[5], list(range(50, 60)))
+        assert_items_equal(resampler.blocks[-1], list(range(90, 100)))
+
+        resampler_2 = paths.numerics.BlockResampling(self.samples, n_blocks=8)
+        assert_equal(resampler_2.n_total_samples, 100)
+        assert_equal(resampler_2.n_blocks, 8)
+        assert_equal(resampler_2.n_per_block, 12)
+        assert_equal(resampler_2.n_resampled, 96)
+        assert_items_equal(resampler_2.blocks[-1], list(range(84, 96)))
+        assert_items_equal(resampler_2.unassigned, list(range(96, 100)))
 
     def test_n_per_block_initialization(self):
-        raise SkipTest
+        resampler = paths.numerics.BlockResampling(self.samples, n_per_block=10)
+        assert_equal(resampler.n_total_samples, 100)
+        assert_equal(resampler.n_blocks, 10)
+        assert_equal(resampler.n_per_block, 10)
+        assert_equal(len(resampler.blocks), 10)
+        assert_equal(resampler.n_resampled, 100)
+        assert_equal(resampler.unassigned, [])
+        assert_items_equal(resampler.blocks[0], list(range(0, 10)))
+        assert_items_equal(resampler.blocks[1], list(range(10, 20)))
+        assert_items_equal(resampler.blocks[5], list(range(50, 60)))
+        assert_items_equal(resampler.blocks[-1], list(range(90, 100)))
+
+        resampler_2 = paths.numerics.BlockResampling(self.samples,
+                                                     n_per_block=8)
+        assert_equal(resampler_2.n_total_samples, 100)
+        assert_equal(resampler_2.n_blocks, 12)
+        assert_equal(resampler_2.n_resampled, 96)
+        assert_items_equal(resampler_2.blocks[-1], list(range(88, 96)))
+        assert_items_equal(resampler_2.unassigned, list(range(96, 100)))
+
+    def test_n_blocks_and_n_per_block_initialization(self):
+        resampler = paths.numerics.BlockResampling(self.samples, n_blocks=9,
+                                                   n_per_block=10)
+        assert_equal(resampler.n_total_samples, 100)
+        assert_equal(resampler.n_blocks, 9)
+        assert_equal(resampler.n_per_block, 10)
+        assert_equal(len(resampler.blocks), 9)
+        assert_equal(resampler.n_resampled, 90)
+        assert_items_equal(resampler.unassigned, list(range(90, 100)))
+        assert_items_equal(resampler.blocks[0], list(range(0, 10)))
+        assert_items_equal(resampler.blocks[1], list(range(10, 20)))
+        assert_items_equal(resampler.blocks[5], list(range(50, 60)))
+        assert_items_equal(resampler.blocks[-1], list(range(80, 90)))


### PR DESCRIPTION
Very basic setup for doing some resampling to get error estimates. The main idea is to create an overall framework that takes a function that generates a `pandas.DataFrame` as output (e.g., our `rate_matrix` calculation) and can return the statistics we're interested in. This is all designed for a case where we're using `pandas.DataFrame` as a relatively small table (as it is with our `rate_matrix` and most other analyses where we output a `DataFrame`.)

There are three main parts to this:

1. Selecting sets of samples to use to recalculate (currently, just implementing block resampling; others could be added later)
2. Applying the (user-defined) function to each set of samples, resulting in a set of `pandas.DataFrame`s for each result
3. Getting statistics from the set of `pandas.DataFrame`s (to help estimate uncertainty)

Tasks:

- [x] Get statistics out of `pandas.DataFrame`s
- [x] `ResamplingStatistics` object to hold relevant statistics and results from subsamples
- [x] tests for `ResamplingStatistics`
- [x] `BlockResampling` object to select sequential blocks of samples
- [x] tests for `BlockResampling`
- [x] docstrings
- [x] update MISTIS example to include error calculation

Note that this will cover stuff for getting errors from `DataFrame`s. If the output is one of our `LookupFunction`s (as with crossing probability and some of our internal histograms), then most of the statistics (mean and stddev) are already included in `numerics/lookup_function.py`.