### PR TITLE
Improve performance on trajectory_from_mdtraj

### DIFF
--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -220,6 +220,11 @@ def trajectory_from_mdtraj(mdtrajectory, simple_topology=False,
         empty_vel = u.Quantity(np.zeros(mdtrajectory.xyz[0].shape),
                                vel_unit)
 
+    if mdtrajectory.unitcell_vectors is not None:
+        box_vects = u.Quantity(mdtrajectory.unitcell_vectors, u.nanometers)
+    else:
+        box_vects = [None] * len(mdtrajectory)
+
 
     engine = TopologyEngine(topology)
 
@@ -231,11 +236,7 @@ def trajectory_from_mdtraj(mdtrajectory, simple_topology=False,
         else:
             vel = empty_vel
 
-        if mdtrajectory.unitcell_vectors is not None:
-            box_v = u.Quantity(mdtrajectory.unitcell_vectors[frame_num],
-                               u.nanometers)
-        else:
-            box_v = None
+        box_v = box_vects[frame_num]
 
         statics = Snapshot.StaticContainer(
             coordinates=coord,


### PR DESCRIPTION
I was working on a system where I read in a really long trajectory (10^5 frames) with MDTraj, and then convert that to an OPS trajectory using `paths.engines.openmm.tools.trajectory_from_mdtraj`. It was agonizingly slow, so I looked into the code.

In our code, we obtained the box vectors from the MDTraj trajectory inside the loop over frames. However, MDTraj's `unitcell_vectors` is a `@property`. This means that, for every frame, we were recalculating *all* the unitcell vectors, and then selecting the one relevant to the frame we wanted, leading to quadratic scaling.

In this PR, I fix that by moving the box vector calculation outside of the loop over frames, so that it is only done once. Still passes all tests, and was *much* faster for my use case!

This should be immediately ready for review.
