### PR TITLE
snapshot.md box_vectors

### DIFF
--- a/docs/developers/advanced_engines.rst
+++ b/docs/developers/advanced_engines.rst
@@ -3,7 +3,6 @@
 Advanced Engines
 ================
 
-
 Custom snapshot features
 ------------------------
 
@@ -12,5 +11,55 @@ dynamics, even things that have nothing to do with molecular dynamics. If
 that's your interest (or if you're interested in methods like *ab initio* or
 quantum dynamics which might make use of a definition of state beyond
 standard MD), then this is the section for you.
+
+Standard snapshot features
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Adding features with new stored data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Adding features that are proxies to stored data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Adding features that are properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Support for additional OPS modules
+----------------------------------
+
+The basic engine setup is easy to do, and enables the core of
+OpenPathSampling's functionality. However, some additional functionality can
+be added with very little effort, for engines where this might be relevant. 
+
+Shooting Point Velocity Modification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The original descriptions of TPS used two-way shooting with a ":math:`\Delta
+p`" velocity modification. That is, the direction of the velocity on one
+particle was changed.
+
+OPS has the ability to do this using the
+:class:`.VelocityDirectionModifier`, but this procedure becomes extremely
+complicated in condensed phase (periodic) systems with holonomic
+constraints. Therefore, OPS only allows this for engines where the snapshots
+have the ``n_degrees_of_freedom`` feature. In addition, the engine can tell
+OPS not to bother removing linear momentum (e.g., if the engine represents a
+particle rolling on a surface, like our toy engine) by setting
+``engine.ignore_linear_momentum = True``.
+
+MDTraj support
+~~~~~~~~~~~~~~
+
+Several aspects of `MDTraj <http://mdtraj.org>`_ support require an
+:class:`mdtraj.Topology` object. The developer can add these by adding a
+property/attribute called ``mdtraj_topology`` to their engine. With this,
+you automatically get:
+
+* trajectory conversion to :class:`mdtraj.Trajectory`, which enables output
+  to various file formats, and integration with other projects such as
+  nglview for trajectory visualization.
+* ??? TODO: can we make MDTraj CV support automated as well? Check for topol
+  on first run? ???
+
 
 

--- a/openpathsampling/engines/features/statics.py
+++ b/openpathsampling/engines/features/statics.py
@@ -90,7 +90,8 @@ def md(snapshot):
 
     Notes
     -----
-    Rather slow since the topology has to be made each time. Try to avoid it
+    Rather slow since the topology has to be made each time. Try to avoid
+    it. This will only work if the engine has an mdtraj_topology property.
     """
     if snapshot.statics is not None:
         return paths.Trajectory([snapshot]).to_mdtraj()

--- a/openpathsampling/engines/features/statics.py
+++ b/openpathsampling/engines/features/statics.py
@@ -2,6 +2,7 @@ import numpy as np
 from .shared import StaticContainerStore, StaticContainer
 import mdtraj
 from openpathsampling.netcdfplus import WeakLRUCache
+import openpathsampling as paths
 
 variables = ['statics']
 lazy = ['statics']
@@ -91,14 +92,8 @@ def md(snapshot):
     -----
     Rather slow since the topology has to be made each time. Try to avoid it
     """
-
     if snapshot.statics is not None:
-        n_atoms = snapshot.coordinates.shape[0]
-
-        output = np.zeros([1, n_atoms, 3], np.float32)
-        output[0, :, :] = snapshot.coordinates
-
-        return mdtraj.Trajectory(output, snapshot.topology.mdtraj)
+        return paths.Trajectory([snapshot]).to_mdtraj()
 
 
 @property

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -331,6 +331,9 @@ class OpenMMEngine(DynamicsEngine):
             options=options,
             openmm_properties=properties
         )
+    @property
+    def mdtraj_topology(self):
+        return self.topology.mdtraj
 
     @property
     def snapshot_timestep(self):

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -135,7 +135,8 @@ def topology_from_pdb(pdb_file, simple_topology=False):
     return topology
 
 
