### PR TITLE
Dev install script

### DIFF
--- a/devtools/conda_ops_dev_install.sh
+++ b/devtools/conda_ops_dev_install.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# This assumes you've already installed conda. Then it installs OPS as a
+# developer install.
+
+conda install -y -c omnia openpathsampling
+conda update -y --all
+conda uninstall -y openpathsampling
+git clone https://github.com/openpathsampling/openpathsampling.git
+cd openpathsampling && pip install -e . && cd ..
+
+# this puts to the OPS dev install in a directory so you can change to that
+# directory and add remotes/switch branches as necessary


### PR DESCRIPTION
Several projects I'm working on are based on OPS, and I like to test them against the most recent development branch of OPS. In addition, users might want to test their own OPS-based packages against modifications in their own forks of OPS.

In order to make that easier, I've made this little script that does a developer install of OPS (assuming you have `conda` installed). The premise is that, if something (requirements?) changes between conda releases, this script will be updated to make sure that someone has a working version of the most recent version of OPS. Since the repo is downloaded, it also gives them the option to (after the script) add remotes and switch to a branch in a remote.

The idea is that they could `curl` down this script and use it to install during their CI, and we'd try to keep it up to date. I'm already using a version of this script in my [`ops_additional_examples`](https://gitlab.e-cam2020.eu/dwhswenson/ops_additional_examples/) repo, where I recently added CI using `ipynbtest`.

This involves no changes to the OPS code, so review should be trivial. I haven't written a test for it, but that would be pretty easy (add a new element to the matrix installing using this; run nosetests). But it seems wasteful to have an extra Travis matrix test for this on every push; maybe it's better to count on downstream repos to notify when something when wrong? (since I know I'll get notifications from several downstream repos!)