### PR TITLE
Fix Travis timeout on conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   # Sets up a miniconda environment
   - source devtools/ci/miniconda_install.sh
   - conda install --yes conda-build
-  - conda build --quiet devtools/conda-recipe
+  - conda build devtools/conda-recipe
   - conda create --quiet --yes --name test --use-local openpathsampling-dev
   - source activate test
   - conda info --envs


### PR DESCRIPTION
For some reason, our conda build command has started taking significantly longer -- long enough that Travis times out without output, which is causing our nightly builds to error before the tests even run.