### PR TITLE
Add possible _safemode_ to object reconstruction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ addons:
     - pandoc
 
 env:
-    - CONDA_PY=2.7  CONDA_NPY=1.10
-    - CONDA_PY=3.6  CONDA_NPY=1.10
+    - CONDA_PY=2.7
+    - CONDA_PY=3.6
 
 global:
   - secure: "NJvoSrLNd2ZR3HluJjEqI36gD5lsucwIvgnYjNmM4cwnnA77aLV9FRYTwlLRZn3XY9FL8KOzL5l0amNzMD7sQrf7bWwWv7iCUBddH549q9RSgiuOugtodYJ6VaXi76hk1rOgcJpDoCj9wTCIlMtWibPUzr1QHmdihfdM2iA2kkE="

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -193,24 +193,24 @@ class CollectiveVariable(cd.Wrap, StorableNamedObject):
         if self._store_dict:
             self._store_dict.cache_all()
 
-    def __eq__(self, other):
-        """Override the default Equals behavior"""
-        if isinstance(other, self.__class__):
-            if self.name != other.name:
-                    return False
+    # def __eq__(self, other):
+    #     """Override the default Equals behavior"""
+    #     if isinstance(other, self.__class__):
+    #         if self.name != other.name:
+    #                 return False
+    #
+    #         return True
+    #
+    #     return NotImplemented
 
-            return True
-
-        return NotImplemented
-
-    __hash__ = StorableNamedObject.__hash__
-
-    def __ne__(self, other):
-        """Define a non-equality test"""
-        if isinstance(other, self.__class__):
-            return not self.__eq__(other)
-
-        return NotImplemented
+    # __hash__ = StorableNamedObject.__hash__
+    #
+    # def __ne__(self, other):
+    #     """Define a non-equality test"""
+    #     if isinstance(other, self.__class__):
+    #         return not self.__eq__(other)
+    #
+    #     return NotImplemented
 
     to_dict = create_to_dict(['name', 'cv_time_reversible'])
 
@@ -393,27 +393,27 @@ class CallableCV(CollectiveVariable):
 
         return obj
 
-    def __eq__(self, other):
-        """Override the default Equals behavior"""
-        if isinstance(other, self.__class__):
-            if self.name != other.name:
-                return False
-            if self.kwargs != other.kwargs:
-                return False
-            if self.cv_callable is None or other.cv_callable is None:
-                return False
-
-            self_code = get_code(self.cv_callable)
-            other_code = get_code(other.cv_callable)
-            if hasattr(self_code, 'op_code') \
-                    and hasattr(other_code, 'op_code') \
-                    and self_code.op_code != other_code.op_code:
-                # Compare Bytecode. Not perfect, but should be good enough
-                return False
-
-            return True
-
-        return NotImplemented
+    # def __eq__(self, other):
+    #     """Override the default Equals behavior"""
+    #     if isinstance(other, self.__class__):
+    #         if self.name != other.name:
+    #             return False
+    #         if self.kwargs != other.kwargs:
+    #             return False
+    #         if self.cv_callable is None or other.cv_callable is None:
+    #             return False
+    #
+    #         self_code = get_code(self.cv_callable)
+    #         other_code = get_code(other.cv_callable)
+    #         if hasattr(self_code, 'op_code') \
+    #                 and hasattr(other_code, 'op_code') \
+    #                 and self_code.op_code != other_code.op_code:
+    #             # Compare Bytecode. Not perfect, but should be good enough
+    #             return False
+    #
+    #         return True
+    #
+    #     return NotImplemented
 
     __hash__ = CollectiveVariable.__hash__
 

--- a/openpathsampling/netcdfplus/base.py
+++ b/openpathsampling/netcdfplus/base.py
@@ -173,6 +173,15 @@ class StorableObject(object):
     def __hash__(self):
         return hash(self.__uuid__)
 
