### PR TITLE
Update installation docs to include conda-forge

### DIFF
--- a/devtools/conda_ops_dev_install.sh
+++ b/devtools/conda_ops_dev_install.sh
@@ -3,7 +3,7 @@
 # This assumes you've already installed conda. Then it installs OPS as a
 # developer install.
 
-conda install -y -c omnia openpathsampling
+conda install -y -c conda-forge -c omnia openpathsampling
 conda update -y --all
 conda uninstall -y openpathsampling
 git clone https://github.com/openpathsampling/openpathsampling.git

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,11 +20,12 @@ dependencies seamlessly.  If you don't want the full ``conda`` installation,
 the ``miniconda`` package provides much of the convenience of ``conda`` with
 a smaller footprint.
 
-OpenPathSampling is part of the ``omnia`` channel in ``conda``. To install
+OpenPathSampling is part of the ``omnia`` channel in ``conda``, although
+some requirements are best found in the ``conda-forge`` channel. To install
 the most recent release of OpenPathSampling with conda, use the following
-commands ::
+command ::
 
-  $ conda install -c omnia openpathsampling
+  $ conda install -c conda-forge -c omnia openpathsampling
 
 .. _developer-install-conda:
 


### PR DESCRIPTION
The correct way to install omnia packages is now (and has been for a while):

```
conda install -c conda-forge -c omnia $PACKAGE_NAME
```

Based on a report from @bolhuis, it sounds like missing `conda-forge` can cause a segfault. This PR updates the installation docs to provide the correct command.

This should be immediately ready for review, since it is a very simple PR. I'll merge it tomorrow (Tuesday 23 April) if there are no objects before then.