### PR TITLE
Fix warnings for Python 3.7

### DIFF
--- a/openpathsampling/netcdfplus/base.py
+++ b/openpathsampling/netcdfplus/base.py
@@ -10,6 +10,11 @@ if sys.version_info > (3, ):
 
 logger = logging.getLogger(__name__)
 
+try:
+    getfullargspec = inspect.getfullargspec
+except AttributeError:
+    getfullargspec = inspect.getargspec
+
 
 class StorableObject(object):
     """Mixin that allows objects of the class to to be stored using netCDF+
@@ -253,7 +258,7 @@ class StorableObject(object):
 
         """
         try:
-            args = inspect.getargspec(cls.__init__)
+            args = getfullargspec(cls.__init__)
         except TypeError:
             return []
         return args[0]

--- a/openpathsampling/tests/test_interface_set.py
+++ b/openpathsampling/tests/test_interface_set.py
@@ -217,5 +217,8 @@ class TestPeriodicVolumeInterfaceSet(object):
         for (v, l) in zip(reloaded.volumes, reloaded.lambdas):
             assert_equal(reloaded.get_lambda(v), l)
 
+        storage_r.close()
+        storage_w.close()
+
         if os.path.isfile(fname):
             os.remove(fname)

--- a/openpathsampling/tests/test_network.py
+++ b/openpathsampling/tests/test_network.py
@@ -384,6 +384,8 @@ class TestMISTISNetwork(TestMultipleStateTIS):
         assert_equal(reloaded.sampling_transitions[0].ensembles[0],
                      self.mistis.sampling_transitions[0].ensembles[0])
 
+        storage_w.close()
+        storage_r.close()
         if os.path.isfile(fname):
             os.remove(fname)
 

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -204,6 +204,7 @@ class TestShootFromSnapshotsSimulation(object):
         self.simulation.output_stream = open(os.devnull, "w")
 
     def teardown(self):
+        self.storage.close()
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None
@@ -269,6 +270,7 @@ class TestCommittorSimulation(object):
         self.simulation.output_stream = open(os.devnull, 'w')
 
     def teardown(self):
+        self.storage.close()
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -204,7 +204,6 @@ class TestShootFromSnapshotsSimulation(object):
         self.simulation.output_stream = open(os.devnull, "w")
 
     def teardown(self):
-        self.storage.close()
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None
@@ -258,8 +257,7 @@ class TestCommittorSimulation(object):
         randomizer = paths.NoModification()
 
         self.filename = data_filename("committor_test.nc")
-        self.storage = paths.Storage(self.filename,
-                                     mode="w")
+        self.storage = paths.Storage(self.filename, mode="w")
         self.storage.save(self.snap0)
 
         self.simulation = CommittorSimulation(storage=self.storage,
@@ -289,8 +287,10 @@ class TestCommittorSimulation(object):
         sim.storage = paths.Storage(new_filename, 'w')
         sim.output_stream = open(os.devnull, 'w')
         sim.run(n_per_snapshot=2)
+        sim.storage.close()
         if os.path.isfile(new_filename):
             os.remove(new_filename)
+        self.storage = read_store  # teardown will get rid of this
 
     def test_committor_run(self):
         self.simulation.run(n_per_snapshot=20)

--- a/openpathsampling/tests/test_shooting_point_analysis.py
+++ b/openpathsampling/tests/test_shooting_point_analysis.py
@@ -39,7 +39,7 @@ class TestTransformedDict(object):
 
     def test_initialization(self):
         assert_equal(self.test_dict.store, self.transformed)
-        assert_equal(self.test_dict.hash_representatives, 
+        assert_equal(self.test_dict.hash_representatives,
                      {0: (0,1), 1: (1,2), 2: (2,3)})
 
     def test_set_get(self):
@@ -132,8 +132,7 @@ class TestShootingPointAnalysis(object):
 
         randomizer = paths.NoModification()
         self.filename = data_filename("shooting_analysis.nc")
-        self.storage = paths.Storage(self.filename, 
-                                     mode="w")
+        self.storage = paths.Storage(self.filename, mode="w")
 
         self.simulation = paths.CommittorSimulation(
             storage=self.storage,
@@ -150,6 +149,7 @@ class TestShootingPointAnalysis(object):
 
     def teardown(self):
         import os
+        self.storage.close()
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None # set by Committor

--- a/openpathsampling/tests/test_storage.py
+++ b/openpathsampling/tests/test_storage.py
@@ -337,6 +337,8 @@ class TestStorage(object):
 
         compare_snapshot(storage_w.objects['snapshot0'][4], test_snap)
 
+        storage_w.close()
+
     def test_load_save_uuid(self):
         store = Storage(filename=self.filename, mode='w')
         assert(os.path.isfile(self.filename))


### PR DESCRIPTION
I've switched to using Python 3.7 as my primary development environment -- a big jump from 2.7! This PR fixes a few warnings I was getting when running the tests in 3.7.

1. `inspect.getargspec` is deprecated and will be removed in 3.8. Using a try/except to prefer `inspect.getfullargspec` when available (Py3k) and fall back to `inspect.getargspec` when not. (This only occurs once, in `netcdfplus/base.py`.)

2. We were getting a weird error (multiple times) at the end of pytest:

        Error in sys.excepthook:
        
        Original exception was:

    This didn't actually cause the tests to fail, but certainly looked bad. It turns out that this was happening in tests that had opened a file for writing, but not closed the file after. Closing the file fixes. Figured it out pretty quickly thanks to https://github.com/pytest-dev/execnet/issues/30#issuecomment-316962021 -- same error message, also solved by closing "files" they were writing to.

I'm still seeing a few warnings (about importing from `collections.abc` vs. just `collections`), but these are emitted by pandas, networkx, and mdtraj. It looks to me like the next releases of those packages may fix.

Also, this isn't intended to add testing for Python 3.7 yet. For one thing, we can't do full tests until msmbuilder works on 3.7 (they seem to have a problem with recent Cython).