### PR TITLE
Docs deployment updates

### DIFF
--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -45,6 +45,8 @@ conda list -e
 
 (cd docs && python premake.py && make html && cd -)
 ls -lt docs/_build
+ls -lt docs/_build/html
+ls -lt docs/_build/html/static/
 pwd
 echo travis_fold:end:build.docs
 

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -54,7 +54,10 @@ echo travis_fold:start:upload.docs
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     python devtools/ci/push-docs-to-s3.py
 elif [[ "$TRAVIS_BRANCH" == "docs_deploy" ]]; then
-    python devtools/ci/push-docs-to-s3.py --clobber
+    # change the behavior for the docs testing branch (docs_deploy branch in
+    # the openpathsampling/openpathsampling GitHub repo) in this block
+    echo "No docs deploy on branch $TRAVIS_BRANCH"
+    # python devtools/ci/push-docs-to-s3.py --clobber
 else
     echo "No docs deploy on branch $TRAVIS_BRANCH"
 fi

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -46,7 +46,7 @@ conda list -e
 (cd docs && python premake.py && make html && cd -)
 ls -lt docs/_build
 ls -lt docs/_build/html
-ls -lt docs/_build/html/static/
+ls -lt docs/_build/html/_static/
 pwd
 echo travis_fold:end:build.docs
 

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -51,9 +51,9 @@ echo travis_fold:end:build.docs
 
 echo travis_fold:start:upload.docs
 
-if [[ $"TRAVIS_BRANCH" == "master" ]]; then
+if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     python devtools/ci/push-docs-to-s3.py
-elif [[ "$TRAVIS_BRANCH" != "docs_deploy" ]]; then
+elif [[ "$TRAVIS_BRANCH" == "docs_deploy" ]]; then
     python devtools/ci/push-docs-to-s3.py --clobber
 else
     echo "No docs deploy on branch $TRAVIS_BRANCH"

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -46,14 +46,16 @@ conda list -e
 (cd docs && python premake.py && make html && cd -)
 ls -lt docs/_build
 ls -lt docs/_build/html
-ls -lt docs/_build/html/_static/
 pwd
 echo travis_fold:end:build.docs
 
 echo travis_fold:start:upload.docs
-if [[ "$TRAVIS_BRANCH" != "master" ]]; then
-    echo "No docs deploy on branch $TRAVIS_BRANCH"
-else
+
+if [[ $"TRAVIS_BRANCH" == "master" ]]; then
     python devtools/ci/push-docs-to-s3.py
+elif [[ "$TRAVIS_BRANCH" != "docs_deploy" ]]; then
+    python devtools/ci/push-docs-to-s3.py --clobber
+else
+    echo "No docs deploy on branch $TRAVIS_BRANCH"
 fi
 echo travis_fold:end:upload.docs

--- a/devtools/ci/push-docs-to-s3.py
+++ b/devtools/ci/push-docs-to-s3.py
@@ -23,7 +23,8 @@ secret_key = {AWS_SECRET_ACCESS_KEY}
     f.flush()
 
     template = ('s3cmd --config {config} '
-                'sync docs/_build/html/ s3://{bucket}/{prefix}/')
+                'sync docs/_build/html/ s3://{bucket}/{prefix}/ '
+                '--no-mime-magic --guess-mime-type')
     cmd = template.format(
             config=f.name,
             bucket=BUCKET_NAME,

--- a/devtools/ci/push-docs-to-s3.py
+++ b/devtools/ci/push-docs-to-s3.py
@@ -1,9 +1,19 @@
+from __future__ import print_function
 import os
 import pip
 import tempfile
 import subprocess
 import openpathsampling.version
 
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--clobber', action='store_true',
+                    help='completely overwrite S3 bucket (default false)')
+parser.add_argument('--dry', action='store_true')
+opts = parser.parse_args()
+
+CLOBBER = opts.clobber
 
 BUCKET_NAME = 'openpathsampling.org'
 if not openpathsampling.version.release:
