### PR TITLE
Update docs; remove need for conda (library) in dev install

### DIFF
--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -2,8 +2,17 @@
 
 DEPLOY_PY="3.7"
 
+echo "Running after success for:"
+echo "* Python version: ${CONDA_PY}\n* Branch: ${TRAVIS_BRANCH}"
+echo "* Pull request: $TRAVIS_PULL_REQUEST"
+
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     echo "This is a pull request. No deployment will be done."; exit 0
+fi
+
+if [[ "$CONDA_PY" != "$DEPLOY_PY" ]]; then
+    echo "Only deploy from Python ${DEPLOY_PY}. This is Python ${CONDA_PY}."
+    exit 0
 fi
 
 #if [[ "$TRAVIS_BRANCH" != "master" ]]; then
@@ -56,8 +65,8 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
 elif [[ "$TRAVIS_BRANCH" == "docs_deploy" ]]; then
     # change the behavior for the docs testing branch (docs_deploy branch in
     # the openpathsampling/openpathsampling GitHub repo) in this block
-    #echo "No docs deploy on branch $TRAVIS_BRANCH"
-    python devtools/ci/push-docs-to-s3.py --clobber
+    echo "No docs deploy on branch $TRAVIS_BRANCH"
+    #python devtools/ci/push-docs-to-s3.py --clobber
 else
     echo "No docs deploy on branch $TRAVIS_BRANCH"
 fi

--- a/devtools/install_recipe_requirements.py
+++ b/devtools/install_recipe_requirements.py
@@ -6,7 +6,7 @@ import tempfile
 import argparse
 
 # This requires that you have already installed conda and pyyaml
-import conda.cli
+# import conda.cli
 import yaml
 
 def parse_arguments():
@@ -45,6 +45,7 @@ if __name__ == "__main__":
     if args.dry:
         print(req_file_str)
     else:
+        raise RuntimeError("Only dry run works")
         for install in required_packages:
             channels = ['conda-forge', 'omnia']
             channel_str = sum([['-c', channel] for channel in channels], [])

--- a/docs/acknowledgments.rst
+++ b/docs/acknowledgments.rst
@@ -16,15 +16,15 @@ those who developed new tools that build on OPS during their participation
 in E-CAM Extended Software Development Workshops (one held in Traunkirchen,
 Austria in 2016, and one in Leiden, Netherlands, in 2017):
 
-* Jony Castagna (STFC, Sci-Tech Daresbury Laboratory)
 * Raffaella Cabriolu (Norwegian University of Science and Technology)
+* Jony Castagna (STFC, Sci-Tech Daresbury Laboratory)
 * Nicole de Groot (University of Amsterdam)
 * Sonya Hanson (Memorial Sloan Kettering Cancer Center)
 * Colm Herbert (University College Dublin)
 * Hendrik Jung (Max Planck Institute for Biophysics)
 * Anders Lervik (Norwegian University of Science and Technology)
-* Anastasiia Maslechko (Norwegian University of Science and Technology)
 * Donal MacKernan (University College Dublin)
+* Anastasiia Maslechko (Norwegian University of Science and Technology)
 * Sarah McCartan (University College Dublin)
 * Clemens Moritz (University of Vienna)
 * Alberto Pérez de Alba Ortíz (University of Amsterdam)

--- a/docs/api_sections.rst
+++ b/docs/api_sections.rst
@@ -1,3 +1,5 @@
+.. _api_main:
+
 OpenPathSampling API
 ====================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ To learn more about what OPS can do, look at our :ref:`examples <examples>`.
 If you want to jump right in, take a look at how easy it is to
 :ref:`install <install>`!
 
-OPS is an open-source project, distributed under the LGPL. Join us in
+OPS is an open-source project, distributed under the MIT license. Join us in
 the development process on GitHub_, and follow `@pathsampling
 <http://twitter.com/pathsampling>`_ on Twitter for updates!
 
@@ -72,9 +72,15 @@ For Developers
     developers/index
     api_sections
 
+.. toctree::
+    :hidden:
+
+    acknowledgments
+
 --------------------------------------------------------------------------------
 
 
 License
 -------
-OpenPathSampling is licensed under the LGPL, v. 2.1 or later.
+OpenPathSampling is licensed under the `MIT license
+<https://github.com/openpathsampling/openpathsampling/blob/master/LICENSE>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,9 +4,9 @@
 Installation
 ************
 
-OpenPathSampling currently only works on Mac and Linux. It should work with
-either Python 2.7 or Python 3.5+, although there may be some corners of the
-code that aren't Python 3-compatible yet.
+OpenPathSampling currently only works on Mac and Linux. It is tested against
+Python 2.7, 3.6, and 3.7, although there may be some corners of the code
+that aren't Python 3-compatible yet.
 
 .. _install-with-conda:
 
@@ -75,9 +75,8 @@ Testing Your Installation
 .. _run-tests:
 
 Running the tests is a great way to verify that everything is working. The
-test suite uses both `pytest <http://pytest.org>`_ and, for the time being,
-`nose <https://nose.readthedocs.org/en/latest/>`_. You can pick these up via
-``conda`` if you don't already have them. ::
+test suite uses `pytest <http://pytest.org>`_ and, for legacy reasons, also
+requires the `nose <https://nose.readthedocs.org/en/latest/>`_ package. You can pick these up via ``conda`` if you don't already have them. ::
 
   $ conda install pytest nose
 


### PR DESCRIPTION
Fixes #846, plus a few other issues (in particular, I noticed that our docs were building on all Python versions, not only the deploy version — not a problem,  but a waste of time on Travis.)

- [x] Fix docs license info
- [x] Fix mention of Python 3.5+
- [x] Fix discussion of Pytest/Nose
- [x] Fix install script to not require conda
- [x] Fix issue with docs building for all versions
- [x] Add acknowledgments to TOC so the link is in the sidebar