### PR TITLE
Make DelayedInterrupt context optional

### DIFF
--- a/openpathsampling/engines/delayedinterrupt.py
+++ b/openpathsampling/engines/delayedinterrupt.py
@@ -37,5 +37,5 @@ class EmptyContext(object):
     def __enter__(self):
         pass
 
-    def __exit__(self):
+    def __exit__(self, type, value, traceback):
         pass

--- a/openpathsampling/engines/delayedinterrupt.py
+++ b/openpathsampling/engines/delayedinterrupt.py
@@ -32,3 +32,10 @@ class DelayedInterrupt(object):
             signal.signal(sig, self.old_handlers[sig])
             if self.signal_received[sig] and self.old_handlers[sig]:
                 self.old_handlers[sig](*self.signal_received[sig])
+
+class EmptyContext(object):
+    def __enter__(self):
+        pass
+
+    def __exit__(self):
+        pass

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -147,6 +147,7 @@ class DynamicsEngine(StorableNamedObject):
 
         self.descriptor = descriptor
         self._check_options(options)
+        self.interrupter = DelayedInterrupt
 
     @property
     def current_snapshot(self):
@@ -539,7 +540,7 @@ class DynamicsEngine(StorableNamedObject):
                 snapshot = None
 
                 try:
-                    with DelayedInterrupt():
+                    with self.interrupter():
                         snapshot = self.generate_next_frame()
 
                         # if self.on_nan != 'ignore' and \


### PR DESCRIPTION
This was interfering with task distribution using dask.distributed (thanks to Mariusz Uchronski for identifying the problem).

All this does is make the `interrupter` into an attribute of the `Engine`. Defaults to `DelayedInterrupt`; added an `EmptyContext` that can be used to remove the signal catcher with:

```python
from openpathsampling.engines.delayedinterrupt import EmptyContext
engine.interrupter = EmptyContext
```

(Note that the `interrupter` attribute is the *class* itself, not an instance of it. That's important!)

Still WIP while we're experimenting with it.