### PR TITLE
Fix warnings that show up in nosetests

### DIFF
--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -422,8 +422,7 @@ class ChannelAnalysis(StorableNamedObject):
         switch_count = collections.Counter(switches)
         df = pd.DataFrame(index=sorted_labels, columns=sorted_labels)
         for switch in switch_count:
-            df.set_value(index=switch[0], col=switch[1],
-                         value=switch_count[switch])
+            df.at[switch[0], switch[1]] = switch_count[switch]
 
         df = df.fillna(0)
         return df

--- a/openpathsampling/analysis/tis/core.py
+++ b/openpathsampling/analysis/tis/core.py
@@ -116,8 +116,8 @@ class TransitionDictResults(StorableNamedObject):
         columns = [key_map(k) for k in order if k in col_vols]
         result = pd.DataFrame(index=index, columns=columns)
         for k in keys:
-            result.set_value(key_map(k[0]), key_map(k[1]),
-                             self.results_dict[k])
+            result.at[key_map(k[0]), key_map(k[1])] = self.results_dict[k]
+
         return result
 
     def __str__(self):  # pragma: no cover

--- a/openpathsampling/bias_function.py
+++ b/openpathsampling/bias_function.py
@@ -92,18 +92,18 @@ class BiasEnsembleTable(BiasFunction):
             for ens_to in self_only | both:
                 orig_to_id = self.ensembles_to_ids[ens_to]
                 orig_value = self.dataframe.loc[orig_from_id, orig_to_id]
-                dataframe.set_value(index=ensembles_to_ids[ens_from],
-                                    col=ensembles_to_ids[ens_to],
-                                    value=orig_value)
+                idx = ensembles_to_ids[ens_from]
+                col = ensembles_to_ids[ens_to]
+                dataframe.at[idx, col] = orig_value
 
         for ens_from in other_only:
             orig_from_id = other.ensembles_to_ids[ens_from]
             for ens_to in other_only | both:
                 orig_to_id = other.ensembles_to_ids[ens_to]
                 orig_value = other.dataframe.loc[orig_from_id, orig_to_id]
-                dataframe.set_value(index=ensembles_to_ids[ens_from],
-                                    col=ensembles_to_ids[ens_to],
-                                    value=orig_value)
+                idx = ensembles_to_ids[ens_from]
+                col = ensembles_to_ids[ens_to]
+                dataframe.at[idx, col] = orig_value
 
         for ens_from in both:
             self_from_id = self.ensembles_to_ids[ens_from]
@@ -111,15 +111,15 @@ class BiasEnsembleTable(BiasFunction):
             for ens_to in self_only:
                 to_id = self.ensembles_to_ids[ens_to]
                 orig_value = self.dataframe.loc[self_from_id, to_id]
-                dataframe.set_value(index=ensembles_to_ids[ens_from],
-                                    col=ensembles_to_ids[ens_to],
-                                    value=orig_value)
+                idx = ensembles_to_ids[ens_from]
+                col = ensembles_to_ids[ens_to]
+                dataframe.at[idx, col] = orig_value
             for ens_to in other_only:
                 to_id = other.ensembles_to_ids[ens_to]
                 orig_value = other.dataframe.loc[other_from_id, to_id]
-                dataframe.set_value(index=ensembles_to_ids[ens_from],
-                                    col=ensembles_to_ids[ens_to],
-                                    value=orig_value)
+                idx = ensembles_to_ids[ens_from]
+                col = ensembles_to_ids[ens_to]
+                dataframe.at[idx, col] = orig_value
             for ens_to in both:
                 self_to_id = self.ensembles_to_ids[ens_to]
                 other_to_id = other.ensembles_to_ids[ens_to]
@@ -149,9 +149,9 @@ class BiasEnsembleTable(BiasFunction):
                         raise ValueError(msg)
                 value = self_value if self_value is not None else other_value
                 if value is not None:
-                    dataframe.set_value(index=ensembles_to_ids[ens_from],
-                                        col=ensembles_to_ids[ens_to],
-                                        value=value)
+                    idx = ensembles_to_ids[ens_from]
+                    col = ensembles_to_ids[ens_to]
+                    dataframe.at[idx, col] = value
                 # if both self_value and other_value are None, df unchanged
 
         return BiasEnsembleTable(dataframe, ensembles_to_ids)
@@ -185,7 +185,7 @@ class BiasEnsembleTable(BiasFunction):
             for e_to in ratio_dictionary:
                 id_to = ensembles_to_ids[e_to]
                 w_to = ratio_dictionary[e_to]
-                id_based_df.set_value(id_from, id_to, w_from/w_to)
+                id_based_df.at[id_from, id_to] = w_from / w_to
         return BiasEnsembleTable(id_based_df, ensembles_to_ids)
 
 
@@ -304,10 +304,8 @@ def SRTISBiasFromNetwork(network, steps=None):
         outer_count = len(network.special_ensembles['ms_outer'][outer])
         for col in bias.dataframe.columns:
             val_from_outer = bias.dataframe.loc[outer_id, col]
-            bias.dataframe.set_value(index=outer_id, col=col,
-                                     value=val_from_outer * outer_count)
+            bias.dataframe.at[outer_id, col] = val_from_outer * outer_count
             val_to_outer = bias.dataframe.loc[col, outer_id]
