### PR TITLE
Dev install: More widely-compatible `cut` call

### DIFF
--- a/devtools/conda_ops_dev_install.sh
+++ b/devtools/conda_ops_dev_install.sh
@@ -30,7 +30,7 @@ if [ -z "$CONDA_PY" ]; then
     CONDA_PY=`python -V 2>&1 |    # redirect stderr to stdout
               head -n 1 |         # ensure we only take first line
               cut -d " " -f2 |    # get the version number
-              cut -d "." -f1 -f2` # only keep major/minor
+              cut -d "." -f1,2`   # only keep major/minor
 fi
 
 if [ -z "$OPS_ENV" ]; then


### PR DESCRIPTION
This is a tiny follow-up to #824. Apparently the way I called `cut` doesn't work with all versions of `cut`.  Old method of `cut -d "." -f1 -f2` doesn't work everywhere, instead use `cut -d "." -f1,2`.

Since this is tiny, I will merge it as soon as tests pass.