### PR TITLE
Fix bug in BackwardFirstTwoWayShooting

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -2292,11 +2292,16 @@ class BackwardFirstTwoWayShootingMover(AbstractTwoWayShootingMover):
 
         bkwd_partial = self._make_backward_trajectory(trajectory, modified,
                                                       shooting_index)
+        #logger.info("Complete backward shot (length " +
+                    #str(len(bkwd_partial)) + ")")
         # TODO: come up with a test that shows why you need mid_traj here;
         # should be a SeqEns with OptionalEnsembles. Exact example is hard!
         mid_traj = bkwd_partial.reversed + trajectory[shooting_index + 1:]
+        mid_traj_shoot_idx = len(bkwd_partial) - 1
         fwd_partial = self._make_forward_trajectory(mid_traj, modified,
-                                                    shooting_index)
+                                                    mid_traj_shoot_idx)
+        #logger.info("Complete forward shot (length " +
+                    #str(len(fwd_partial)) + ")")
 
         # join the two
         trial_trajectory = bkwd_partial.reversed + fwd_partial[1:]

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -145,7 +145,7 @@ class testShootingMover(object):
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
         self.toy_opts = {'integ': integ,
                          'n_frames_max': 1000,
-                         'n_steps_per_frame': 5}
+                         'n_steps_per_frame': 1}
         # self.toy_engine: perfectly flat
         # self.toy_engine_AA: sloped to give AA trajectories
         # self.toy_engine_BB = sloped to give BB trajectories
@@ -367,9 +367,6 @@ class testForwardFirstTwoWayShootingMover(testShootingMover):
 
             expected_early_reject = path_type in expected_rejections
             ran_full_two_way = ensemble(change.trials[0].trajectory)
-            if expected_early_reject == ran_full_two_way:
-                print(path_type)
-                print(change.trials[0].trajectory.xyz)
             assert_equal(expected_early_reject, not ran_full_two_way)
 
     def test_early_reject_tps(self):

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -122,7 +122,7 @@ class testPathMover(object):
 
 class testShootingMover(object):
     def setup(self):
-        self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7, 
+        self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7,
                                       -0.1, 0.2, 0.4, 0.6, 0.8])
         op = FunctionCV("myid", f=lambda snap : snap.coordinates[0][0])
         self.stateA = CVDefinedVolume(op, -100, 0.0)
@@ -140,10 +140,16 @@ class testShootingMover(object):
 
         integ = toys.LeapfrogVerletIntegrator(dt=0.1)
         pes = toys.LinearSlope(m=[0.0], c=[0.0])
+        pes_AA = toys.LinearSlope(m=[10.0], c=[0.0])
+        pes_BB = toys.LinearSlope(m=[-10.0], c=[0.0])
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
-        self.toy_engine = toys.Engine(options={'integ': integ,
-                                               'n_frames_max': 1000,
-                                               'n_steps_per_frame': 5},
+        self.toy_opts = {'integ': integ,
+                         'n_frames_max': 1000,
+                         'n_steps_per_frame': 5}
+        # self.toy_engine: perfectly flat
+        # self.toy_engine_AA: sloped to give AA trajectories
+        # self.toy_engine_BB = sloped to give BB trajectories
+        self.toy_engine = toys.Engine(options=self.toy_opts,
                                       topology=topology)
         self.toy_snap = toys.Snapshot(coordinates=np.array([[0.3]]),
                                       velocities=np.array([[0.1]]),
@@ -154,8 +160,8 @@ class testShootingMover(object):
                           engine=self.toy_engine)
             for k in range(67)
         ])
