### PR TITLE
Docs deployment

### DIFF
--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+DEPLOY_PY="2.7"
+
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     echo "This is a pull request. No deployment will be done."; exit 0
 fi
@@ -12,14 +15,13 @@ GROUP_NAME=omnia
 BUILD_PATH=~/miniconda2/conda-bld
 
 echo travis_fold:start:binstar.upload
-if [[ "2.7" =~ "$python" ]]; then
+if [[ $CONDA_PY -eq $DEPLOY_PY ]]; then
     conda install --yes anaconda-client jinja2
     conda convert -p all ${BUILD_PATH}/linux-64/${PACKAGE_NAME}*.tar.bz2 -o ${BUILD_PATH}/
     anaconda -t ${ANACONDA_TOKEN}  upload  --force -u ${GROUP_NAME} -p ${PACKAGE_NAME} ${BUILD_PATH}/*/${PACKAGE_NAME}*.tar.bz2
-fi
-
-if [[ "$python" != "2.7" ]]; then
-    echo "No deploy on PYTHON_VERSION=${python}"; exit 0
+else
+    echo "Only deploy from Python ${DEPLOY_PY}. This is Python ${CONDA_PY}."
+    exit 0
 fi
 
 echo travis_fold:end:binstar.upload

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -6,9 +6,9 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     echo "This is a pull request. No deployment will be done."; exit 0
 fi
 
-if [[ "$TRAVIS_BRANCH" != "master" ]]; then
-    echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
-fi
+#if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    #echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
+#fi
 
 PACKAGE_NAME=openpathsampling-dev
 GROUP_NAME=omnia
@@ -18,7 +18,11 @@ echo travis_fold:start:binstar.upload
 if [[ $CONDA_PY -eq $DEPLOY_PY ]]; then
     conda install --yes anaconda-client jinja2
     conda convert -p all ${BUILD_PATH}/linux-64/${PACKAGE_NAME}*.tar.bz2 -o ${BUILD_PATH}/
-    anaconda -t ${ANACONDA_TOKEN}  upload  --force -u ${GROUP_NAME} -p ${PACKAGE_NAME} ${BUILD_PATH}/*/${PACKAGE_NAME}*.tar.bz2
+    if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+        echo "No conda deploy on branch $TRAVIS_BRANCH"
+    else
+        anaconda -t ${ANACONDA_TOKEN}  upload  --force -u ${GROUP_NAME} -p ${PACKAGE_NAME} ${BUILD_PATH}/*/${PACKAGE_NAME}*.tar.bz2
+    fi
 else
     echo "Only deploy from Python ${DEPLOY_PY}. This is Python ${CONDA_PY}."
     exit 0
@@ -45,5 +49,9 @@ pwd
 echo travis_fold:end:build.docs
 
 echo travis_fold:start:upload.docs
-python devtools/ci/push-docs-to-s3.py
+if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    echo "No docs deploy on branch $TRAVIS_BRANCH"
+else
+    python devtools/ci/push-docs-to-s3.py
+fi
 echo travis_fold:end:upload.docs

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -15,7 +15,7 @@ GROUP_NAME=omnia
 BUILD_PATH=~/miniconda2/conda-bld
 
 echo travis_fold:start:binstar.upload
-if [[ $CONDA_PY -eq $DEPLOY_PY ]]; then
+if [[ "$CONDA_PY" == "$DEPLOY_PY" ]]; then
     conda install --yes anaconda-client jinja2
     conda convert -p all ${BUILD_PATH}/linux-64/${PACKAGE_NAME}*.tar.bz2 -o ${BUILD_PATH}/
     if [[ "$TRAVIS_BRANCH" != "master" ]]; then

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'OpenPathSampling'
-copyright = u'2016, Jan-Hendrik Prinz, David W.H. Swenson, John Chodera, Peter Bolhuis'
+copyright = u'2014-2017, Jan-Hendrik Prinz, David W.H. Swenson, John Chodera, Peter Bolhuis'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Apparently we've had some deployment issues with our docs for a while. This PR fixes that, and also makes future problems a little easier to troubleshoot.

It used to be that the only way to even build docs (or prep for conda deployment) was if we were both *not* a PR, and on the master branch.

Now we build docs/prep for deployment if we're not a PR, regardless of branch. This still means that in the most common case (PRs), Travis won't take the time to build docs or prep deployment. However, if we want to debug the deployment procedure, we can now create a branch under the `openpathsampling` fork, and that should do all the work up to, but not including, deployment. Ideally, this will be useful for future debugging.

Fixes #711.