### PR TITLE
Fix problem in conda-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - export PYTHONUNBUFFERED=true
   # Sets up a miniconda environment
   - source devtools/ci/install.sh
-  = conda install --yes conda-build
+  - conda install --yes conda-build
   - conda build --quiet devtools/conda-recipe
   - conda create --quiet --yes --name test --use-local openpathsampling-dev
   - source activate test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,7 @@ install:
 script:
   - python --version
   - source devtools/ci/git_hash.sh
-  #- echo "Building OPS (with conda)" && echo -en 'travis_fold:start:build\\r'
-  #- echo -en 'travis_fold:end:build\\r'
-
-  # Run tests in test environment
-  #- echo "Create test environment" && echo -en 'travis_fold:start:create_env\\r'
-  #- echo -en 'travisfold:end:create_env\\r'
   - conda list -n test
-  #- conda install --yes future
-  #- conda install --yes jupyter nose nose-timer python-coveralls msmbuilder pyemma #ipynbtest
   - source devtools/ci/nosetests.sh
   - if [ ${CONDA_PY:0:1} -eq "2" ]; then source devtools/ci/ipythontests.sh; fi
   #- source devtools/ci/ipythontests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ install:
   - export PYTHONUNBUFFERED=true
   # Sets up a miniconda environment
   - source devtools/ci/install.sh
+  = conda install --yes conda-build
   - conda build --quiet devtools/conda-recipe
   - conda create --quiet --yes --name test --use-local openpathsampling-dev
   - source activate test
   - conda info --envs
   - conda install --quiet --yes msmbuilder
-  - conda install -quiet --yes nose python-coveralls ipynbtest
+  - conda install --quiet --yes nose python-coveralls ipynbtest
   - conda update --all --yes --use-local --quiet
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,30 @@ language: python
 
 install:
   - deactivate
-  # Sets up a MINIConda enviroment in the name of the selected python version
-  - source devtools/ci/install.sh
-  # Do not buffer output of python outputs but flush them directly to the terminal
+  # Do not buffer python outputs; flush them directly to the terminal
   - export PYTHONUNBUFFERED=true
+  # Sets up a miniconda environment
+  - source devtools/ci/install.sh
+  - conda build --quiet devtools/conda-recipe
+  - conda create --quiet --yes --name test --use-local openpathsampling-dev
+  - source activate test
+  - conda info --envs
+  - conda install --quiet --yes msmbuilder
+  - conda install -quiet --yes nose python-coveralls ipynbtest
+  - conda update --all --yes --use-local --quiet
 
 script:
   - python --version
-  - echo "Building OPS (with conda)" && echo -en 'travis_fold:start:build\\r'
-  - conda build --quiet devtools/conda-recipe
-  - echo -en 'travis_fold:end:build\\r'
+  - source devtools/ci/git_hash.sh
+  #- echo "Building OPS (with conda)" && echo -en 'travis_fold:start:build\\r'
+  #- echo -en 'travis_fold:end:build\\r'
 
-  # Run tests in _test environment
-  - echo "Create test environment" && echo -en 'travis_fold:start:create_env\\r'
-  - conda create --quiet --yes --name test --use-local openpathsampling-dev
-  - conda info --envs
-  - source activate test
-  - echo -en 'travisfold:end:create_env\\r'
+  # Run tests in test environment
+  #- echo "Create test environment" && echo -en 'travis_fold:start:create_env\\r'
+  #- echo -en 'travisfold:end:create_env\\r'
   - conda list -n test
   #- conda install --yes future
   #- conda install --yes jupyter nose nose-timer python-coveralls msmbuilder pyemma #ipynbtest
-  - conda install --yes msmbuilder
-  - conda install --yes nose python-coveralls ipynbtest
-  # - conda update --all --yes --use-local
-  - source devtools/ci/git_hash.sh
   - source devtools/ci/nosetests.sh
   - if [ ${CONDA_PY:0:1} -eq "2" ]; then source devtools/ci/ipythontests.sh; fi
   #- source devtools/ci/ipythontests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,19 @@ install:
 
 script:
   - python --version
-  #- echo travis_fold:start:conda.build.package
-  - conda install --yes conda-build
+  - echo travis_fold:start:conda_build
   - conda build --quiet devtools/conda-recipe
-  #- echo travis_fold:end:conda.build.package
+  - echo travis_fold:end:conda_build
 
   # Run tests in _test environment
-  - conda create --yes --name test --use-local openpathsampling-dev
+  - conda create --quiet --yes --name test --use-local openpathsampling-dev
   - conda info --envs
   - source activate test
   - conda list -n test
   #- conda install --yes future
   #- conda install --yes jupyter nose nose-timer python-coveralls msmbuilder pyemma #ipynbtest
-  - conda install --yes nose python-coveralls ipynbtest
   - conda install --yes msmbuilder
+  - conda install --yes nose python-coveralls ipynbtest
   # - conda update --all --yes --use-local
   - source devtools/ci/git_hash.sh
   - source devtools/ci/nosetests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ install:
 
 script:
   - python --version
-  - echo travis_fold:start:conda.build.package
+  #- echo travis_fold:start:conda.build.package
   - conda install --yes conda-build
-  - conda build devtools/conda-recipe
-  - echo travis_fold:end:conda.build.package
+  - conda build --quiet devtools/conda-recipe
+  #- echo travis_fold:end:conda.build.package
 
   # Run tests in _test environment
   - conda create --yes --name test --use-local openpathsampling-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ install:
 
 script:
   - python --version
-  - echo travis_fold:start:conda_build
+  - echo "Building OPS (with conda)" && echo -en 'travis_fold:start:build\\r'
   - conda build --quiet devtools/conda-recipe
-  - echo travis_fold:end:conda_build
+  - echo -en 'travis_fold:end:build\\r'
 
   # Run tests in _test environment
+  - echo "Create test environment" && echo -en 'travis_fold:start:create_env\\r'
   - conda create --quiet --yes --name test --use-local openpathsampling-dev
   - conda info --envs
   - source activate test
+  - echo -en 'travisfold:end:create_env\\r'
   - conda list -n test
   #- conda install --yes future
   #- conda install --yes jupyter nose nose-timer python-coveralls msmbuilder pyemma #ipynbtest

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -28,5 +28,6 @@ conda config --add channels http://conda.anaconda.org/omnia
 conda update --yes conda
 
 echo travis_fold:start:install.conda_build
+echo Installing conda-build
 conda install --yes conda-build
 echo travis_fold:end:install.conda_build

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -3,9 +3,6 @@
 
 ### Install Miniconda
 
-echo travis_fold:start:install.conda
-echo Install conda
-
 if [ -z "$CONDA_PY" ]
 then
     CONDA_PY=2.7
@@ -30,4 +27,6 @@ export PATH=$HOME/miniconda${pyV}/bin:$PATH
 conda config --add channels http://conda.anaconda.org/omnia
 conda update --yes conda
 
-echo travis_fold:end:install.conda
+echo travis_fold:start:install.conda_build
+conda install --yes conda-build
+echo travis_fold:end:install.conda_build

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -26,8 +26,3 @@ export PATH=$HOME/miniconda${pyV}/bin:$PATH
 # add omnia and update
 conda config --add channels http://conda.anaconda.org/omnia
 conda update --yes conda
-
-echo travis_fold:start:install.conda_build
-echo Installing conda-build
-conda install --yes conda-build
-echo travis_fold:end:install.conda_build


### PR DESCRIPTION
There seems to be a problem with the stage that installs OPS into a test environment that is causing build failures. I'll see if I can fix it; if not, a version pin on conda or conda-build might do it.