### PR TITLE
Documentation cleanup

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,14 +46,14 @@ Ensemble
 Volume
 ******
 
-.. automodule:: volume
+.. automodule:: openpathsampling.volume
 	:members:
 	
 *********
 PathMover
 *********
 
-.. automodule:: pathmover
+.. automodule:: openpathsampling.pathmover
 	:members:
 	
 *******

--- a/docs/engines/openmm.rst
+++ b/docs/engines/openmm.rst
@@ -16,7 +16,7 @@ Main functions
    Engine
    engine.OpenMMEngine
    topology.MDTrajTopology
-   topology.OpenMMSystemTopology
+..   topology.OpenMMSystemTopology
 
 
 Utility functions

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -57,7 +57,6 @@ The advanced examples demonstrate some of the more specialized uses of OPS.
     :maxdepth: 1
 
     AD_tps_advanced_analysis
-    DNA_flux_example
     custom_movescheme
 
 Special Topics

--- a/docs/netcdfplus/stores.rst
+++ b/docs/netcdfplus/stores.rst
@@ -1,6 +1,6 @@
 .. _objects:
 
-.. currentmodule:: openpathsampling.netcdfplus.objects
+.. currentmodule:: openpathsampling.netcdfplus.stores
 
 Store Functions
 ===============

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -26,11 +26,12 @@ stores
 .. autosummary::
     :toctree: api/generated/
 
-    SampleStore
-    MoveChangeStore
-    MCStepStore
-    SampleStore
-    SampleSetStore
-    TrajectoryStore
-    BaseSnapshotStore
-    FeatureSnapshotStore
+    stores.CVStore
+    stores.SampleStore
+    stores.MoveChangeStore
+    stores.MCStepStore
+    stores.SampleStore
+    stores.SampleSetStore
+    stores.TrajectoryStore
+    stores.SnapshotWrapperStore
+    stores.PathSimulatorStore


### PR DESCRIPTION
We were getting a lot of warnings when building the docs. This fixes most of them (leaving only a couple because the developer documentation is still in progress and missing some files that need to be written).

Most of the warnings had to do with files that had been renamed or relocated, so it was straightforward to fix.

This changes no code -- only docs -- and should be pretty straightforward to review and merge. It's ready as soon as it passes tests.