### PR TITLE
Fix notebook tests

### DIFF
--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -37,37 +37,37 @@ cp `basename $mistis` toy_mistis_1k_OPS1.nc
 ls *nc
 cd toy_model_mstis/
 date
-ipynbtest.py "toy_mstis_1_setup.ipynb" || testfail=1
+#ipynbtest.py "toy_mstis_1_setup.ipynb" || testfail=1
 date
-ipynbtest.py "toy_mstis_2_run.ipynb" || testfail=1
+#ipynbtest.py "toy_mstis_2_run.ipynb" || testfail=1
 date
-ipynbtest.py "toy_mstis_3_analysis.ipynb" || testfail=1
+#ipynbtest.py "toy_mstis_3_analysis.ipynb" || testfail=1
 date
-ipynbtest.py "toy_mstis_4_repex_analysis.ipynb" || testfail=1
+#ipynbtest.py "toy_mstis_4_repex_analysis.ipynb" || testfail=1
 #date
 #ipynbtest.py "toy_mstis_5_srtis.ipynb" || testfail=1
 cd ../toy_model_mistis/
 date
-ipynbtest.py "toy_mistis_1_setup_run.ipynb" || testfail=1
+#ipynbtest.py "toy_mistis_1_setup_run.ipynb" || testfail=1
 date
 # skip toy_mistis_2_flux: not needed
-ipynbtest.py "toy_mistis_3_analysis.ipynb" || testfail=1
+#ipynbtest.py "toy_mistis_3_analysis.ipynb" || testfail=1
 date
 cd ../tests/
 cp ../toy_model_mstis/mstis.nc ./
-ipynbtest.py --strict --show-diff "test_openmm_integration.ipynb" || testfail=1
+#ipynbtest.py --strict --show-diff "test_openmm_integration.ipynb" || testfail=1
 date
-ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
+#ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
 date
-ipynbtest.py --strict "test_netcdfplus.ipynb" || testfail=1
+ipynbtest.py -d --strict "test_netcdfplus.ipynb" || testfail=1
 date
-ipynbtest.py --strict "test_cv.ipynb" || testfail=1
+ipynbtest.py -d --strict "test_cv.ipynb" || testfail=1
 date
-ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
+#ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
 date
 cd ../misc/
 cp ../toy_model_mstis/mstis.nc ./
-ipynbtest.py "tutorial_storage.ipynb" || testfail=1
+#ipynbtest.py "tutorial_storage.ipynb" || testfail=1
 
 cd ..
 rm toy_mstis_1k_OPS1.nc

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -37,37 +37,37 @@ cp `basename $mistis` toy_mistis_1k_OPS1.nc
 ls *nc
 cd toy_model_mstis/
 date
-#ipynbtest.py "toy_mstis_1_setup.ipynb" || testfail=1
+ipynbtest.py "toy_mstis_1_setup.ipynb" || testfail=1
 date
-#ipynbtest.py "toy_mstis_2_run.ipynb" || testfail=1
+ipynbtest.py "toy_mstis_2_run.ipynb" || testfail=1
 date
-#ipynbtest.py "toy_mstis_3_analysis.ipynb" || testfail=1
+ipynbtest.py "toy_mstis_3_analysis.ipynb" || testfail=1
 date
-#ipynbtest.py "toy_mstis_4_repex_analysis.ipynb" || testfail=1
+ipynbtest.py "toy_mstis_4_repex_analysis.ipynb" || testfail=1
 #date
 #ipynbtest.py "toy_mstis_5_srtis.ipynb" || testfail=1
 cd ../toy_model_mistis/
 date
-#ipynbtest.py "toy_mistis_1_setup_run.ipynb" || testfail=1
+ipynbtest.py "toy_mistis_1_setup_run.ipynb" || testfail=1
 date
 # skip toy_mistis_2_flux: not needed
-#ipynbtest.py "toy_mistis_3_analysis.ipynb" || testfail=1
+ipynbtest.py "toy_mistis_3_analysis.ipynb" || testfail=1
 date
 cd ../tests/
 cp ../toy_model_mstis/mstis.nc ./
-#ipynbtest.py --strict --show-diff "test_openmm_integration.ipynb" || testfail=1
+ipynbtest.py --strict --show-diff "test_openmm_integration.ipynb" || testfail=1
 date
-#ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
+ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
 date
-ipynbtest.py -d --strict "test_netcdfplus.ipynb" || testfail=1
+ipynbtest.py --strict "test_netcdfplus.ipynb" || testfail=1
 date
-ipynbtest.py -d --strict "test_cv.ipynb" || testfail=1
+ipynbtest.py --strict "test_cv.ipynb" || testfail=1
 date
-#ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
+ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
 date
 cd ../misc/
 cp ../toy_model_mstis/mstis.nc ./
-#ipynbtest.py "tutorial_storage.ipynb" || testfail=1
+ipynbtest.py "tutorial_storage.ipynb" || testfail=1
 
 cd ..
 rm toy_mstis_1k_OPS1.nc

