### PR TITLE
Add conda-forge to channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,28 @@ install:
   - echo $PACKAGES
   - conda install -y -q -c conda-forge -c omnia $PACKAGES
   - python setup.py install
+  - python -c "import openpathsampling"
   
   # report info about our conda env and finish installation
   - conda info --envs
   - conda install --quiet --yes msmbuilder
+  - python -c "import openpathsampling"
   - conda install --quiet --yes nose python-coveralls ipynbtest 
+  - python -c "import openpathsampling"
   - conda install --quiet --yes pytest 
+  - python -c "import openpathsampling"
   - conda update --all --yes --use-local --quiet
+  - python -c "import openpathsampling"
   # pin pytest-cov b/c: https://github.com/z4r/python-coveralls/issues/66
   # usually this should be before the conda update
   - conda install --quiet --yes pytest-cov=2.5.1
+  - python -c "import openpathsampling"
   - conda update --quiet --yes matplotlib  # no idea why pytest-cov downgraded
+  - python -c "import openpathsampling"
 
 before_script:
   - python --version
+  - python -c "import openpathsampling"
   - source devtools/ci/git_hash.sh
   - conda list -n test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,27 +21,18 @@ install:
   - export PACKAGES=`python devtools/install_recipe_requirements.py --dry devtools/conda-recipe/meta.yaml`
   - echo $PACKAGES
   - conda install -y -q -c conda-forge -c omnia $PACKAGES
-  - python setup.py install
-  - pushd ..
-  - python -c "import openpathsampling"
   
   # report info about our conda env and finish installation
   - conda info --envs
   - conda install --quiet --yes msmbuilder
-  - python -c "import openpathsampling"
   - conda install --quiet --yes nose python-coveralls ipynbtest 
-  - python -c "import openpathsampling"
   - conda install --quiet --yes pytest 
-  - python -c "import openpathsampling"
   - conda update --all --yes --use-local --quiet
-  - python -c "import openpathsampling"
   # pin pytest-cov b/c: https://github.com/z4r/python-coveralls/issues/66
   # usually this should be before the conda update
   - conda install --quiet --yes pytest-cov=2.5.1
-  - python -c "import openpathsampling"
   - conda update --quiet --yes matplotlib  # no idea why pytest-cov downgraded
-  - python -c "import openpathsampling"
-  - popd
+  - python setup.py install
 
 before_script:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - echo $PACKAGES
   - conda install -y -q -c conda-forge -c omnia $PACKAGES
   - python setup.py install
+  - pushd ..
   - python -c "import openpathsampling"
   
   # report info about our conda env and finish installation
@@ -40,6 +41,7 @@ install:
   - python -c "import openpathsampling"
   - conda update --quiet --yes matplotlib  # no idea why pytest-cov downgraded
   - python -c "import openpathsampling"
+  - popd
 
 before_script:
   - python --version

--- a/devtools/ci/miniconda_install.sh
+++ b/devtools/ci/miniconda_install.sh
@@ -27,4 +27,5 @@ export PATH=$HOME/miniconda${pyV}/bin:$PATH
 
 # add omnia and update
 conda config --add channels http://conda.anaconda.org/omnia
+conda config --add channels http://conda.anaconda.org/conda-forge
 conda update --yes conda


### PR DESCRIPTION
There is some conflict with MSMBuilder (at least, for Py3). This PR will fix that.

I don't see it in my own Py3 installations, where I use the `conda-forge` channel, so I'm hoping that adding the `conda-forge` to our channels will fix the problem. 

In any case, `conda-forge` is now the recommended channel for Omnia projects, unless there's a specific reason to use the `omnia` channel, so we might as well search it first.