### PR TITLE
Refactor path histograms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   #- conda install --quiet --yes pytest 
   - conda config --env --add pinned_packages libnetcdf=4.6.1
   - conda config --env --add pinned_packages pytest-cov=2.5.1
+  - conda config --env --add pinned_packages ipython!=7.4.0
   - conda update --all --yes --use-local --quiet
   # pin pytest-cov b/c: https://github.com/z4r/python-coveralls/issues/66
   # usually this should be before the conda update

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - openmm
     - openmmtools
     - jupyter
+    - ipython!=7.4.0
     - mdtraj
     - svgwrite
     - networkx

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -18,7 +18,7 @@ case $PYTHON_VERSION in
         ;;
     "3.5")
         mstis=$dropbox_base_url/1ulzssv5p4lr61f/toy_mstis_1k_OPS1_py36.nc
-        mistis=$dropbox_base_url/76981cbgxm639m3/toy_mistis_1k_OPS1_py36.nc
+        mistis=$dropbox_base_url/8wldep8e26qignt/toy_mistis_1k_OPS1_py35.nc
         ;;
     "3.6")
         mstis=$dropbox_base_url/1ulzssv5p4lr61f/toy_mstis_1k_OPS1_py36.nc

--- a/examples/toy_model_mistis/toy_mistis_1_setup_run.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_1_setup_run.ipynb
@@ -464,21 +464,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -62,7 +62,7 @@
    ],
    "source": [
     "%%time\n",
-    "storage = paths.AnalysisStorage(filename)"
+    "storage = paths.Storage(filename, mode='r')"
    ]
   },
   {
@@ -965,21 +965,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -3,15 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
     "# if our large test file is available, use it. Otherwise, use file generated from toy_mistis_1_setup_run.ipynb\n",
     "import os\n",
-    "test_file = \"../toy_mistis_1k_OPS1.nc \"\n",
+    "test_file = \"../toy_mistis_1k_OPS1.nc\"\n",
     "filename = test_file if os.path.isfile(test_file) else \"mistis.nc\""
    ]
   },
@@ -24,7 +22,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mistis.nc\n"
+      "../toy_mistis_1k_OPS1.nc\n"
      ]
     }
    ],
@@ -35,9 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -55,8 +51,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6min 20s, sys: 14.2 s, total: 6min 34s\n",
-      "Wall time: 6min 38s\n"
+      "CPU times: user 617 ms, sys: 108 ms, total: 725 ms\n",
+      "Wall time: 788 ms\n"
      ]
     }
    ],
@@ -68,10 +64,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'storage' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-6044c40634e8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmistis\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mstorage\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnetworks\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'storage' is not defined"
+     ]
+    }
+   ],
    "source": [
     "mistis = storage.networks.load(0)"
    ]

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -58,7 +58,7 @@
    ],
    "source": [
     "%%time\n",
-    "storage = paths.Storage(filename, mode='r')"
+    "storage = paths.AnalysisStorage(filename)"
    ]
   },
   {

--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -5,6 +5,23 @@ from collections import Counter
 import numpy as np
 
 class VoxelInterpolator(object):
+    """
+    Identify voxels visited during linear interpolation between two points
+
+    This class includes some conveniences to facilate this with
+    n-dimensional histograms.
+
+    This is an abstract class; the __call__ method needs to be implemented
+    by subclasses. The __call__ method should take the arguments ``old_pt``
+    and ``new_pt``, which are the points to interpolate between, and should
+    return the list of voxel identifiers (n-dimensional integer tuples) for
+    the visited voxels, excluding the voxel for ``old_pt``.
+
+    Parameters
+    ----------
+    histogram : :class:`.PathHistogram`
+        the histogram that this will interpolate for
+    """
     def __init__(self, histogram):
         self.histogram = histogram
 
@@ -24,11 +41,33 @@ class VoxelInterpolator(object):
 
 
 class NoInterpolation(VoxelInterpolator):
+    """No interpolation.
+
+    Just returns the bin for the new point. The effect is that no
+    interpolation is done.
+
+    Parameters
+    ----------
+    histogram : :class:`.PathHistogram`
+        the histogram that this will interpolate for
+    """
     def __call__(self, old_pt, new_pt):
         return [self.map_to_bins(new_pt)]
 
 
 class SubdivideInterpolation(VoxelInterpolator):
+    """Interpolate by bisection.
+
+    Identifies all voxels that are visited between two points by
+    successively recursively taking the midpoint, until all voxels found are
+    adjacent (with special case handling for corners, where the line does
+    not go through a face).
+
+    Parameters
+    ----------
+    histogram : :class:`.PathHistogram`
+        the histogram that this will interpolate for
+    """
     def _interpolated_bins(self, old_pt, new_pt):
         """Interpolate between trajectory points.
 


### PR DESCRIPTION
This refactors a few parts of the path histogram code. Technically, this is an API break: there were methods that *should* have been private, but were part of the public API (methods related to the interpolation). This PR refactors so that there is a separate class `VoxelInterpolator`, with subclasses `NoInterpolation` and `SubdivideInterpolation`. Note that this does not affect the tests at all; all the tested behavior remains the same.

This will make it much easier to implement alternative interpolation algorithms (which may be much faster than what we have now).