--- a/examples/tests/test_cv.ipynb
+++ b/examples/tests/test_cv.ipynb
@@ -114,7 +114,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "338489518249846260551333267048467791884\n"
+      "297526090140029669978659587005861593100\n"
      ]
     }
    ],
@@ -140,7 +140,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(store.attributes[PseudoAttribute] : 4 object(s), 20, 338489518249846260551333267048467791886L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 338489518249846260551333267048467791888L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 338489518249846260551333267048467791890L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 338489518249846260551333267048467791892L)]\n"
+      "[(store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593102L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593104L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593106L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593108L)]\n"
      ]
     }
    ],
@@ -158,7 +158,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{338489518249846260551333267048467791888L: 1, 338489518249846260551333267048467791890L: 2, 338489518249846260551333267048467791892L: 3, 338489518249846260551333267048467791886L: 0}\n"
+      "{297526090140029669978659587005861593104L: 1, 297526090140029669978659587005861593106L: 2, 297526090140029669978659587005861593108L: 3, 297526090140029669978659587005861593102L: 0}\n"
      ]
     }
    ],
@@ -372,7 +372,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(store.trajectories[Trajectory] : 1 object(s), 0, 338489518249846260551333267048467791960L)\n"
+      "(store.trajectories[Trajectory] : 1 object(s), 0, 297526090140029669978659587005861593176L)\n"
      ]
     }
    ],
@@ -409,7 +409,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "338489518249846260551333267048467791962\n"
+      "297526090140029669978659587005861593178\n"
      ]
     }
    ],
@@ -496,7 +496,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[3.3921003341674805]\n"
+      "[3.3921]\n"
      ]
     }
    ],
@@ -513,7 +513,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[3.3921003341674805]\n"
+      "[3.3921]\n"
      ]
     }
    ],
@@ -585,7 +585,7 @@
     {
      "data": {
       "text/plain": [
-       "<openpathsampling.netcdfplus.attribute.FunctionPseudoAttribute at 0x7f2ba9332e50>"
+       "<openpathsampling.netcdfplus.attribute.FunctionPseudoAttribute at 0x7fd0d1599d10>"
       ]
      },
      "execution_count": 37,

--- a/examples/tests/test_cv.ipynb
+++ b/examples/tests/test_cv.ipynb
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.set_printoptions(precision=6)"
+    "# force numpy print options for test comparison\n",
+    "np.set_printoptions(precision=6, formatter={'float_kind': lambda x: \"{:.6f}\".format(x)})"
    ]
   },
   {
@@ -114,7 +115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "297526090140029669978659587005861593100\n"
+      "283860163354172696480456782077640048652\n"
      ]
     }
    ],
@@ -140,7 +141,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593102L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593104L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593106L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 297526090140029669978659587005861593108L)]\n"
+      "[(store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048654L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048656L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048658L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048660L)]\n"
      ]
     }
    ],
@@ -158,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{297526090140029669978659587005861593104L: 1, 297526090140029669978659587005861593106L: 2, 297526090140029669978659587005861593108L: 3, 297526090140029669978659587005861593102L: 0}\n"
+      "{283860163354172696480456782077640048656L: 1, 283860163354172696480456782077640048658L: 2, 283860163354172696480456782077640048660L: 3, 283860163354172696480456782077640048654L: 0}\n"
      ]
     }
    ],
@@ -372,7 +373,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(store.trajectories[Trajectory] : 1 object(s), 0, 297526090140029669978659587005861593176L)\n"
+      "(store.trajectories[Trajectory] : 1 object(s), 0, 283860163354172696480456782077640048728L)\n"
      ]
     }
    ],
@@ -409,7 +410,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "297526090140029669978659587005861593178\n"
+      "283860163354172696480456782077640048730\n"
      ]
     }
    ],
@@ -496,7 +497,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[3.3921]\n"
+      "[3.392100]\n"
      ]
     }
    ],
@@ -513,7 +514,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[3.3921]\n"
+      "[3.392100]\n"
      ]
     }
    ],
@@ -585,7 +586,7 @@
     {
      "data": {
       "text/plain": [
-       "<openpathsampling.netcdfplus.attribute.FunctionPseudoAttribute at 0x7fd0d1599d10>"
+       "<openpathsampling.netcdfplus.attribute.FunctionPseudoAttribute at 0x7f2957bf4d50>"
       ]
      },
      "execution_count": 37,

--- a/examples/tests/test_netcdfplus.ipynb
+++ b/examples/tests/test_netcdfplus.ipynb
@@ -43,7 +43,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.set_printoptions(precision=6)"
+    "# force numpy print options for test comparison\n",
+    "np.set_printoptions(precision=6, formatter={'float_kind': lambda x: \"{:.6f}\".format(x)})"
    ]
   },
   {
@@ -805,7 +806,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'{\"_store\":\"nodes\",\"_hex_uuid\":\"0xf9124d44b73911e8ae98000000000024L\"}'\n",
+      "[u'{\"_store\":\"nodes\",\"_hex_uuid\":\"0xebbeb5f0b75311e89830000000000024L\"}'\n",
       " u'{\"Test\":3,\"Hallo\":2}']\n"
      ]
     }
