### PR TITLE
Add `storage.tags` shortcut to access `storage.tag`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ addons:
     - pandoc
 
 env:
-    - CONDA_PY=2.7  CONDA_NPY=1.10
-    - CONDA_PY=3.6  CONDA_NPY=1.10
+    - CONDA_PY=2.7
+    - CONDA_PY=3.6
 
 global:
   - secure: "NJvoSrLNd2ZR3HluJjEqI36gD5lsucwIvgnYjNmM4cwnnA77aLV9FRYTwlLRZn3XY9FL8KOzL5l0amNzMD7sQrf7bWwWv7iCUBddH549q9RSgiuOugtodYJ6VaXi76hk1rOgcJpDoCj9wTCIlMtWibPUzr1QHmdihfdM2iA2kkE="

--- a/openpathsampling/storage/storage.py
+++ b/openpathsampling/storage/storage.py
@@ -115,6 +115,10 @@ class Storage(NetCDFPlus):
 
         self.create_store('tag', ImmutableDictStore())
 
+    @property
+    def tags(self):
+        return self.tag
+
     def write_meta(self):
         self.setncattr('storage_format', 'openpathsampling')
         self.setncattr('storage_version', paths.version.version)


### PR DESCRIPTION
Resolves #643. Super simple, but is more consistent in the naming.