### PR TITLE
Quick fix for problem with move_summary

### DIFF
--- a/openpathsampling/high_level/move_scheme.py
+++ b/openpathsampling/high_level/move_scheme.py
@@ -765,7 +765,7 @@ class MoveScheme(StorableNamedObject):
             group = my_movers[groupname]
             for mover in group:
                 key_iter = (k for k in self._mover_acceptance.keys()
-                            if k[0] is mover)
+                            if k[0] == mover)
 
                 for k in key_iter:
                     stats[groupname][0] += self._mover_acceptance[k][0]


### PR DESCRIPTION
This fixes a problem with `MoveScheme.move_summary` that @hejung found. I had used `is` in a case where I should have used `==` (to use UUID to check that the mover is the same). Was only a problem in some edge case (not fully identified, since it depended on the scheme) where the scheme was already in memory. For some reason, movers loaded from `storage` were re-instantiated (@jhprinz, any idea how that might have happened)? This meant that the mover in the `change` will be `==` to the one in the scheme, but not `is`.