### PR TITLE
Release 0.9.4

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openpathsampling-dev
-  version: "0.9.3"
+  version: "0.9.4"
 
 source:
 #  git_url: ../../.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,18 +23,18 @@ the development process on GitHub_, and follow `@pathsampling
 
 .. _GitHub: http://github.com/openpathsampling/openpathsampling
 
-.. note:: **Project status:** Currently we're at version 0.9.3.  There will
-          be some API cleanup before 1.0, but we don't expect the file
-          format to change.  Note, however, that files generated with Python
-          2 will not fully load with Python 3 or vice versa (partial Python 3
-          support starting in 0.9.3).
+.. note:: **Project status:** Currently we're at version 0.9.4.  There will
+          be some API cleanup before 1.0, but files created with current
+          this version will load in 1.0.  Note, however, that files
+          generated with Python 2 will not fully load with Python 3 or vice
+          versa (partial Python 3 support starting in 0.9.3).
 
           Overall, OPS is ready for production work. We're already writing
-          two papers that used it, in addition to the paper in prep about
-          the code itself. Version 1.0 will be released once the paper about
-          the code has been accepted for publication. Documentation is still
-          in progress; if you have questions, please contact the development
-          team.
+          several papers that used it, in addition to the paper in prep
+          about the code itself. Version 1.0 will be released once the paper
+          about the code has been accepted for publication. Documentation is
+          still in progress; if you have questions, please contact the
+          development team.
 
 To see the most recent updates to the code, see the `release notes
 <https://github.com/openpathsampling/openpathsampling/releases>`_ page on

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,10 +24,10 @@ the development process on GitHub_, and follow `@pathsampling
 .. _GitHub: http://github.com/openpathsampling/openpathsampling
 
 .. note:: **Project status:** Currently we're at version 0.9.4.  There will
-          be some API cleanup before 1.0, but files created with current
-          this version will load in 1.0.  Note, however, that files
-          generated with Python 2 will not fully load with Python 3 or vice
-          versa (partial Python 3 support starting in 0.9.3).
+          be some API cleanup before 1.0, but files created with the current
+          version will load in 1.0.  Note, however, that files generated
+          with Python 2 will not fully load with Python 3 or vice versa
+          (partial Python 3 support starting in 0.9.3).
 
           Overall, OPS is ready for production work. We're already writing
           several papers that used it, in addition to the paper in prep

--- a/openpathsampling/netcdfplus/version.py
+++ b/openpathsampling/netcdfplus/version.py
@@ -1,5 +1,5 @@
-short_version = '0.9.3'
-version = '0.9.3'
-full_version = '0.9.3-alpha'
+short_version = '0.9.4'
+version = '0.9.4'
+full_version = '0.9.4-alpha'
 git_revision = 'alpha'
 release = False

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ Operating System :: MacOS
         'matplotlib',
         'ujson'],
     'url': 'http://www.openpathsampling.org',
-    'version': '0.9.3'}
+    'version': '0.9.4'}
 
 setup_keywords = build_keyword_dictionary(preferences)
 


### PR DESCRIPTION
Release notes:

OpenPathSampling 0.9.4 includes a few new features, several important bug fixes, and a lot of minor improvements. A few highlights include:

* New ability to include velocities when creating an OPS trajectory from and MDTraj trajectory
* New default colors in visualizations (better visibility for the most common type of color blindness)
* Significant updates to the documentation
* Major improvements in Python 3 support
* Critical bug fix in the direct MD flux calculation
* Critical bug fix in two-way shooting

Details on all improvements below. 

## New features
* Add velocities as input to `trajectory_from_mdtraj` (#750)
* Tools for converting flux to `pandas` structures (#735)

## Bugs fixed
* Allow unicode for string options in engine option check (#757)
* Fix bug in `BackwardFirstTwoWayShooting` (#752)
* Fix problem with `HistogramPlotter2D` limits (#732)
* Fix bug in `snapshot.md box_vectors` (#731)
* Fix bug in `DirectSimulation` flux (#726)

## Miscellaneous improvements
* Default path tree colors are better for color-blind (#733)
* Improvements to documentation (#751, #748, #744, #737, #729, #723)
* Improved Python 3 compatibility (#743, #741, #739, #738)
* Improvements to examples (#746, #743, #719 [by @bolhuis])
* Behind-the-scenes upates to CI, testing, and deployment (#758, #749, #747, #745, #742)
* Dev install for simple developer installs (#728)
* Code readability updates (#724)