### PR TITLE
Fix push-docs-to-s3 for pip 10

### DIFF
--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -56,8 +56,8 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
 elif [[ "$TRAVIS_BRANCH" == "docs_deploy" ]]; then
     # change the behavior for the docs testing branch (docs_deploy branch in
     # the openpathsampling/openpathsampling GitHub repo) in this block
-    echo "No docs deploy on branch $TRAVIS_BRANCH"
-    # python devtools/ci/push-docs-to-s3.py --clobber
+    # echo "No docs deploy on branch $TRAVIS_BRANCH"
+    python devtools/ci/push-docs-to-s3.py --clobber
 else
     echo "No docs deploy on branch $TRAVIS_BRANCH"
 fi

--- a/devtools/ci/push-docs-to-s3.py
+++ b/devtools/ci/push-docs-to-s3.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import os
-import pip
+import pkg_resources
 import tempfile
 import subprocess
 import openpathsampling.version
@@ -22,7 +22,7 @@ else:
     PREFIX = openpathsampling.version.short_version
 
 def is_s3cmd_installed():
-    dists = pip.get_installed_distributions()
+    dists = pkg_resources.working_set
     if not any(d.project_name == 's3cmd' for d in dists):
         raise ImportError('The s3cmd package is required. '
                           'try $ pip install s3cmd')

--- a/docs/data_objects.rst
+++ b/docs/data_objects.rst
@@ -7,10 +7,11 @@ This describes some of the objects used to describe data. Note that
 :class:`Trajectories <.Trajectory>` and :class:`Snapshots <.Snapshot>` are
 described in the :ref:`Engines <engine>` section.
 
-.. currentmodule:: openpathsampling.sample
+.. currentmodule:: openpathsampling
 
 .. autosummary::
    :toctree: api/generated/
 
     Sample
     SampleSet
+    MCStep

--- a/docs/pathsimulator.rst
+++ b/docs/pathsimulator.rst
@@ -1,6 +1,6 @@
 .. _pathsimulator:
 
-.. currentmodule:: openpathsampling.pathsimulator
+.. currentmodule:: openpathsampling
 
 PathSimulator API
 =======================

--- a/docs/topics/data_objects.rst
+++ b/docs/topics/data_objects.rst
@@ -1,5 +1,7 @@
 .. _data-objects:
 
+.. currentmodule:: openpathsampling
+
 ============
 Data objects
 ============


### PR DESCRIPTION
As of pip 10.0, the `pip.get_installed_distributions()` no longer exists (https://github.com/pypa/pip/issues/5243), so our docs haven't been pushing. This fixes the problem.

It also fixes some problems missing docs after the pathsimulator split #754.

Note that to test this, the docs already had to get pushed (so the openpathsampling.org website already matches this PR).