### PR TITLE
snapshot_from_pdb should use same code path as other functions

### DIFF
--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -95,18 +95,17 @@ def snapshot_from_pdb(pdb_file, simple_topology=False):
         the constructed Snapshot
 
     """
-    pdb = md.load(pdb_file)
-    velocities = np.zeros(pdb.xyz[0].shape)
+    snap = ops_load_trajectory(pdb_file)[0]
 
     if simple_topology:
         topology = Topology(*pdb.xyz[0].shape)
     else:
-        topology = MDTrajTopology(pdb.topology)
+        topology = snap.topology
 
     snapshot = Snapshot.construct(
-        coordinates=u.Quantity(pdb.xyz[0], u.nanometers),
-        box_vectors=u.Quantity(pdb.unitcell_vectors[0], u.nanometers),
-        velocities=u.Quantity(velocities, u.nanometers / u.picoseconds),
+        coordinates=snap.coordinates,
+        box_vectors=snap.box_vectors,
+        velocities=snap.velocities,
         engine=FileEngine(topology, pdb_file)
     )
 


### PR DESCRIPTION
As discussed in #832, `snapshot_from_pdb` should use the same code path (for creating velocities; setting box vectors) as related functions. Namely, the main functionality should be in `trajectory_from_mdtraj`. This PR makes it so that it uses `ops_load_trajectory`, which in turn uses `trajectory_from_mdtraj`.

In the future, I think we should deprecate the `simple_topology` option. The topology should only be made once, which would mean that the performance concern is not a worry.