### PR TITLE
fix DeprecationWarning about invalid escape characters

### DIFF
--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -164,7 +164,7 @@ class CallableCV(CollectiveVariable):
         This function is abstract and need _eval to be implemented to work.
         Problem is that there are two types of callable functions:
         1. direct functions: these can be called and give the wanted value
-           `c(snapshot, \**kwargs)` would be the typical call
+           `c(snapshot, **kwargs)` would be the typical call
         2. a generating function: a function the creates the callable object
            `c(**kwargs)(snapshot)` is the typical call. This is usually used
            for classes. Create the instance and then use it.
@@ -392,7 +392,7 @@ class GeneratorCV(CallableCV):
     """Turn a callable class or function generating a callable object into a CV
 
     The class instance will be called with snapshots. The instance itself
-    will be created using the given \**kwargs.
+    will be created using the given **kwargs.
     """
 
     def __init__(
@@ -418,7 +418,7 @@ class GeneratorCV(CallableCV):
         kwargs
             additional arguments which should be given to `c` (for example, the
             atoms which define a specific distance/angle). Finally an instance
-            `instance = cls(\**kwargs)` is create when the CV is created and
+            `instance = cls(**kwargs)` is create when the CV is created and
             using the CV will call `instance(snapshots)`
 
         Notes
@@ -457,7 +457,7 @@ class CoordinateGeneratorCV(GeneratorCV):
     """Turn a callable class or function generating a callable object into a CV
 
     The class instance will be called with snapshots. The instance itself
-    will be created using the given \**kwargs.
+    will be created using the given **kwargs.
     """
 
     def __init__(
@@ -544,8 +544,8 @@ class MDTrajFunctionCV(CoordinateFunctionCV):
         scalarize_numpy_singletons : bool, default: True
             If `True` then arrays of length 1 will be treated as array with one
             dimension less. e.g. `[[1], [2], [3]]` will be turned into
-            `[1, 2, 3]`. This is often useful, when you use en external function
-            from mdtraj to get only a single value.
+            `[1, 2, 3]`. This is often useful, when you use en external
+            function from mdtraj to get only a single value.
 
         """
 
@@ -615,7 +615,7 @@ class MSMBFeaturizerCV(CoordinateGeneratorCV):
         kwargs
             a dictionary of named arguments which should be given to `c`
             (for example, the atoms which define a specific distance/angle).
-            Finally an instance `instance = cls(\**kwargs)` is create when the
+            Finally an instance `instance = cls(**kwargs)` is create when the
             CV is created and using the CV will call `instance(snapshots)`
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
@@ -700,7 +700,7 @@ class PyEMMAFeaturizerCV(MSMBFeaturizerCV):
         topology : :obj:`openpathsampling.engines.openmm.MDTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
             the featurizer in `pyemma.coordinates.featurizer(topology)`
-        \*\*kwargs : dict
+        **kwargs : dict
             a dictionary of named arguments which should be given to the
             `featurizer` (for example, the atoms which define a specific
             distance/angle).

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -28,10 +28,10 @@ class CollectiveVariable(PseudoAttribute):
         A descriptive name of the collectivevariable. It is used in the string
         representation.
     cv_time_reversible : bool
-        If `True` (default) the CV assumes that reversed snapshots have the
+        If ``True`` (default) the CV assumes that reversed snapshots have the
         same value. This is the default case when CVs do not depend on momenta
         reversal. This will speed up computation of CVs by about a factor of
-        two. In rare cases you might want to set this to `False`
+        two. In rare cases you might want to set this to ``False``
 
     Attributes
     ----------
@@ -75,7 +75,8 @@ class CollectiveVariable(PseudoAttribute):
 
 
 class InVolumeCV(CollectiveVariable):
-    """ Turn a `Volume` into a collective variable
+    """Turn a :class:`openpathsampling.volume.Volume` into a collective
+    variable
 
     Attributes
     ----------
@@ -114,7 +115,7 @@ class InVolumeCV(CollectiveVariable):
 
 
 class CallableCV(CollectiveVariable):
-    """Turn any callable object into a storable `CollectiveVariable`.
+    """Turn any callable object into a storable :class:`CollectiveVariable`.
 
     Attributes
     ----------
@@ -140,33 +141,33 @@ class CallableCV(CollectiveVariable):
         cv_callable : callable (function or class with __call__)
             The callable to be used
         cv_time_reversible
-        cv_requires_lists : If `True` the internal function  always a list of
+        cv_requires_lists : If ``True`` the internal function  always a list of
             elements instead of single values. It also means that if you call
             the CV with a list of snapshots a list of snapshot objects will be
-            passed. If `False` a list of Snapshots like a trajectory will
+            passed. If ``False`` a list of Snapshots like a trajectory will
             be passed snapshot by snapshot.
         cv_wrap_numpy_array : bool, default: False
-            if `True` the returned array will be wrapped with a
-            `numpy.array()` which will convert a list of numpy arrays into a
+            if ``True`` the returned array will be wrapped with a
+            ``numpy.array()`` which will convert a list of numpy arrays into a
             single large numpy.array. This is useful for post-processing of
             larger data since numpy arrays are easier to manipulate.
         cv_scalarize_numpy_singletons : bool, default: True
-            If `True` then arrays of length 1 will be treated as array with one
-            dimension less. e.g. [[1], [2], [3]] will be turned into [1, 2, 3].
-            This is often useful, when you use en external function to get only
-            a single value.
-        kwargs : **kwargs
+            If ``True`` then arrays of length 1 will be treated as array with
+            one dimension less. e.g. [[1], [2], [3]] will be turned into
+            [1, 2, 3]. This is often useful, when you use en external function
+            to get only a single value.
+        **kwargs : kwargs
             a dictionary with named arguments which should be used
-            with `c`. Either for class creation or for calling the function
+            with ``c``. Either for class creation or for calling the function
 
         Notes
         -----
         This function is abstract and need _eval to be implemented to work.
         Problem is that there are two types of callable functions:
         1. direct functions: these can be called and give the wanted value
-           `c(snapshot, **kwargs)` would be the typical call
+           ``c(snapshot, **kwargs)`` would be the typical call
         2. a generating function: a function the creates the callable object
-           `c(**kwargs)(snapshot)` is the typical call. This is usually used
+           ``c(**kwargs)(snapshot)`` is the typical call. This is usually used
            for classes. Create the instance and then use it.
 
         This function is very powerful, but need some explanation if you want
@@ -201,7 +202,8 @@ class CallableCV(CollectiveVariable):
         >>> cv = FunctionCV('my_cv', func, indices=[[4, 6, 8, 10]])
 
         The function will also check if non-standard modules are imported,
-        which are now `numpy`, `math`, `msmbuilder`, `pandas` and `mdtraj`
+        which are now ``numpy``, ``math``, ``msmbuilder``, ``pandas`` and
+        ``mdtraj``
         """
 
         super(CallableCV, self).__init__(
@@ -281,7 +283,7 @@ class CallableCV(CollectiveVariable):
 
 
 class FunctionCV(CallableCV):
-    """Turn any function into a `CollectiveVariable`.
+    """Turn any function into a :class:`CollectiveVariable`.
 
     Attributes
     ----------
@@ -308,15 +310,15 @@ class FunctionCV(CallableCV):
         cv_requires_lists
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
-        kwargs
+        **kwargs:
             a dictionary of named arguments which should be given to
-            `cv_callable` (for example, the atoms which define a specific
-            distance/angle). Finally `cv_callable(snapshots, **kwargs)` is
+            ``cv_callable`` (for example, the atoms which define a specific
+            distance/angle). Finally ``cv_callable(snapshots, **kwargs)`` is
             called
 
         See also
         --------
-        `openpathsampling.CallableCV`
+        :class:`openpathsampling.collectivevariable.CallableCV`
 
         """
 
@@ -340,7 +342,7 @@ class FunctionCV(CallableCV):
 
 
 class CoordinateFunctionCV(FunctionCV):
-    """Turn any function into a `CollectiveVariable`.
+    """Turn any function into a :class:`CollectiveVariable`.
 
     Attributes
     ----------
@@ -364,11 +366,11 @@ class CoordinateFunctionCV(FunctionCV):
         cv_requires_lists
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
-        kwargs
+        **kwargs
 
         See also
         --------
-        `openpathsampling.CallableCV`
+        :class:`openpathsampling.collectivevariable.CallableCV`
 
         """
 
@@ -392,7 +394,7 @@ class GeneratorCV(CallableCV):
     """Turn a callable class or function generating a callable object into a CV
 
     The class instance will be called with snapshots. The instance itself
-    will be created using the given `**kwargs`.
+    will be created using the given ``**kwargs``.
     """
 
     def __init__(
@@ -410,16 +412,16 @@ class GeneratorCV(CallableCV):
         ----------
         name
         generator : callable class
-            a class where instances have a `__call__` attribute
+            a class where instances have a ``__call__`` attribute
         cv_time_reversible
         cv_requires_lists
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
-        kwargs
-            additional arguments which should be given to `c` (for example, the
-            atoms which define a specific distance/angle). Finally an instance
-            `instance = cls(**kwargs)` is created when the CV is created and
-            using the CV will call `instance(snapshots)`
+        **kwargs
+            additional arguments which should be given to ``c`` (for example,
+            the atoms which define a specific distance/angle). Finally an
+            instance ``instance = cls(**kwargs)`` is created when the CV is
+            created and using the CV will call ``instance(snapshots)``
 
         Notes
         -----
@@ -457,7 +459,7 @@ class CoordinateGeneratorCV(GeneratorCV):
     """Turn a callable class or function generating a callable object into a CV
 
     The class instance will be called with snapshots. The instance itself
-    will be created using the given `**kwargs`.
+    will be created using the given ``**kwargs``.
     """
 
     def __init__(
@@ -477,7 +479,7 @@ class CoordinateGeneratorCV(GeneratorCV):
         cv_requires_lists
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
-        kwargs
+        **kwargs
 
         Notes
         -----
@@ -502,12 +504,13 @@ class CoordinateGeneratorCV(GeneratorCV):
 
 
 class MDTrajFunctionCV(CoordinateFunctionCV):
-    """Make `CollectiveVariable` from `f` that takes mdtraj.trajectory as input.
+    """Make ``CollectiveVariable`` from ``f`` that takes
+    :class:`mdtraj.Trajectory` as input.
 
     This is identical to FunctionCV except that the function is called with
     an :class:`mdtraj.Trajectory` object instead of the
     :class:`openpathsampling.Trajectory` one using
-    `f(traj.to_mdtraj(), **kwargs)`
+    ``f(traj.to_mdtraj(), **kwargs)``
 
     Examples
     --------
@@ -537,14 +540,14 @@ class MDTrajFunctionCV(CoordinateFunctionCV):
         f
         topology : :obj:`openpathsampling.engines.openmm.MDTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
-            the featurizer in `pyemma.coordinates.featurizer(topology)`
+            the featurizer in ``pyemma.coordinates.featurizer(topology)``
         cv_requires_lists
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
         scalarize_numpy_singletons : bool, default: True
-            If `True` then arrays of length 1 will be treated as array with one
-            dimension less. e.g. `[[1], [2], [3]]` will be turned into
-            `[1, 2, 3]`. This is often useful, when you use en external
+            If ``True`` then arrays of length 1 will be treated as array with
+            one dimension less. e.g. ``[[1], [2], [3]]`` will be turned into
+            ``[1, 2, 3]``. This is often useful, when you use en external
             function from mdtraj to get only a single value.
 
         """
@@ -585,13 +588,7 @@ class MDTrajFunctionCV(CoordinateFunctionCV):
 @has_deprecations
 @deprecate(MSMBUILDER)
 class MSMBFeaturizerCV(CoordinateGeneratorCV):
-    """
-    A CollectiveVariable that uses an MSMBuilder3 featurizer
-
-    Attributes
-    ----------
-    scalarize_numpy_singletons
-    """
+    """A CollectiveVariable that uses an MSMBuilder3 featurizer"""
 
     def __init__(
             self,
@@ -611,12 +608,13 @@ class MSMBFeaturizerCV(CoordinateGeneratorCV):
             the featurizer used as a callable class
         topology : :obj:`openpathsampling.engines.openmm.MDTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
-            the featurizer in `pyemma.coordinates.featurizer(topology)`
-        kwargs
-            a dictionary of named arguments which should be given to `c`
+            the featurizer in ``pyemma.coordinates.featurizer(topology)``
+        **kwargs :
+            a dictionary of named arguments which should be given to ``c``
             (for example, the atoms which define a specific distance/angle).
-            Finally an instance `instance = cls(**kwargs)` is created when the
-            CV is created and using the CV will call `instance(snapshots)`
+            Finally an instance ``instance = cls(**kwargs)`` is created when
+            the CV is created and using the CV will call
+            ``instance(snapshots)``
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
 
@@ -676,9 +674,9 @@ class MSMBFeaturizerCV(CoordinateGeneratorCV):
 class PyEMMAFeaturizerCV(MSMBFeaturizerCV):
     """Make a CV from a function that takes mdtraj.trajectory as input.
 
-    This is identical to `CoordinateGeneratorCV` except that the function is
-    called with an mdraj.Trajetory object instead of the
-    openpathsampling.Trajectory one using ``fnc(traj.to_mdtraj(),
+    This is identical to :class:`CoordinateGeneratorCV` except that the
+    function is called with an :class:`mdraj.Trajetory` object instead of the
+    :class:`openpathsampling.Trajectory` one using ``fnc(traj.to_mdtraj(),
     **kwargs)``
 
     """
@@ -695,14 +693,14 @@ class PyEMMAFeaturizerCV(MSMBFeaturizerCV):
         Parameters
         ----------
         name
-        featurizer : `pyemma.coordinates.featurizer`
+        featurizer : :class:`pyemma.coordinates.featurizer`
             the pyemma featurizer used as a callable class
         topology : :obj:`openpathsampling.engines.openmm.MDTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
-            the featurizer in `pyemma.coordinates.featurizer(topology)`
+            the featurizer in ``pyemma.coordinates.featurizer(topology)``
         **kwargs : dict
             a dictionary of named arguments which should be given to the
-            `featurizer` (for example, the atoms which define a specific
+            ``featurizer`` (for example, the atoms which define a specific
             distance/angle).
             Finally an instance ``instance = cls(**kwargs)`` is created when
             the CV is created and using the CV will call

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -392,7 +392,7 @@ class GeneratorCV(CallableCV):
     """Turn a callable class or function generating a callable object into a CV
 
     The class instance will be called with snapshots. The instance itself
-    will be created using the given **kwargs.
+    will be created using the given `**kwargs`.
     """
 
     def __init__(
@@ -418,7 +418,7 @@ class GeneratorCV(CallableCV):
         kwargs
             additional arguments which should be given to `c` (for example, the
             atoms which define a specific distance/angle). Finally an instance
-            `instance = cls(**kwargs)` is create when the CV is created and
+            `instance = cls(**kwargs)` is created when the CV is created and
             using the CV will call `instance(snapshots)`
 
         Notes
@@ -457,7 +457,7 @@ class CoordinateGeneratorCV(GeneratorCV):
     """Turn a callable class or function generating a callable object into a CV
 
     The class instance will be called with snapshots. The instance itself
-    will be created using the given **kwargs.
+    will be created using the given `**kwargs`.
     """
 
     def __init__(
@@ -615,7 +615,7 @@ class MSMBFeaturizerCV(CoordinateGeneratorCV):
         kwargs
             a dictionary of named arguments which should be given to `c`
             (for example, the atoms which define a specific distance/angle).
-            Finally an instance `instance = cls(**kwargs)` is create when the
+            Finally an instance `instance = cls(**kwargs)` is created when the
             CV is created and using the CV will call `instance(snapshots)`
         cv_wrap_numpy_array
         cv_scalarize_numpy_singletons
@@ -704,7 +704,7 @@ class PyEMMAFeaturizerCV(MSMBFeaturizerCV):
             a dictionary of named arguments which should be given to the
             `featurizer` (for example, the atoms which define a specific
             distance/angle).
-            Finally an instance ``instance = cls(**kwargs)`` is create when
+            Finally an instance ``instance = cls(**kwargs)`` is created when
             the CV is created and using the CV will call
             ``instance(snapshots)``
 


### PR DESCRIPTION
This morning, running `py.test` with python `3.7`. Spat out these `DeprecationWarning`s:
```
openpathsampling/collectivevariable.py:205
  /home/sander/github_files/openpathsampling/openpathsampling/collectivevariable.py:205: DeprecationWarning: invalid escape sequence \*
    """

openpathsampling/collectivevariable.py:396
  /home/sander/github_files/openpathsampling/openpathsampling/collectivevariable.py:396: DeprecationWarning: invalid escape sequence \*
    """

openpathsampling/collectivevariable.py:461
  /home/sander/github_files/openpathsampling/openpathsampling/collectivevariable.py:461: DeprecationWarning: invalid escape sequence \*
    """

openpathsampling/collectivevariable.py:627
  /home/sander/github_files/openpathsampling/openpathsampling/collectivevariable.py:627: DeprecationWarning: invalid escape sequence \*
    """

openpathsampling/collectivevariable.py:715
  /home/sander/github_files/openpathsampling/openpathsampling/collectivevariable.py:715: DeprecationWarning: invalid escape sequence \*
    """
```

Looking at [SO](https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d) it seems due to python `3` reading it as Unicode characters instead of  a raw string.

This might break doc building, but did not have thad time yet to look at that