### PR TITLE
Improve conda performance

### DIFF
--- a/devtools/ci/miniconda_install.sh
+++ b/devtools/ci/miniconda_install.sh
@@ -25,7 +25,11 @@ bash $MINICONDA -b
 
 export PATH=$HOME/miniconda${pyV}/bin:$PATH
 
-# add omnia and update
+# this puts the channel priority to (1) conda-forge; (2) omnia (3) defaults
 conda config --add channels http://conda.anaconda.org/omnia
 conda config --add channels http://conda.anaconda.org/conda-forge
+
+# this may speed up conda's package resolution
+conda config --set channel_priority strict
+
 conda update --yes conda


### PR DESCRIPTION
Our Py 3.5 builds are failing on Travis because conda is taking too long to solve the environment. Granted, we should be moving away from 3.5, but conda performance is an issue in general. It just isn't quite bad enough to cause Travis failures for other Python versions.

To make this faster, I'll work through some of the steps described here: https://www.anaconda.com/understanding-and-improving-condas-performance/