### PR TITLE
Fix error in docs installation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ runipy
 openmm
 pytables
 scikit-learn
+packaging


### PR DESCRIPTION
After #729, there was a package (`packaging`) needed for docs that was missing from the Travis environment. This fixes it.

Going to merge directly when tests pass, since the difference is trivial.