### PR TITLE
Fix problems with storage for nonperiodic systems

### DIFF
--- a/openpathsampling/engines/features/shared.py
+++ b/openpathsampling/engines/features/shared.py
@@ -132,7 +132,13 @@ class StaticContainerStore(ObjectStore):
     def _save(self, configuration, idx):
         # Store configuration.
         self.vars['coordinates'][idx] = configuration.coordinates
-        self.vars['box_vectors'][idx] = configuration.box_vectors
+        box_vectors = configuration.box_vectors
+
+        if box_vectors is None:
+            n_spatial = configuration.coordinates.shape[1]
+            box_vectors = np.zeros((n_spatial, n_spatial))
+
+        self.vars['box_vectors'][idx] = box_vectors
 
     def get(self, indices):
         return [self.load(idx) for idx in indices]
@@ -140,6 +146,9 @@ class StaticContainerStore(ObjectStore):
     def _load(self, idx):
         coordinates = self.vars["coordinates"][idx]
         box_vectors = self.vars["box_vectors"][idx]
+
+        if not np.count_nonzero(box_vectors):
+            box_vectors = None
 
         configuration = StaticContainer(coordinates=coordinates, box_vectors=box_vectors)
 

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -423,12 +423,12 @@ class OpenMMEngine(DynamicsEngine):
             # if snapshot.coordinates is not None:
             self.simulation.context.setPositions(snapshot.coordinates)
 
-            # if snapshot.box_vectors is not None:
-            self.simulation.context.setPeriodicBoxVectors(
-                snapshot.box_vectors[0],
-                snapshot.box_vectors[1],
-                snapshot.box_vectors[2]
-            )
+            if snapshot.box_vectors is not None:
+                self.simulation.context.setPeriodicBoxVectors(
+                    snapshot.box_vectors[0],
+                    snapshot.box_vectors[1],
+                    snapshot.box_vectors[2]
+                )
 
             # if snapshot.velocities is not None:
             self.simulation.context.setVelocities(snapshot.velocities)

--- a/openpathsampling/tests/test_shared.py
+++ b/openpathsampling/tests/test_shared.py
@@ -21,3 +21,5 @@ class TestStaticContainerStore(object):
         reloaded = load.snapshots[0]
         npt.assert_array_equal(snap.coordinates, reloaded.coordinates)
         npt.assert_array_equal(snap.box_vectors, reloaded.box_vectors)
+        assert snap.box_vectors is None
+        assert reloaded.box_vectors is None

--- a/openpathsampling/tests/test_shared.py
+++ b/openpathsampling/tests/test_shared.py
@@ -1,0 +1,23 @@
+from numpy import testing as npt
+import openpathsampling as paths
+import os
+
+import openmmtools
+
+
+class TestStaticContainerStore(object):
+    def teardown(self):
+        if os.path.isfile("test.nc"):
+            os.remove("test.nc")
+
+    def test_store_nonperiodic(self):
+        testsystem = openmmtools.testsystems.AlanineDipeptideVacuum()
+        snap = paths.engines.openmm.snapshot_from_testsystem(testsystem,
+                                                             periodic=False)
+        storage = paths.Storage("test.nc", 'w')
+        storage.save(snap)
+        storage.close()
+        load = paths.Storage("test.nc", 'r')
+        reloaded = load.snapshots[0]
+        npt.assert_array_equal(snap.coordinates, reloaded.coordinates)
+        npt.assert_array_equal(snap.box_vectors, reloaded.box_vectors)


### PR DESCRIPTION
Resolves #832. Currently, netcdfplus creates a storage space for box vectors as `n_spatial` x `n_spatial` arrays. If you create a nonperiodic system, the box vectors are `None`. When trying to save the snapshot, it raises an error, since `None` can't be reshaped into the correct size array.

Here, I modify the `StaticContainerStore` such that it will convert box vectors `None` to an array of all zeros for storage, and when loading, will convert a box vector array of all zeros to `None`.
