### PR TITLE
Fix to make MSOuter.make_ensemble take list of forbidden volumes

### DIFF
--- a/openpathsampling/high_level/ms_outer_interface.py
+++ b/openpathsampling/high_level/ms_outer_interface.py
@@ -151,7 +151,12 @@ class MSOuterTISInterface(netcdfplus.StorableNamedObject):
         if forbidden is None:
             ensemble_to_intersect = paths.FullEnsemble()
         else:
-            ensemble_to_intersect = paths.AllOutXEnsemble(forbidden)
+            try:
+                _ = len(forbidden)
+            except TypeError:
+                forbidden = [forbidden]
+            forbidden_vol = paths.join_volumes(forbidden)
+            ensemble_to_intersect = paths.AllOutXEnsemble(forbidden_vol)
 
         # TODO: maybe we should crash if given transitions aren't relevant?
         relevant_transitions = self.relevant_transitions(transitions)


### PR DESCRIPTION
The docstring said that `MSOuterTISInterface.make_ensemble` takes a parameter `forbidden`, which is a list of `Volume`s. However, it only worked if `forbidden` was a single `Volume`. This fixes it so that it can take either a single `Volume` or a list of them.

This popped up as a problem when doing a MISTISNetwork with `strict_sampling=True`. The MISTISNetwork code expected MSOuter to do what the docstring said.