@@ -11,8 +21,25 @@ if not openpathsampling.version.release:
 else:
     PREFIX = openpathsampling.version.short_version
 
-if not any(d.project_name == 's3cmd' for d in pip.get_installed_distributions()):
-    raise ImportError('The s3cmd package is required. try $ pip install s3cmd')
+def is_s3cmd_installed():
+    dists = pip.get_installed_distributions()
+    if not any(d.project_name == 's3cmd' for d in dists):
+        raise ImportError('The s3cmd package is required. '
+                          'try $ pip install s3cmd')
+
+def run_cmd(template, config_filename, dry=False):
+    cmd = template.format(
+        config=config_filename,
+        bucket=BUCKET_NAME,
+        prefix=PREFIX)
+    if dry:
+        return_val = cmd
+    else:
+        is_s3cmd_installed()
+        return_val = subprocess.call(cmd.split())
+    return return_val
+
+
 # The secret key is available as a secure environment variable
 # on travis-ci to push the build documentation to Amazon S3.
 with tempfile.NamedTemporaryFile('w') as f:
@@ -22,20 +49,27 @@ secret_key = {AWS_SECRET_ACCESS_KEY}
 '''.format(**os.environ))
     f.flush()
 
-    template = ('s3cmd --config {config} '
-                'sync docs/_build/html/ s3://{bucket}/{prefix}/ '
-                '--no-mime-magic --guess-mime-type')
-    cmd = template.format(
-            config=f.name,
-            bucket=BUCKET_NAME,
-            prefix=PREFIX)
-    return_val = subprocess.call(cmd.split())
+    s3cmd_core = "s3cmd --config {config} --no-mime-magic --guess-mime-type"
 
-    # Sync index file.
-    template = ('s3cmd --config {config} '
-                'sync devtools/ci/index.html s3://{bucket}/')
-    cmd = template.format(
-            config=f.name,
-            bucket=BUCKET_NAME)
-    return_val = subprocess.call(cmd.split())
+    if CLOBBER:
+        s3cmd = s3cmd_core + " put --recursive "
+    else:
+        s3cmd = s3cmd_core + " sync "
+
+    # get the relevant docs onto S3
+    template = s3cmd + "docs/_build/html/ s3://{bucket}/{prefix}"
+    print(run_cmd(template, f.name, dry=opts.dry))
+    #cmd = template.format(
+            #config=f.name,
+            #bucket=BUCKET_NAME,
+            #prefix=PREFIX)
+    #return_val = subprocess.call(cmd.split())
+
+    # get the index file (main redirect)
+    template = s3cmd + 'devtools/ci/index.html s3://{bucket}/'
+    print(run_cmd(template, f.name, dry=opts.dry))
+    #cmd = template.format(
+            #config=f.name,
+            #bucket=BUCKET_NAME)
+    #return_val = subprocess.call(cmd.split())
 

--- a/devtools/ci/push-docs-to-s3.py
+++ b/devtools/ci/push-docs-to-s3.py
@@ -57,7 +57,7 @@ secret_key = {AWS_SECRET_ACCESS_KEY}
         s3cmd = s3cmd_core + " sync "
 
     # get the relevant docs onto S3
-    template = s3cmd + "docs/_build/html/ s3://{bucket}/{prefix}"
+    template = s3cmd + "docs/_build/html/ s3://{bucket}/{prefix}/"
     print(run_cmd(template, f.name, dry=opts.dry))
     #cmd = template.format(
             #config=f.name,


### PR DESCRIPTION
We were having some problems with the OPS website. For some reason, the S3 upload was incorrectly identifying MIME types, meaning that even though our CSS was being uploaded, it wasn't actually being used as CSS on the website. (This was not an easy thing to debug!)

In this PR, I mainly changed some of the structure of how the `push-docs-to-s3.py` script works. It could do with more cleanup, but this is all to enable quick fixes if something goes wrong with the S3 upload process in the future. The website is already fixed, because I could force the upload from the `docs_deploy` branch, where I did this work.