-        self.toy_samp = SampleSet([Sample(trajectory=self.toy_traj, 
-                                          replica=0, 
+        self.toy_samp = SampleSet([Sample(trajectory=self.toy_traj,
+                                          replica=0,
                                           ensemble=self.tps)])
         # setup checks: keep around (commented) for debugging
         # assert_equal(self.stateA(self.toy_traj[0]), True)
@@ -195,7 +201,7 @@ class testForwardShootMover(testShootingMover):
                      newsamp[0].trajectory[0])
         assert_not_equal(self.toy_samp[0].trajectory[-1],
                          newsamp[0].trajectory[-1])
-        
+
 
     def test_is_ensemble_change_mover(self):
         mover = ForwardShootMover(
@@ -303,10 +309,111 @@ class testForwardFirstTwoWayShootingMover(testShootingMover):
         assert_in(change.details.shooting_snapshot,
                   change.initial_trajectory)
 
+    def _setup_early_reject(self, pair):
+        zero_vel_traj = paths.Trajectory([
+            toys.Snapshot(coordinates=np.array([[0.01*k - 0.005]]),
+                          velocities=np.array([[0.0]]),
+                          engine=self.toy_engine)
+            for k in range(67)
+        ])
+        if pair == "AA":
+            pes = toys.LinearSlope(m=[10.0], c=[0.0])
+            traj = zero_vel_traj
+        elif pair == "BB":
+            pes = toys.LinearSlope(m=[-10.0], c=[0.0])
+            traj = zero_vel_traj
+        elif pair == "AB":
+            pes = toys.LinearSlope(m=[0.0], c=[0.0])
+            traj = self.init_samp[0].trajectory
+        else:
+            raise RuntimeError("unknown path type: " + pair)
+
+        topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
+        engine = toys.Engine(options=self.toy_opts, topology=topology)
+
+        mapping = {'A': self.stateA, 'B': self.stateB}
+        start = pair[0]
+        end = pair[1]
+        ensemble = paths.SequentialEnsemble([
+            paths.AllInXEnsemble(mapping[start]) & paths.LengthEnsemble(1),
+            paths.AllOutXEnsemble(self.stateA | self.stateB),
+            paths.AllInXEnsemble(mapping[end]) & paths.LengthEnsemble(1)
+        ])
+        return (ensemble, engine, traj)
+
+    def _test_early_reject(self, test_ensemble, path_types,
+                           expected_rejections):
+        for path_type in path_types:
+            (ensemble, engine, traj) = self._setup_early_reject(path_type)
+            # the ensemble returned above tells us what ensemble we expect
+            # the trajectory to satisfy after the move, if *both* directions
+            # were shot. (This is determined by the PES, which varies for
+            # each path type.) We know whether we have early rejection based
+            # on whether the trial trajectory satisfies that ensemble: if it
+            # does, then we ran a full two-way shooting, and did not have
+            # early rejection. If it does not, then we had early rejection.
+            initial_sample_set = SampleSet([Sample(trajectory=traj,
+                                                   replica=0,
+                                                   ensemble=test_ensemble)])
+            initial_sample_set.sanity_check()
+
+            mover = self._MoverType(
+                ensemble=test_ensemble,
+                selector=UniformSelector(),
+                modifier=paths.NoModification(),
+                engine=engine
+            )
+            change = mover.move(initial_sample_set)
+
+            expected_early_reject = path_type in expected_rejections
+            ran_full_two_way = ensemble(change.trials[0].trajectory)
+            if expected_early_reject == ran_full_two_way:
+                print(path_type)
+                print(change.trials[0].trajectory.xyz)
+            assert_equal(expected_early_reject, not ran_full_two_way)
+
+    def test_early_reject_tps(self):
+        self._test_early_reject(test_ensemble=self.tps,
+                                path_types=['AA', 'BB', 'AB'],
+                                expected_rejections=['AA'])
+
+    def test_early_reject_tis(self):
+        both = self.stateA | self.stateB
+        pseudo_tis_ensemble = paths.SequentialEnsemble([
+            paths.AllInXEnsemble(self.stateA) & paths.LengthEnsemble(1),
+            paths.AllOutXEnsemble(both),
+            paths.AllInXEnsemble(both) & paths.LengthEnsemble(1)
+        ])
+        # when shooting forward-first, no TIS shot is ever rejected early
+        self._test_early_reject(test_ensemble=pseudo_tis_ensemble,
+                                path_types=['AA', 'BB', 'AB'],
+                                expected_rejections=[])
+
+    def test_sequential_shots(self):
+        # make sure that, with no modification, the trajectory doesn't
+        # change
+        raise SkipTest
+
 
 class testBackwardFirstTwoWayShootingMover(testForwardFirstTwoWayShootingMover):
     _MoverType = BackwardFirstTwoWayShootingMover
     # runs the same tests as ForwardFirst
+    def test_early_reject_tps(self):
+        self._test_early_reject(test_ensemble=self.tps,
+                                path_types=['AA', 'BB', 'AB'],
+                                expected_rejections=['BB'])
+
+    def test_early_reject_tis(self):
+        both = self.stateA | self.stateB
+        pseudo_tis_ensemble = paths.SequentialEnsemble([
+            paths.AllInXEnsemble(self.stateA) & paths.LengthEnsemble(1),
+            paths.AllOutXEnsemble(both),
+            paths.AllInXEnsemble(both) & paths.LengthEnsemble(1)
+        ])
+        # when shooting forward-first, no TIS shot is ever rejected early
+        self._test_early_reject(test_ensemble=pseudo_tis_ensemble,
+                                path_types=['AA', 'BB', 'AB'],
+                                expected_rejections=['BB'])
 
 
 class testTwoWayShootingMover(testShootingMover):

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -389,7 +389,20 @@ class testForwardFirstTwoWayShootingMover(testShootingMover):
     def test_sequential_shots(self):
         # make sure that, with no modification, the trajectory doesn't
         # change
-        raise SkipTest
+        mover = self._MoverType(
+            ensemble=self.tps,
+            selector=UniformSelector(),
+            modifier=paths.NoModification(),
+            engine=self.toy_engine
+        )
+        change = mover.move(self.init_samp)
+        real_traj = change.trials[0].trajectory
+        real_sample_set = SampleSet(change.trials)
+        real_sample_set.sanity_check()
+
+        new_change = mover.move(real_sample_set)
+        new_traj = new_change.trials[0].trajectory
+        assert_allclose(new_traj.xyz[:,0,0], real_traj.xyz[:,0,0])
 
 
 class testBackwardFirstTwoWayShootingMover(testForwardFirstTwoWayShootingMover):


### PR DESCRIPTION
This fixes a bug in the `BackwardFirstTwoWayShootingMover` as well as adding several new tests for two-way shooting. The bug was uncovered through the tests, which were implemented because @bolhuis was suspicious of some behavior in two-way shooting in the MISTIS toy example.

The bug was that the wrong shooting point was being used after the backward-first modification (shooting point was from the original trajectory; failed to account for the fact that the new backward segment had affected the shooting point index!)

The new tests include the following:

1. For TPS and TIS, forward-first and backward-first 2-way shooting can abort early in certain circumstances. For example, with forward-first shooting in TPS, if the forward shot lands in state A, there is no reason to do the backward shot. The new tests include these early rejection tests for both TPS and TIS ensembles (TIS-like, actually) in forward-first and backward-first dynamics.

2. For deterministic dynamics,  shooting with no modification of the shooting point should recover the original trajectory. There is now a test that checks this with two-way shooting.