### PR TITLE
Fix Shooting Point Analysis

### DIFF
--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -40,7 +40,7 @@ class TransformedDict(abc.MutableMapping):
         del self.hash_representatives[hashed]
 
     def __iter__(self):
-        return iter(self.store)
+        return iter(self.hash_representatives.values())
 
     def __len__(self):
         return len(self.store)
@@ -58,8 +58,8 @@ class TransformedDict(abc.MutableMapping):
         velocities, the resulting mapping would be invalid. It is up to the
         user to avoid such invalid remappings.
         """
-        return TransformedDict(new_hash, 
-                               {self.hash_representatives[k]: self.store[k] 
+        return TransformedDict(new_hash,
+                               {self.hash_representatives[k]: self.store[k]
                                 for k in self.store})
 
 
@@ -71,7 +71,7 @@ class SnapshotByCoordinateDict(TransformedDict):
     """
     def __init__(self, *args, **kwargs):
         hash_fcn = lambda x : x.coordinates.tostring()
-        super(SnapshotByCoordinateDict, self).__init__(hash_fcn, 
+        super(SnapshotByCoordinateDict, self).__init__(hash_fcn,
                                                        *args, **kwargs)
 
 
@@ -227,9 +227,9 @@ class ShootingPointAnalysis(SnapshotByCoordinateDict):
             label_function = lambda s : s
         results = {}
         for k in self:
-            out_key = label_function(self.hash_representatives[k])
-            counter_k = self.store[k]
-            committor = float(counter_k[state]) / sum(counter_k.values())
+            out_key = label_function(k)
+            counter_k = self[k]
+            committor = float(counter_k[state]) / sum([counter_k[s] for s in self.states])
             results[out_key] = committor
         return results
 
@@ -240,7 +240,7 @@ class ShootingPointAnalysis(SnapshotByCoordinateDict):
         except TypeError:
             ndim = 1
         if ndim > 2 or ndim < 1:
-            raise RuntimeError("Histogram key dimension {0} > 2 or {0} < 1 " 
+            raise RuntimeError("Histogram key dimension {0} > 2 or {0} < 1 "
                                + "(key: {1})".format(ndim, key))
         return ndim
 

--- a/openpathsampling/tests/test_shooting_point_analysis.py
+++ b/openpathsampling/tests/test_shooting_point_analysis.py
@@ -50,9 +50,9 @@ class TestTransformedDict(object):
 
     def test_update(self):
         self.test_dict.update({(5,6): "d"})
-        assert_equal(self.test_dict.store, 
+        assert_equal(self.test_dict.store,
                      {0 : "a", 1 : "b", 2 : "c", 5 : "d"})
-        assert_equal(self.test_dict.hash_representatives, 
+        assert_equal(self.test_dict.hash_representatives,
                      {0: (0,1), 1: (1,2), 2: (2,3), 5: (5,6)})
 
     def test_del(self):
@@ -61,7 +61,7 @@ class TestTransformedDict(object):
 
     def test_iter(self):
         iterated = [k for k in self.test_dict]
-        for (truth, beauty) in zip(list(self.transformed.keys()), iterated):
+        for (truth, beauty) in zip(list(self.untransformed.keys()), iterated):
             assert_equal(truth, beauty)
 
     def test_len(self):


### PR DESCRIPTION
closes #722
I reimplemented the TransformedDict.__iter__() method and updated the corresponding test.
Now self.values(), self.keys() and self.items() work consistently and return counter, snapshots and tuples of them respectively.
