### PR TITLE
Flaky test_pyemma.ipynb tests

### DIFF
--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -67,7 +67,7 @@ ipynbtest.py --strict "test_netcdfplus.ipynb" || testfail=1
 date
 ipynbtest.py --strict "test_cv.ipynb" || testfail=1
 date
-ipynbtest.py --strict --verbose "test_pyemma.ipynb" || testfail=1
+ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
 date
 cd ../misc/
 cp ../toy_model_mstis/mstis.nc ./

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -67,7 +67,7 @@ ipynbtest.py --strict "test_netcdfplus.ipynb" || testfail=1
 date
 ipynbtest.py --strict "test_cv.ipynb" || testfail=1
 date
-ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
+ipynbtest.py --strict --verbose "test_pyemma.ipynb" || testfail=1
 date
 cd ../misc/
 cp ../toy_model_mstis/mstis.nc ./

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -307,7 +307,7 @@
    ],
    "source": [
     "#! ignore\n",
-    "print(storage.variables['cvs_json'][:])"
+    "print(storage.variables['attributes_json'][:])"
    ]
   },
   {
@@ -326,9 +326,9 @@
    "outputs": [],
    "source": [
     "#! lazy\n",
-    "print(len(storage.cvs))\n",
-    "print([cv.name for cv in storage.cvs])\n",
-    "storage.idx(py_cv)"
+    "#print(len(storage.cvs))\n",
+    "#print([cv.name for cv in storage.cvs])\n",
+    "#storage.idx(py_cv)"
    ]
   },
   {
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "#! lazy\n",
-    "py_cv in storage.cvs"
+    "#py_cv in storage.cvs"
    ]
   },
   {
@@ -348,7 +348,7 @@
    "outputs": [],
    "source": [
     "#! lazy\n",
-    "print(py_cv.__uuid__, storage.cvs[0].__uuid__)"
+    "#print(py_cv.__uuid__, storage.cvs[0].__uuid__)"
    ]
   },
   {

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -312,6 +312,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#! lazy\n",
+    "print([cv.name for cv in storage.collectivevariables])\n",
+    "storage.idx(py_cv)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
    "outputs": [
@@ -468,7 +479,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -312,56 +312,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "### DEBUG"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#! lazy\n",
-    "#print(len(storage.cvs))\n",
-    "#print([cv.name for cv in storage.cvs])\n",
-    "#storage.idx(py_cv)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#! lazy\n",
-    "#py_cv in storage.cvs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#! lazy\n",
-    "#print(py_cv.__uuid__, storage.cvs[0].__uuid__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "### DEBUG"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
    "outputs": [

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -316,9 +316,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "### DEBUG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#! lazy\n",
-    "print([cv.name for cv in storage.collectivevariables])\n",
+    "print(len(storage.cvs))\n",
+    "print([cv.name for cv in storage.cvs])\n",
     "storage.idx(py_cv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#! lazy\n",
+    "py_cv in storage.cvs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#! lazy\n",
+    "print(py_cv.__uuid__, storage.cvs[0].__uuid__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### DEBUG"
    ]
   },
   {


### PR DESCRIPTION
In #847, I started seeing some flaky test behavior in the `test_pyemma.ipynb` notebook. It would often fail on Py 3.6 and/or 3.7. It looks like it might have something to do with storage (it fails after reloading CVs from storage).

I can't reproduce it locally, so this PR first an attempt to see if I can diagnose the problem. I've turned on verbose output for that notebook.