### PR TITLE
allow conversion of LoaderProxies into real objects using `.proxy()`

### DIFF
--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -611,3 +611,9 @@ class Trajectory(list, StorableObject):
             return paths.Trajectory([trajectories])
 
         return trajectories
+
+    def unproxy(self):
+        for idx, snapshot in enumerate(self.iter_proxies()):
+            if issubclass(type(snapshot), LoaderProxy):
+                list.__setitem__(self, idx, snapshot.__subject__)
+                snapshot.__subject__.unproxy();

--- a/openpathsampling/netcdfplus/__init__.py
+++ b/openpathsampling/netcdfplus/__init__.py
@@ -1,7 +1,7 @@
 from .base import StorableNamedObject, StorableObject, create_to_dict
 from .cache import WeakKeyCache, WeakLRUCache, WeakValueCache, MaxCache, \
     NoCache, Cache, LRUCache, LRUChunkLoadingCache
-from .dictify import ObjectJSON, StorableObjectJSON, UUIDObjectJSON
+from .dictify import ObjectJSON, UUIDObjectJSON
 from .netcdfplus import NetCDFPlus
 
 from .stores import ObjectStore

--- a/openpathsampling/netcdfplus/base.py
+++ b/openpathsampling/netcdfplus/base.py
@@ -345,6 +345,13 @@ class StorableObject(object):
         else:
             return cls(**dct)
 
+    def unproxy(self):
+        if hasattr(self, '_lazy') :
+            for attr, value in self._lazy.items() :
+                if hasattr(value, '__subject__') :
+                    self._lazy[attr] = value.__subject__
+                    value.__subject__.unproxy()
+
 
 class StorableNamedObject(StorableObject):
     """Mixin that allows an object to carry a .name property that can be saved

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -589,48 +589,6 @@ class ObjectJSON(object):
         return self.unit_from_dict(self.from_json(json_string))
 
 
-class StorableObjectJSON(ObjectJSON):
-    def __init__(self, storage, unit_system=None):
-        super(StorableObjectJSON, self).__init__(unit_system)
-        self.excluded_keys = ['idx', 'json', 'identifier']
-        self.storage = storage
-
-    def simplify(self, obj, base_type=''):
-        if obj is self.storage:
-            return {'_storage': 'self'}
-        if obj.__class__.__module__ != builtin_module:
-            if obj.__class__ in self.storage._obj_store:
-                store = self.storage._obj_store[obj.__class__]
-                if not store.nestable or obj.base_cls_name != base_type:
-                    # this also returns the base class name used for storage
-                    # store objects only if they are not creatable. If so they
-                    # will only be created in their top instance and we use
-                    # the simplify from the super class ObjectJSON
-                    idx = store.save(obj)
-                    if idx is None:
-                        raise RuntimeError(
-                            'cannot store idx None in store %s' % store)
-                    return {
-                        '_idx': idx,
-                        '_store': store.prefix}
-
-        return super(StorableObjectJSON, self).simplify(obj, base_type)
-
-    def build(self, obj):
-        if type(obj) is dict:
-            if '_storage' in obj:
-                if obj['_storage'] == 'self':
-                    return self.storage
-
-            if '_idx' in obj and '_store' in obj:
-                store = self.storage._stores[obj['_store']]
-                result = store.load(obj['_idx'])
-
-                return result
-
-        return super(StorableObjectJSON, self).build(obj)
-
-
 class UUIDObjectJSON(ObjectJSON):
     def __init__(self, storage, unit_system=None):
         super(UUIDObjectJSON, self).__init__(unit_system)

--- a/openpathsampling/netcdfplus/proxy.py
+++ b/openpathsampling/netcdfplus/proxy.py
@@ -98,11 +98,11 @@ class LoaderProxy(object):
             if type(self.__uuid__) is int:
                 raise RuntimeWarning(
                     'Index %s is not in store. This should never happen!' %
-                    self._idx)
+                    self.__uuid__)
             else:
                 raise RuntimeWarning(
                     'Object %s is not in store. Attach it using fallbacks.' %
-                    self._idx)
+                    self.__uuid__)
 
 
 class DelayedLoader(object):
@@ -114,7 +114,7 @@ class DelayedLoader(object):
     def __get__(self, instance, owner):
         if instance is not None:
             obj = instance._lazy[self]
-            if hasattr(obj, '_idx'):
+            if isinstance(obj, LoaderProxy):
                 return obj.__subject__
             else:
                 return obj

--- a/openpathsampling/tests/test_collectivevariable.py
+++ b/openpathsampling/tests/test_collectivevariable.py
@@ -174,10 +174,6 @@ class TestFunctionCV(object):
             assert (cv_cache.allow_incomplete == allow_incomplete)
 
             for idx, snap in enumerate(storage_r.trajectories[1]):
-                # print idx, snap
-                # if hasattr(snap, '_idx'):
-                #     print 'Proxy IDX', snap._idx
-
                 # print 'ITEMS', storage_r.snapshots.index.items()
                 # print snap, type(snap), snap.__dict__
 


### PR DESCRIPTION
Implements #671 

This was not so difficult. There is now a method

```
StorableObject.unproxy()
```

which will convert recursively all existing LoaderProxies into real objects to avoid the problem of loading an object and have it implicitly requiring an open file where the object was loaded from.

There are specific implementations for `Trajectory` and `SampleSet`

There was also a little bug when getting delayed attributes which lead to returning the Proxy and not the full object. The user should not see the LoaderProxies unless specifically asking for it.