+    def __eq__(self, other):
+        if self is other:
+            return True
+
+        if hasattr(other, '__uuid__'):
+            return self.__uuid__ == other.__uuid__
+
+        return NotImplemented
+
     @property
     def base_cls_name(self):
         """

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -276,7 +276,6 @@ class ObjectJSON(object):
                     return None
 
             elif '_marshal' in obj or '_module' in obj:
-                print(self.safemode)
                 if self.safemode:
                     return None
 

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -269,6 +269,7 @@ class ObjectJSON(object):
                     return None
 
             elif '_marshal' in obj or '_module' in obj:
+                print(self.safemode)
                 if self.safemode:
                     return None
 

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -13,6 +13,7 @@ import marshal
 import types
 import opcode
 import builtins
+import sys
 
 from .base import StorableObject
 
@@ -22,7 +23,7 @@ from .cache import WeakValueCache
 
 __author__ = 'Jan-Hendrik Prinz'
 
-import sys
+
 if sys.version_info > (3, ):
     long = int
     unicode = str
@@ -33,6 +34,7 @@ else:
     builtin_module = '__builtin__'
     get_code = lambda func: func.func_code
     intify_byte = lambda b: ord(b)
+
 
 class ObjectJSON(object):
     """
@@ -69,6 +71,7 @@ class ObjectJSON(object):
         self.allowed_storable_types = dict()
         self.type_names = {}
         self.type_classes = {}
+        self.safemode = False
 
         self.update_class_list()
 
@@ -266,6 +269,9 @@ class ObjectJSON(object):
                     return None
 
             elif '_marshal' in obj or '_module' in obj:
+                if self.safemode:
+                    return None
+
                 return self.callable_from_dict(obj)
 
             else:

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -612,7 +612,7 @@ class UUIDObjectJSON(ObjectJSON):
 
             if '_hex_uuid' in obj and '_store' in obj:
                 store = self.storage._stores[obj['_store']]
-                result = store.load(long(obj['_hex_uuid'], 16))
+                result = store.load(int(obj['_hex_uuid'].strip('L'), 16))
 
                 return result
 

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -40,6 +40,13 @@ class ObjectJSON(object):
     """
     A simple implementation of a pickle algorithm to create object that can be
     converted to json and back
+
+    Attributes
+    ----------
+    safemode: bool
+        If set to `True` the recreation of marshalled objects like functions is
+        switched off and these objects are replaced by None. Can be used to load
+        from incompatible python versions or potential unsafe trajectory files.
     """
 
     allow_marshal = True

--- a/openpathsampling/storage/storage.py
+++ b/openpathsampling/storage/storage.py
@@ -63,6 +63,10 @@ class Storage(NetCDFPlus):
             mode,
             fallback=fallback)
 
+    def _create_simplifier(self):
+        super(Storage, self)._create_simplifier()
+        self.simplifier.safemode = False
+
     def _create_storages(self):
         """
         Register all Stores used in the OpenPathSampling Storage

--- a/openpathsampling/tests/teststorage.py
+++ b/openpathsampling/tests/teststorage.py
@@ -85,6 +85,36 @@ class testStorage(object):
 
         store.close()
 
+    def test_safemode(self):
+        fname = data_filename("cv_storage_safemode_test.nc")
+        if os.path.isfile(fname):
+            os.remove(fname)
+
+        cv = paths.CoordinateFunctionCV('cv', lambda x: x)
+
+        traj = paths.Trajectory(list(self.traj))
+        template = traj[0]
+
+        storage_w = paths.Storage(fname, "w")
+        storage_w.snapshots.save(template)
+        storage_w.cvs.save(cv)
+        storage_w.close()
+
+        storage_r = paths.Storage(fname, 'r')
+        # default safemode = False
+        assert(storage_r.simplifier.safemode is False)
+        cv_r = storage_r.cvs[0]
+        assert(cv_r == cv)
+        assert(cv.cv_callable is not None)
+        storage_r.close()
+
+        storage_r = paths.Storage(fname, 'r')
+        storage_r.simplifier.safemode = True
+        cv_r = storage_r.cvs[0]
+        assert(cv_r == cv)
+        assert(cv_r.cv_callable is None)
+        storage_r.close()
+
     def test_store_snapshots(self):
         fname = data_filename("cv_storage_test.nc")
         if os.path.isfile(fname):


### PR DESCRIPTION
Addresses #693.

You can now do 

```py
storage = Storage()
storage.simplifier.safemode = True
```

will force the object handling inside the storage to not load any marshalled functions and replace these with None. It will pratically affect all CVs and you need to replace the function manually if you need it.

Caching is not affected.