### PR TITLE
Add engine property to OneWayShooting

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -2102,31 +2102,21 @@ class OneWayShootingMover(RandomChoiceMover):
 
     def __init__(self, ensemble, selector, engine=None):
         movers = [
-            ForwardShootMover(
-                ensemble=ensemble,
-                selector=selector,
-                engine=engine
-            ),
-            BackwardShootMover(
-                ensemble=ensemble,
-                selector=selector,
-                engine=engine
-            )
+            ForwardShootMover(ensemble=ensemble,
+                              selector=selector,
+                              engine=engine),
+            BackwardShootMover(ensemble=ensemble,
+                               selector=selector,
+                               engine=engine)
         ]
-        super(OneWayShootingMover, self).__init__(
-            movers=movers
-        )
+        super(OneWayShootingMover, self).__init__(movers=movers)
 
     @classmethod
     def from_dict(cls, dct):
         mover = cls.__new__(cls)
-
         # override with stored movers and use the init of the super class
         # this assumes that the super class has movers as its signature
-        super(cls, mover).__init__(
-            movers=dct['movers']
-        )
-
+        super(cls, mover).__init__(movers=dct['movers'])
         return mover
 
     @property
@@ -2136,6 +2126,10 @@ class OneWayShootingMover(RandomChoiceMover):
     @property
     def selector(self):
         return self.movers[0].selector
+
+    @property
+    def engine(self):
+        return self.movers[0].engine
 
 
 class OneWayExtendMover(RandomChoiceMover):
@@ -2153,20 +2147,18 @@ class OneWayExtendMover(RandomChoiceMover):
 
     def __init__(self, ensemble, target_ensemble, engine=None):
         movers = [
-            ForwardExtendMover(
-                ensemble=ensemble,
-                target_ensemble=target_ensemble,
-                engine=engine
-            ),
-            BackwardExtendMover(
-                ensemble=ensemble,
-                target_ensemble=target_ensemble,
-                engine=engine
-            )
+            ForwardExtendMover(ensemble=ensemble,
+                               target_ensemble=target_ensemble,
+                               engine=engine),
+            BackwardExtendMover(ensemble=ensemble,
+                                target_ensemble=target_ensemble,
+                                engine=engine)
         ]
-        super(OneWayExtendMover, self).__init__(
-            movers=movers
-        )
+        super(OneWayExtendMover, self).__init__(movers=movers)
+
+    @property
+    def engine(self):
+        return self.movers[0].engine
 
     @classmethod
     def from_dict(cls, dct):

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -270,6 +270,12 @@ class TestOneWayShootingMover(TestShootingMover):
         moverclasses = [m.__class__ for m in mover.movers]
         assert_equal(ForwardShootMover in moverclasses, True)
         assert_equal(BackwardShootMover in moverclasses, True)
+        assert_equal(mover.engine, mover.movers[0].engine)
+        assert_equal(mover.engine, mover.movers[1].engine)
+        assert_equal(mover.selector, mover.movers[0].selector)
+        assert_equal(mover.selector, mover.movers[1].selector)
+        assert_equal(mover.ensemble, mover.movers[0].ensemble)
+        assert_equal(mover.ensemble, mover.movers[1].ensemble)
 
 class TestForwardFirstTwoWayShootingMover(TestShootingMover):
     _MoverType = ForwardFirstTwoWayShootingMover


### PR DESCRIPTION
`OneWayShootingMover` did not have an `engine` attribute. It could be accessed from the submovers, but this is not very user-friendly.

This PR adds an `engine` property to `OneWayShootingMover` and to `OneWayExtendMover`. It also cleans up formatting to remove some of the unnecessary vertical space.

This should be immediately ready for review/merge.