### PR TITLE
Attempt to fix for old openmmtools as well as new

### DIFF
--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -26,6 +26,7 @@ def restore_custom_integrator_interface(integrator):
     # for openmmtools integrators
     try:
         import openmmtools
+        import openmmtools.integrators  # hash table, see #767
     except ImportError:  # pragma: no cover
         pass  # if openmmtools doesn't exist, can't restore interface
     else:

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -29,7 +29,15 @@ def restore_custom_integrator_interface(integrator):
     except ImportError:  # pragma: no cover
         pass  # if openmmtools doesn't exist, can't restore interface
     else:
-        RestorableObject = openmmtools.utils.RestorableOpenMMObject
+        try:
+            # openmmtools 0.15 or later
+            from openmmtools.utils import RestorableOpenMMObject \
+                    as RestorableObject
+        except ImportError: # pragma: no cover
+            # DEPRECATED: remove in 2.0 (support for openmmtools < 0.15)
+            from openmmtools.integrators import RestorableIntegrator \
+                    as RestorableObject
+
         if RestorableObject.is_restorable(integrator):
             success = RestorableObject.restore_interface(integrator)
             logger.debug("Restored interface to integrator: " + str(success))


### PR DESCRIPTION
This, combined with pinning to `openmmtools==0.14`, may be a (temporary?) fix for #767.

Update: thanks to @andrrizzi's suggestion in https://github.com/openpathsampling/openpathsampling/issues/767#issuecomment-381629371, this PR now resolves #767 in two ways:

* If the user has `openmmtools 0.14` or older installed, we still work with that (although that will be removed in 2.0, if not before)
* We also work directly with integrators in `0.15`.

