### PR TITLE
Add velocities to trajectory_from_mdtraj

### DIFF
--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -177,7 +177,8 @@ def snapshot_from_testsystem(testsystem, simple_topology=False):
     return snapshot
 
 
-def trajectory_from_mdtraj(mdtrajectory, simple_topology=False):
+def trajectory_from_mdtraj(mdtrajectory, simple_topology=False,
+                           velocities=None):
     """
     Construct a Trajectory object from an mdtraj.Trajectory object
 
@@ -188,28 +189,37 @@ def trajectory_from_mdtraj(mdtrajectory, simple_topology=False):
     simple_topology : bool
         if `True` only a simple topology with n_atoms will be created.
         This cannot be used with complex CVs but loads and stores very fast
+    velocities : np.array
+        velocities in units of nm/ps
 
     Returns
     -------
     openpathsampling.engines.Trajectory
         the constructed Trajectory instance
     """
-
     trajectory = Trajectory()
-    empty_kinetics = Snapshot.KineticContainer(
-        velocities=u.Quantity(
-            np.zeros(mdtrajectory.xyz[0].shape), u.nanometer / u.picosecond)
-    )
+    vel_unit = u.nanometer / u.picosecond
+
     if simple_topology:
         topology = Topology(*mdtrajectory.xyz[0].shape)
     else:
         topology = MDTrajTopology(mdtrajectory.topology)
+
+    if velocities is None:
+        empty_vel = u.Quantity(np.zeros(mdtrajectory.xyz[0].shape),
+                               vel_unit)
+
 
     engine = TopologyEngine(topology)
 
     for frame_num in range(len(mdtrajectory)):
         # mdtraj trajectories only have coordinates and box_vectors
         coord = u.Quantity(mdtrajectory.xyz[frame_num], u.nanometers)
+        if velocities is not None:
+            vel = u.Quantity(velocities[frame_num], vel_unit)
+        else:
+            vel = empty_vel
+
         if mdtrajectory.unitcell_vectors is not None:
             box_v = u.Quantity(mdtrajectory.unitcell_vectors[frame_num],
                                u.nanometers)
@@ -220,10 +230,11 @@ def trajectory_from_mdtraj(mdtrajectory, simple_topology=False):
             coordinates=coord,
             box_vectors=box_v
         )
+        kinetics = Snapshot.KineticContainer(velocities=vel)
 
         snap = Snapshot(
             statics=statics,
-            kinetics=empty_kinetics,
+            kinetics=kinetics,
             engine=engine
         )
         trajectory.append(snap)

--- a/openpathsampling/tests/test_mdtraj_support.py
+++ b/openpathsampling/tests/test_mdtraj_support.py
@@ -11,6 +11,8 @@ from .test_helpers import data_filename, assert_items_equal
 
 import openpathsampling as paths
 import mdtraj as md
+import numpy as np
+from simtk import unit as u
 
 from openpathsampling.engines.openmm.tools import (
     trajectory_from_mdtraj, trajectory_to_mdtraj, ops_load_trajectory
@@ -36,7 +38,7 @@ class testMDTrajSupport(object):
                                self.md_trajectory.xyz)
         nptest.assert_allclose(self.ops_trajectory.box_vectors,
                                self.md_trajectory.unitcell_vectors)
-    
+
         # switch back to mdtraj
         md_trajectory_2 = trajectory_to_mdtraj(self.ops_trajectory,
                                                self.md_topology)
@@ -55,3 +57,12 @@ class testMDTrajSupport(object):
         ops_trajectory = ops_load_trajectory(pdb_file)
         # TODO: we should add tests to make sure this also works correctly
         # with other file formats (e.g., gromacs, where `top` kw is req'd)
+
+    def test_trajectory_from_mdtraj_with_velocities(self):
+        shape = self.md_trajectory.xyz.shape
+        velocities = np.random.random(shape)
+        ops_trajectory = trajectory_from_mdtraj(self.md_trajectory,
+                                                velocities=velocities)
+        u_vel = u.nanometer / u.picosecond
+        nptest.assert_allclose(velocities,
+                               ops_trajectory.velocities / u_vel)


### PR DESCRIPTION
This makes it possible for a user to provide an `np.array` of velocities to `trajectory_from_mdtraj`, and attach those velocities to the results OPS trajectory. Note: since this is part of the interface with MDTraj (as opposed to OpenMM), this does not require explicit units. Instead the implicit units must be nm/ps.