### PR TITLE
Pin conda version in `miniconda_install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   # Do not buffer python outputs; flush them directly to the terminal
   - export PYTHONUNBUFFERED=true
   # Sets up a miniconda environment
-  - source devtools/ci/install.sh
+  - source devtools/ci/miniconda_install.sh
   - conda install --yes conda-build
   - conda build --quiet devtools/conda-recipe
   - conda create --quiet --yes --name test --use-local openpathsampling-dev

--- a/devtools/ci/miniconda_install.sh
+++ b/devtools/ci/miniconda_install.sh
@@ -10,7 +10,7 @@ fi
 
 pyV=${CONDA_PY:0:1}
 conda_version="latest"
-conda_version="4.4.10"  # temporary hack because 'latest' has bad MD5
+#conda_version="4.4.10"  # can pin a miniconda version like this, if needed
 
 MINICONDA=Miniconda${pyV}-${conda_version}-Linux-x86_64.sh
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')

--- a/devtools/ci/miniconda_install.sh
+++ b/devtools/ci/miniconda_install.sh
@@ -9,8 +9,10 @@ then
 fi
 
 pyV=${CONDA_PY:0:1}
+conda_version="latest"
+conda_version="4.4.10"  # temporary hack because 'latest' has bad MD5
 
-MINICONDA=Miniconda${pyV}-latest-Linux-x86_64.sh
+MINICONDA=Miniconda${pyV}-${conda_version}-Linux-x86_64.sh
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then


### PR DESCRIPTION
Also, renamed `install.sh` to `miniconda_install.sh` to be clearer.

All our tests are failing right now because the `miniconda` MD5 hash is wrong. For whatever reason, when they uploaded 4.4.10, the script linked by `latest` got updated, but all the metadata did not. Relevant lines from https://repo.continuum.io/miniconda/ as I see it now:

```
Miniconda2-4.4.10-Linux-x86_64.sh | 38.0M | 2018-02-20 13:04:23 | dd54b344661560b861f86cc5ccff044b
Miniconda2-4.3.31-Linux-x86_64.sh | 37.5M | 2017-12-19 07:17:31 | da2dd466d26e33a2b1f72fdb853a8ff0
Miniconda2-latest-Linux-x86_64.sh | 37.5M | 2017-12-19 07:17:31 | da2dd466d26e33a2b1f72fdb853a8ff0
```

Problem is, the script linked at `latest` actually *is* `4.4.10`, so we find the MD5 hash for `4.4.10` while we're expecting (based on the table on the web site) to find the hash listed for `latest`, which is the hash for `4.3.31`.

This pin should be removed once conda fixes the problem. I tried to raise the issue on the [Anaconda - Public Google group](https://groups.google.com/a/continuum.io/forum/#!forum/anaconda), but as of this writing my message has not gone through. If it doesn't by Monday, I'll raise the issue elsewhere, but I want to cut a release this weekend, and don't want to do that if tests are failing.