### PR TITLE
Bump version to 0.9.5

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openpathsampling-dev
-  version: "0.9.4"
+  version: "0.9.5"
 
 source:
 #  git_url: ../../.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ the development process on GitHub_, and follow `@pathsampling
 
 .. _GitHub: http://github.com/openpathsampling/openpathsampling
 
-.. note:: **Project status:** Currently we're at version 0.9.4.  There will
+.. note:: **Project status:** Currently we're at version 0.9.5.  There will
           be some API cleanup before 1.0, but files created with the current
           version will load in 1.0.  Note, however, that files generated
           with Python 2 will not fully load with Python 3 or vice versa

--- a/openpathsampling/netcdfplus/version.py
+++ b/openpathsampling/netcdfplus/version.py
@@ -1,5 +1,5 @@
-short_version = '0.9.4'
-version = '0.9.4'
-full_version = '0.9.4-alpha'
+short_version = '0.9.5'
+version = '0.9.5'
+full_version = '0.9.5-alpha'
 git_revision = 'alpha'
 release = False

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ Operating System :: MacOS
         'matplotlib',
         'ujson'],
     'url': 'http://www.openpathsampling.org',
-    'version': '0.9.4'}
+    'version': '0.9.5'}
 
 setup_keywords = build_keyword_dictionary(preferences)
 


### PR DESCRIPTION
Doesn't submitting the papers justify a version bump? @jhprinz, I assume you're in favor of another release at this point. If I don't hear from you by noon tomorrow (just over 12 hours from now) I'll assume it's okay to merge this and do a release.

Proposed release notes:

## Bugs fixed
* Only keep existing value stores in attribute_list (#783)
* Omit using rejected paths in correlation visualization (#782)
* Fix problems in notebook tests (#776)
* Fix problem with netCDF not playing nicely with `simtk.unit` (#776)
* Volumes should only be bounded on one side (#772)
* Fix `TISEnsemble` so it allows 0 frames between interface and state B (#772)

## Miscellaneous improvements
* Fix pandas deprecation warning : replace df.as_matrix() with df.values (#781)
* Update minus ensemble implementation (#772)
* Fix openmmtools.RestorableIntegrator error (#764)
* Better source code organization and management (#754, #760)
* Add acknowledgments to docs (#766)