### PR TITLE
omit using rejected paths in correlation visualization

### DIFF
--- a/openpathsampling/visualize.py
+++ b/openpathsampling/visualize.py
@@ -1648,7 +1648,9 @@ class PathTreeBuilder(Builder):
         for pos_y, data in enumerate(self._plot_sample_list):
             sample = data['sample']
 
-            if pos_y > 0:
+            css_class = data['css_class']
+
+            if pos_y > 0 and 'rejected' not in css_class:
                 if not paths.Trajectory.is_correlated(
                         sample.trajectory,
                         prev,


### PR DESCRIPTION
Resolves #773 .

Apparently the visualization does not take rejected or _transparent_ marked trajectories in the path tree. This PR changes this to only consider non-transparent ones. Note, that there are different possibilities to mark paths as transparant. The default is rejected, but it can also intermediate (auxiliary) paths which happen inside of movers.