-def snapshot_from_testsystem(testsystem, simple_topology=False):
+def snapshot_from_testsystem(testsystem, simple_topology=False,
+                             periodic=True):
     """
     Construct a Snapshot from openmm topology and state objects
 
@@ -146,6 +147,8 @@ def snapshot_from_testsystem(testsystem, simple_topology=False):
     simple_topology : bool
         if `True` only a simple topology with n_atoms will be created.
         This cannot be used with complex CVs but loads and stores very fast
+    periodic : bool
+        True (default) if system is periodic; if False, box vectors are None
 
     Returns
     -------
@@ -162,10 +165,13 @@ def snapshot_from_testsystem(testsystem, simple_topology=False):
     else:
         topology = MDTrajTopology(md.Topology.from_openmm(testsystem.topology))
 
-    box_vectors = \
-        np.array([
-            v / u.nanometers for v in
-            testsystem.system.getDefaultPeriodicBoxVectors()]) * u.nanometers
+    if periodic:
+        box_vectors = \
+            np.array([
+                v / u.nanometers for v in
+                testsystem.system.getDefaultPeriodicBoxVectors()]) * u.nanometers
+    else:
+        box_vectors = None
 
     snapshot = Snapshot.construct(
         coordinates=testsystem.positions,

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -28,6 +28,10 @@ class TopologyEngine(NoEngine):
 
         self.topology = topology
 
+    @property
+    def mdtraj_topology(self):
+        return self.topology.mdtraj
+
     def to_dict(self):
         return {
             'topology': self.topology,

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -540,13 +540,10 @@ class Trajectory(list, StorableObject):
         :class:`mdtraj.Trajectory`
             the trajectory
         """
-
-
         if topology is None:
             # TODO: maybe add better error output?
             # if AttributeError here, engine doesAn't support mdtraj
-            topology = self.mdtraj_topology
-
+            topology = self[0].engine.mdtraj_topology
 
         output = self.xyz
 

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -534,9 +534,9 @@ class Trajectory(list, StorableObject):
             If not None this topology will be used to construct the mdtraj
             objects otherwise the topology object will be taken from the
             configurations in the trajectory snapshots.
-        
+
         Returns
-        -------        
+        -------
         :class:`mdtraj.Trajectory`
             the trajectory
         """
@@ -548,7 +548,13 @@ class Trajectory(list, StorableObject):
         output = self.xyz
 
         traj = md.Trajectory(output, topology)
-        traj.unitcell_vectors = self.box_vectors
+        box_vectors = self.box_vectors
+        # box_vectors is a list with an entry for each frame of the traj
+        # if they're all None, we return None, not [None, None, ..., None]
+        if not np.any(box_vectors):
+            box_vectors = None
+
+        traj.unitcell_vectors = box_vectors
         return traj
 
     @property

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -539,11 +539,22 @@ class Trajectory(list, StorableObject):
         -------
         :class:`mdtraj.Trajectory`
             the trajectory
+
+        Notes
+        -----
+
+        If the OPS trajectory is zero-length (has no snapshots), then this
+        fails. MDTraj trajectories must have at least one frame.
         """
+        try:
+            snap = self[0]
+        except IndexError:
+            raise ValueError("Cannot convert length-zero trajectory "
+                             + "to MDTraj")
         if topology is None:
             # TODO: maybe add better error output?
-            # if AttributeError here, engine doesAn't support mdtraj
-            topology = self[0].engine.mdtraj_topology
+            # if AttributeError here, engine doesn't support mdtraj
+            topology = snap.engine.mdtraj_topology
 
         output = self.xyz
 

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -544,12 +544,14 @@ class Trajectory(list, StorableObject):
         -----
 
         If the OPS trajectory is zero-length (has no snapshots), then this