@@ -909,11 +910,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[7. 7.]\n",
-      "  [7. 7.]]\n",
+      "[[[7.000000 7.000000]\n",
+      "  [7.000000 7.000000]]\n",
       "\n",
-      " [[3. 3.]\n",
-      "  [3. 3.]]]\n"
+      " [[3.000000 3.000000]\n",
+      "  [3.000000 3.000000]]]\n"
      ]
     }
    ],
@@ -964,9 +965,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[u'f9124d44-b739-11e8-ae98-00000000002a'\n",
-      "   u'f9124d44-b739-11e8-ae98-00000000002e']\n",
-      "  [u'f9124d44-b739-11e8-ae98-00000000002c' u'']]\n",
+      "[[[u'ebbeb5f0-b753-11e8-9830-00000000002a'\n",
+      "   u'ebbeb5f0-b753-11e8-9830-00000000002e']\n",
+      "  [u'ebbeb5f0-b753-11e8-9830-00000000002c' u'']]\n",
       "\n",
       " [[u'' u'']\n",
       "  [u'' u'']]]\n",
@@ -1043,7 +1044,7 @@
      "text": [
       "Type:    <class 'openpathsampling.netcdfplus.proxy.LoaderProxy'>\n",
       "Class:   <class '__main__.Node'>\n",
-      "Content: {'__uuid__': 331072799483656961540438928126306680880L, 'value': 'First'}\n",
+      "Content: {'__uuid__': 313358805600210293968778471146830954544L, 'value': 'First'}\n",
       "Access:  First\n"
      ]
     }
@@ -1800,7 +1801,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xf9124d44b73911e8ae98000000000048L\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xf9124d44b73911e8ae9800000000004aL\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xf9124d44b73911e8ae9800000000004cL\"} ]\n"
+      "[ {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xebbeb5f0b75311e89830000000000048L\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xebbeb5f0b75311e8983000000000004aL\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xebbeb5f0b75311e8983000000000004cL\"} ]\n"
      ]
     }
    ],
@@ -2070,7 +2071,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0xf9124d44b73911e8ae98000000000012L\n"
+      "0xebbeb5f0b75311e89830000000000012L\n"
      ]
     }
    ],

--- a/examples/tests/test_netcdfplus.ipynb
+++ b/examples/tests/test_netcdfplus.ipynb
@@ -805,7 +805,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'{\"_store\":\"nodes\",\"_hex_uuid\":\"0x604646c0634111e89e59000000000024L\"}'\n",
+      "[u'{\"_store\":\"nodes\",\"_hex_uuid\":\"0xf9124d44b73911e8ae98000000000024L\"}'\n",
       " u'{\"Test\":3,\"Hallo\":2}']\n"
      ]
     }
@@ -909,11 +909,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[7.0 7.0]\n",
-      "  [7.0 7.0]]\n",
+      "[[[7. 7.]\n",
+      "  [7. 7.]]\n",
       "\n",
-      " [[3.0 3.0]\n",
-      "  [3.0 3.0]]]\n"
+      " [[3. 3.]\n",
+      "  [3. 3.]]]\n"
      ]
     }
    ],
@@ -964,9 +964,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[u'604646c0-6341-11e8-9e59-00000000002a'\n",
-      "   u'604646c0-6341-11e8-9e59-00000000002e']\n",
-      "  [u'604646c0-6341-11e8-9e59-00000000002c' u'']]\n",
+      "[[[u'f9124d44-b739-11e8-ae98-00000000002a'\n",
+      "   u'f9124d44-b739-11e8-ae98-00000000002e']\n",
+      "  [u'f9124d44-b739-11e8-ae98-00000000002c' u'']]\n",
       "\n",
       " [[u'' u'']\n",
       "  [u'' u'']]]\n",
@@ -1043,7 +1043,7 @@
      "text": [
       "Type:    <class 'openpathsampling.netcdfplus.proxy.LoaderProxy'>\n",
       "Class:   <class '__main__.Node'>\n",
-      "Content: {'__uuid__': 127970783386646500810318204513600667696L, 'value': 'First'}\n",
+      "Content: {'__uuid__': 331072799483656961540438928126306680880L, 'value': 'First'}\n",
       "Access:  First\n"
      ]
     }
@@ -1800,7 +1800,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0x604646c0634111e89e59000000000048L\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0x604646c0634111e89e5900000000004aL\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0x604646c0634111e89e5900000000004cL\"} ]\n"
+      "[ {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xf9124d44b73911e8ae98000000000048L\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xf9124d44b73911e8ae9800000000004aL\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xf9124d44b73911e8ae9800000000004cL\"} ]\n"
      ]
     }
    ],
@@ -2070,7 +2070,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0x604646c0634111e89e59000000000012L\n"
+      "0xf9124d44b73911e8ae98000000000012L\n"
      ]
     }
    ],


### PR DESCRIPTION
We have notebook tests failing in `test_cv.ipynb` and `test_netcdfplus.ipynb`. This seems to be because of something with the numpy string representation (because `ipynbtest` compares string representation here).

This PR will fix it (or find a way around it).