### PR TITLE
Fix bug with left_bin_edge in histogram

### DIFF
--- a/openpathsampling/numerics/histogram.py
+++ b/openpathsampling/numerics/histogram.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import math
 from .lookup_function import LookupFunction, VoxelLookupFunction
 import collections
-
+import warnings
 from functools import reduce
 
 class SparseHistogram(object):
@@ -373,8 +373,8 @@ class Histogram(SparseHistogram):
 
         cumul_hist = np.array(cumul_hist)
         if total == 0:
-            return 0
-        if maximum is not None:
+            warnings.warn("No non-zero data in the histogram")
+        elif maximum is not None:
             cumul_hist *= maximum / total
 
         xvals = self.xvals(bin_edge)
@@ -394,8 +394,8 @@ class Histogram(SparseHistogram):
 
         cumul_hist = np.array(cumul_hist)
         if total == 0:
-            return 0
-        if maximum is not None:
+            warnings.warn("No non-zero data in the histogram")
+        elif maximum is not None:
             cumul_hist *= maximum / total
 
         xvals = self.xvals(bin_edge)

--- a/openpathsampling/numerics/histogram.py
+++ b/openpathsampling/numerics/histogram.py
@@ -304,7 +304,7 @@ class Histogram(SparseHistogram):
         vals = self.xvals(bin_edge)
         hist = self.histogram()
         bins = sorted(hist.keys())
-        min_bin = min(bins[0][0], self.left_bin_edges[0])
+        min_bin = min(bins[0][0], 0)
         max_bin = bins[-1][0]
         bin_range = range(int(min_bin), int(max_bin)+1)
         hist_list = [hist[(b,)] for b in bin_range]
@@ -691,7 +691,7 @@ class HistogramPlotter2D(object):
         ylim : 2-tuple of (float, float)
             vertical (y-value) range of (minimum, maximum) bounds for
             displaying the plot
-        kwargs : 
+        kwargs :
             additional arguments to pass to plt.pcolormesh
 
         Returns

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -108,7 +108,7 @@ class TestHistogram(object):
         assert_equal(histo.bin_widths, self.bin_widths)
         assert_items_equal(histo.xvals("l"), [1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
         assert_items_equal(histo.xvals("r"), [1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
-        assert_items_equal(histo.xvals("m"), 
+        assert_items_equal(histo.xvals("m"),
                            [1.25, 1.75, 2.25, 2.75, 3.25, 3.75])
 
 
@@ -130,7 +130,7 @@ class TestHistogram(object):
         hist = histo.histogram(self.data)
         cumulative = list(histo.cumulative(None).values())
         assert_items_almost_equal(cumulative, [5.0, 5.0, 7.0, 8.0, 9.0, 10.0])
-        assert_items_almost_equal(histo.cumulative(maximum=1.0), 
+        assert_items_almost_equal(histo.cumulative(maximum=1.0),
                                   [0.5, 0.5, 0.7, 0.8, 0.9, 1.0])
 
     def test_reverse_cumulative(self):
@@ -143,6 +143,10 @@ class TestHistogram(object):
         assert_items_almost_equal(list(rev_cumulative.values()),
                                   [1.0, 0.5, 0.5, 0.3, 0.2, 0.1])
 
+    def test_left_bin_error(self):
+        histo = Histogram(bin_width=0.5, bin_range=(-1.0, 3.5))
+        histo.histogram([3.5])
+        assert histo.reverse_cumulative() != 0
 
 class TestSparseHistogram(object):
     def setup(self):

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -6,7 +6,7 @@ from nose.tools import (assert_equal, assert_not_equal, raises,
                         assert_almost_equal)
 from nose.plugins.skip import SkipTest
 from .test_helpers import assert_items_almost_equal, assert_items_equal
-
+import pytest
 import logging
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
@@ -133,15 +133,27 @@ class TestHistogram(object):
         assert_items_almost_equal(histo.cumulative(maximum=1.0),
                                   [0.5, 0.5, 0.7, 0.8, 0.9, 1.0])
 
+    def test_cumulative_all_zero_warn(self):
+        histo = Histogram(bin_width=0.5, bin_range=(1.0, 3.5))
+        histo._histogram = collections.Counter({(0,): 0, (1,): 0})
+        with pytest.warns(UserWarning, match=r"No non-zero"):
+            histo.cumulative()
+
     def test_reverse_cumulative(self):
         histo = Histogram(n_bins=5)
-        hist = histo.histogram(self.data)
+        histo.histogram(self.data)
         rev_cumulative = histo.reverse_cumulative(maximum=None)
         assert_items_almost_equal(list(rev_cumulative.values()),
                                   [10, 5, 5, 3, 2, 1])
         rev_cumulative = histo.reverse_cumulative(maximum=1.0)
         assert_items_almost_equal(list(rev_cumulative.values()),
                                   [1.0, 0.5, 0.5, 0.3, 0.2, 0.1])
+
+    def test_reverse_cumulative_all_zero_warn(self):
+        histo = Histogram(bin_width=0.5, bin_range=(1.0, 3.5))
+        histo._histogram = collections.Counter({(0,): 0, (1,): 0})
+        with pytest.warns(UserWarning, match=r"No non-zero"):
+            histo.reverse_cumulative()
 
     def test_left_bin_error(self):
         histo = Histogram(bin_width=0.5, bin_range=(-1.0, 3.5))

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -137,7 +137,11 @@ class TestHistogram(object):
         histo = Histogram(bin_width=0.5, bin_range=(1.0, 3.5))
         histo._histogram = collections.Counter({(0,): 0, (1,): 0})
         with pytest.warns(UserWarning, match=r"No non-zero"):
-            histo.cumulative()
+            cumul = histo.cumulative()
+
+        assert cumul(2.13) == 0
+        for val in cumul.values():
+            assert val == 0
 
     def test_reverse_cumulative(self):
         histo = Histogram(n_bins=5)
@@ -153,7 +157,10 @@ class TestHistogram(object):
         histo = Histogram(bin_width=0.5, bin_range=(1.0, 3.5))
         histo._histogram = collections.Counter({(0,): 0, (1,): 0})
         with pytest.warns(UserWarning, match=r"No non-zero"):
-            histo.reverse_cumulative()
+            rcumul = histo.reverse_cumulative()
+        assert rcumul(3.12) == 0
+        for val in rcumul.values():
+            assert val == 0
 
     def test_left_bin_error(self):
         histo = Histogram(bin_width=0.5, bin_range=(-1.0, 3.5))


### PR DESCRIPTION
When trying to do TIS analysis I ran into a bug where the `min_bin` location was either in `bin_space` or in `cv_space` which led to a mismatch between bins and counters.

This became apparent by `reverse_cumulative` returning `0` instead of a `LookUpFunction`. 

The mismatch has been fixed and `(reverse_)cumulative` now gives a `UserWarning` if the total sum is `0` and now returns a LookUpFunction with only zeros.