-        fails. MDTraj trajectories must have at least one frame.
+        fails. OPS cannot currently convert zero-length trajectories to
+        MDTraj, because an OPS zero-length trajectory cannot determine its
+        MDTraj topology.
         """
         try:
             snap = self[0]
         except IndexError:
-            raise ValueError("Cannot convert length-zero trajectory "
+            raise ValueError("Cannot convert zero-length trajectory "
                              + "to MDTraj")
         if topology is None:
             # TODO: maybe add better error output?

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -543,7 +543,10 @@ class Trajectory(list, StorableObject):
 
 
         if topology is None:
-            topology = self.topology.mdtraj
+            # TODO: maybe add better error output?
+            # if AttributeError here, engine doesAn't support mdtraj
+            topology = self.mdtraj_topology
+
 
         output = self.xyz
 

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -244,7 +244,7 @@ class GeneralizedDirectionModifier(SnapshotModifier):
 
         if n_dofs != n_dofs_required:
             raise RuntimeError("Snapshot has " + str(n_dofs)
-                               + " degrees of freedom, not " 
+                               + " degrees of freedom, not "
                                + str(n_dofs_required) + ". "
                                + "Are there constraints? Constraints can't"
                                + " be used with this modifier.")

--- a/openpathsampling/tests/test_mdtraj_support.py
+++ b/openpathsampling/tests/test_mdtraj_support.py
@@ -36,7 +36,7 @@ class testMDTrajSupport(object):
                                self.md_trajectory.xyz)
         nptest.assert_allclose(self.ops_trajectory.box_vectors,
                                self.md_trajectory.unitcell_vectors)
-    
+
         # switch back to mdtraj
         md_trajectory_2 = trajectory_to_mdtraj(self.ops_trajectory,
                                                self.md_topology)

--- a/openpathsampling/tests/test_mdtraj_support.py
+++ b/openpathsampling/tests/test_mdtraj_support.py
@@ -44,6 +44,11 @@ class testMDTrajSupport(object):
         nptest.assert_allclose(self.md_trajectory.unitcell_vectors,
                                md_trajectory_2.unitcell_vectors)
 
+    @raises(ValueError)
+    def test_empty_traj_to_mdtraj(self):
+        empty = paths.Trajectory([])
+        empty.to_mdtraj()
+
     def test_trajectory_to_mdtraj_other_input(self):
         snap = self.ops_trajectory[0]
         md1 = trajectory_to_mdtraj(snap)

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from builtins import object
 import openpathsampling.engines.openmm as omm_engine
 import openpathsampling as paths
-from nose.tools import assert_equal, assert_almost_equal, assert_not_equal
+from nose.tools import (assert_equal, assert_almost_equal, assert_not_equal,
+                        assert_is_not, assert_is)
 from .test_helpers import data_filename, assert_close_unit
 
 import openmmtools as omt
@@ -19,11 +20,11 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class testOpenMMSnapshot(object):
     def setup(self):
-        test_system = omt.testsystems.AlanineDipeptideVacuum()
-        self.template = omm_engine.snapshot_from_testsystem(test_system)
+        self.test_system = omt.testsystems.AlanineDipeptideVacuum()
+        self.template = omm_engine.snapshot_from_testsystem(self.test_system)
         self.engine = omm_engine.Engine(
             topology=self.template.topology,
-            system=test_system.system,
+            system=self.test_system.system,
             integrator=omt.integrators.VVVRIntegrator()
         )
         self.n_atoms = self.engine.topology.n_atoms
@@ -52,7 +53,7 @@ class testOpenMMSnapshot(object):
         )
         test_snap = self.engine.current_snapshot
         expected_ke = sum(
-            [m * vel_unit**2 for m in test_snap.masses], 
+            [m * vel_unit**2 for m in test_snap.masses],
             0.0*u.joule
         )
         n_dofs = 51.0  # see test above
@@ -65,3 +66,19 @@ class testOpenMMSnapshot(object):
         temp_1 = trajectory[1].instantaneous_temperature
         temp_2 = trajectory[2].instantaneous_temperature
         assert_not_equal(temp_1, temp_2)
+
+    def test_mdtraj_trajectory(self):
+        snap_1 = omm_engine.snapshot_from_testsystem(self.test_system,
+                                                     periodic=False)
+        assert_is(snap_1.box_vectors, None)
+        traj_1 = snap_1.md
+        assert_equal(len(traj_1), 1)
+        assert_is_not(traj_1.xyz, None)
+        assert_is(traj_1.unitcell_vectors, None)
+
+        snap_2 = self.engine.current_snapshot
+        traj_2 = snap_2.md
+        assert_equal(len(traj_2), 1)
+        assert_is_not(traj_2.xyz, None)
+        assert_is_not(traj_2.unitcell_vectors, None)
+

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -81,4 +81,3 @@ class testOpenMMSnapshot(object):
         assert_equal(len(traj_2), 1)
         assert_is_not(traj_2.xyz, None)
         assert_is_not(traj_2.unitcell_vectors, None)
-


### PR DESCRIPTION
Fixes #710, plus a test to prove it.

In addition, I changed things so that engine developers who want to support conversion to MDTraj just need to add a `mdtraj_topology` attribute/property to their engines (and added relevant docs).

Also made it so that `snapshot_from_testsystem` allows you to select a nonperiodic snapshot. This was useful for testing.