-            bias.dataframe.set_value(index=col, col=outer_id,
-                                     value=val_to_outer / outer_count)
+            bias.dataframe.at[col, outer_id] = val_to_outer / outer_count
     return bias
 

--- a/openpathsampling/numerics/lookup_function.py
+++ b/openpathsampling/numerics/lookup_function.py
@@ -264,7 +264,7 @@ class VoxelLookupFunction(object):
             columns = range(y_range[0], y_range[1]+1)
         df = pd.DataFrame(index=index, columns=columns)
         for (k,v) in counter.items():
-            df.set_value(k[0], k[1], v)
+            df.at[k[0], k[1]] = v
         df = df.sort_index(0).sort_index(1)
         return df
 

--- a/openpathsampling/numerics/wham.py
+++ b/openpathsampling/numerics/wham.py
@@ -410,8 +410,10 @@ class WHAM(object):
                 for hist_i in Z.index
             ])
             # explicitly allow NaN results for simplcity (should only occur
-            # when numerator and denominator are 0
-            # TODO: where exactly is the output cleaned on this?
+            # when numerator and denominator are 0) ... this will leave NaNs
+            # in the histogram in those locations; if all values of the
+            # total histogram are NaN, that gets caught in the main
+            # wham_bam_histogram routine
             with np.errstate(divide='ignore', invalid='ignore'):
                 output[val] = sum_k_Hk_Q[val] / sum_w_over_Z
 

--- a/openpathsampling/numerics/wham.py
+++ b/openpathsampling/numerics/wham.py
@@ -333,7 +333,10 @@ class WHAM(object):
                 sum_over_Z_byQ = wc.dot(reciprocal_Z_old)
 
                 # divide each entry, and add them (integrate over Q in F&S)
-                addends_k = np.divide(numerator_byQ, sum_over_Z_byQ)
+                # we intentially allow invalid (0/0) to give NaN; gets
+                # removed by using the np.nansum)
+                with np.errstate(divide='ignore', invalid='ignore'):
+                    addends_k = np.divide(numerator_byQ, sum_over_Z_byQ)
                 Z_new[hists[i]] = np.nansum(addends_k)
 
             lnZ_new = np.log(Z_new)
@@ -406,7 +409,11 @@ class WHAM(object):
                 weighted_counts.loc[val, hist_i] * Z0_over_Zi[hist_i]
                 for hist_i in Z.index
             ])
-            output[val] = sum_k_Hk_Q[val] / sum_w_over_Z
+            # explicitly allow NaN results for simplcity (should only occur
+            # when numerator and denominator are 0
+            # TODO: where exactly is the output cleaned on this?
+            with np.errstate(divide='ignore', invalid='ignore'):
+                output[val] = sum_k_Hk_Q[val] / sum_w_over_Z
 
         return output
 

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -1137,7 +1137,7 @@ class DirectSimulation(PathSimulator):
         state_names = [s.name for s in self.states]
         rate_matrix = pd.DataFrame(columns=state_names, index=state_names)
         for t in rates:
-            rate_matrix.set_value(t[0].name, t[1].name, rates[t])
+            rate_matrix.at[t[0].name, t[1].name] = rates[t]
         return rate_matrix
 
     @property

--- a/openpathsampling/tests/testlookupfunction.py
+++ b/openpathsampling/tests/testlookupfunction.py
@@ -115,15 +115,15 @@ class testVoxelLookupFunction(object):
         df1 = self.lookup.df_2d()
         assert_items_equal(df1.index, [-1, 0, 1])
         assert_items_equal(df1.columns, [-1, 0, 2, 4])
-        assert_equal(df1.get_value(-1, -1), 5.0)
-        assert_equal(isnan(df1.get_value(0, 4)), True)
+        assert_equal(df1.at[-1, -1], 5.0)
+        assert_equal(isnan(df1.at[0, 4]), True)
 
         df2 = self.lookup.df_2d(x_range=(-1, 3), y_range=(-1, 4))
         assert_items_equal(df2.index, [-1, 0, 1, 2, 3])
         assert_items_equal(df2.columns, [-1, 0, 1, 2, 3, 4])
-        assert_equal(df2.get_value(-1, -1), 5.0)
-        assert_equal(isnan(df2.get_value(0, 4)), True)
-        assert_equal(isnan(df2.get_value(2, 3)), True)
+        assert_equal(df2.at[-1, -1], 5.0)
+        assert_equal(isnan(df2.at[0, 4]), True)
+        assert_equal(isnan(df2.at[2, 3]), True)
 
     @raises(RuntimeError)
     def test_df_2d_not_2d(self):


### PR DESCRIPTION
There are a few warnings that show up in our tests. This PR fixes or silences them.

* `dataframe.set_value` [is deprecated as of pandas 0.21.0](https://pandas.pydata.org/pandas-docs/stable/whatsnew.html#whatsnew-0210-deprecations), and this is raising lots of warnings in tests. This PR will replace usage of `.set_value` with the `.at` or `.iat` approaches, as recommended.
* For a long time, numpy has been throwing warnings for divide by zero for some of the WHAM. We actually *want* to generate NaNs there and then ignore them after (the speed of numpy and increased simiplicity of the code make it easier to create the NaNs then filter them). Used to be, numpy didn't warn on this; now it does. In this PR, we silence the numpy warnings for the lines of code that are expected to cause them.

- [x] Fix pandas `set_value` warning
- [x] Silence numpy division warnings
- [x] Double-check that silencing numpy warnings is safe