### PR TITLE
Allow unicode for string options in engine option check

### DIFF
--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -19,6 +19,9 @@ from .delayedinterrupt import DelayedInterrupt
 
 logger = logging.getLogger(__name__)
 
+if sys.version_info > (3, ):
+    basestring = str
+
 # =============================================================================
 # SOURCE CONTROL
 # =============================================================================
@@ -240,6 +243,9 @@ class DynamicsEngine(StorableNamedObject):
                         else:
                             okay_options[variable] = my_options[variable]
                     elif isinstance(my_options[variable], type(default_value)):
+                        okay_options[variable] = my_options[variable]
+                    elif isinstance(my_options[variable], basestring) \
+                            and isinstance(default_value, basestring):
                         okay_options[variable] = my_options[variable]
                     elif default_value is None:
                         okay_options[variable] = my_options[variable]

--- a/openpathsampling/tests/testdynamicsengine.py
+++ b/openpathsampling/tests/testdynamicsengine.py
@@ -36,6 +36,7 @@ class testDynamicsEngine(object):
             snapshot_class=paths.engines.toy.Snapshot,
             snapshot_dimensions=snapshot_dimensions
         )
+        self.descriptor = descriptor
         self.engine = paths.engines.DynamicsEngine(options, descriptor)
         self.stupid = StupidEngine(options, descriptor)
 
@@ -61,7 +62,7 @@ class testDynamicsEngine(object):
         self.stupid.property_recovers
 
     @raises_with_message_like(AttributeError,
-                              "'StupidEngine' has no attribute 'foo'" +  
+                              "'StupidEngine' has no attribute 'foo'" +
                               ", nor does its options dictionary")
     def test_getattr_does_not_exist(self):
         self.stupid.foo
@@ -71,3 +72,8 @@ class testDynamicsEngine(object):
         assert (self.engine.n_spatial == 1)
         assert(self.stupid.n_atoms == 1)
         assert (self.stupid.n_spatial == 1)
+
+    def test_unicode_options(self):
+        # regression test: this should NOT raise an error
+        options = {'on_nan': u'fail'}
+        engine = paths.engines.DynamicsEngine(options, self.descriptor)


### PR DESCRIPTION
The `options` for engines has a bunch of type checking, and if the type given isn't the same as the default type, it raises a `ValueError`. I got this error when I tried to replace a `str`-typed default with a `unicode` object. (Note that this will only be a problem in Python 2, since `str` **is** `unicode` in Python 3.)

This PR fixes that problem, and includes a regression test for it as well.