### PR TITLE
Deprecate MSMBuilder

### DIFF
--- a/devtools/optional_packages.txt
+++ b/devtools/optional_packages.txt
@@ -1,1 +1,0 @@
-msmbuilder

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -4,7 +4,8 @@ from openpathsampling.engines.openmm.tools import trajectory_to_mdtraj
 from openpathsampling.netcdfplus import WeakKeyCache, \
     ObjectJSON, create_to_dict, ObjectStore, PseudoAttribute
 
-from deprecations import has_deprecations, deprecate, MSMBUILDER
+from openpathsampling.deprecations import (has_deprecations, deprecate,
+                                           MSMBUILDER)
 
 import sys
 if sys.version_info > (3, ):

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -4,6 +4,8 @@ from openpathsampling.engines.openmm.tools import trajectory_to_mdtraj
 from openpathsampling.netcdfplus import WeakKeyCache, \
     ObjectJSON, create_to_dict, ObjectStore, PseudoAttribute
 
+from deprecations import has_deprecations, deprecate, MSMBUILDER
+
 import sys
 if sys.version_info > (3, ):
     get_code = lambda func: func.__code__
@@ -579,6 +581,8 @@ class MDTrajFunctionCV(CoordinateFunctionCV):
         }
 
 
+@has_deprecations
+@deprecate(MSMBUILDER)
 class MSMBFeaturizerCV(CoordinateGeneratorCV):
     """
     A CollectiveVariable that uses an MSMBuilder3 featurizer

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -151,7 +151,7 @@ MSMBUILDER = Deprecation(
              + "MSMBFeaturizer is no longer officially supported."),
     remedy="Create a CoordinateFunctionCV based on MSMBuilderFeaturizers.",
     remove_version=(2, 0),
-    deprecated_in(1, 1, 0)
+    deprecated_in=(1, 1, 0)
 )
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -146,7 +146,15 @@ SAVE_RELOAD_OLD_TPS_NETWORK = Deprecation(
     deprecated_in=(0, 9 ,3)
 )
 
-# has_deprecation and deprecate hacks to change docstrings inspired by:
+MSMBUILDER = Deprecation(
+    problem=("MSMBuilder is no longer maintained. ",
+             + "MSMBFeaturizer is no longer officially supported."),
+    remedy="Create a CoordinateFunctionCV based on MSMBuilderFeaturizers.",
+    remove_version=(2, 0),
+    deprecated_in(1, 1, 0)
+)
+
+# has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735
 def has_deprecations(cls):
     """Decorator to ensure that docstrings get updated for wrapped class"""

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -147,7 +147,7 @@ SAVE_RELOAD_OLD_TPS_NETWORK = Deprecation(
 )
 
 MSMBUILDER = Deprecation(
-    problem=("MSMBuilder is no longer maintained. ",
+    problem=("MSMBuilder is no longer maintained. "
              + "MSMBFeaturizer is no longer officially supported."),
     remedy="Create a CoordinateFunctionCV based on MSMBuilderFeaturizers.",
     remove_version=(2, 0),


### PR DESCRIPTION
MSMBuilder is not being maintained. Its `conda-forge` build pins numpy to 1.12. OpenMM 7.4 requires numpy>=1.14, (although this requirement is implicit, not explicit, so we end up with test failures when we try to run OpenMM with an old version of numpy, see https://github.com/openmm/openmm/issues/2385).

I think the solution on our end is to deprecate the integration with MSMBuilder (`MSMBFeaturizerCV`). In principle, we can keep it around, but we can't test it in the same environment as the newest OpenMM.

I'm marking it as deprecated and to be removed in 2.0, with the thoughts that:

1. I don't think anyone was using this functionality in OPS.
2. It's more important to keep up to date with OpenMM.
3. If someone picks up MSMBuilder maintenance, we can always "undeprecate."