### PR TITLE
[docs] Protect caps in openpathsampling.bib

### DIFF
--- a/docs/openpathsampling.bib
+++ b/docs/openpathsampling.bib
@@ -1,6 +1,7 @@
 @article{ops1,
 author = {Swenson, David W. H. and Prinz, Jan-Hendrik and Noe, Frank and Chodera, John D. and Bolhuis, Peter G.},
-title = {OpenPathSampling: A Python Framework for Path Sampling Simulations. 1. Basics},
+title = {{OpenPathSampling}: {A} {Python} Framework for Path Sampling
+    Simulations. 1. {Basics}},
 journal = {Journal of Chemical Theory and Computation},
 volume = {15},
 number = {2},
@@ -23,7 +24,8 @@ eprint = {
 
 @article{ops2,
     author = {Swenson, David W. H. and Prinz, Jan-Hendrik and Noe, Frank and Chodera, John D. and Bolhuis, Peter G.},
-title = {OpenPathSampling: A Python Framework for Path Sampling Simulations. 2. Building and Customizing Path Ensembles and Sample Schemes},
+title = {{OpenPathSampling}: {A} {P}ython Framework for Path Sampling
+    Simulations. 2. {B}uilding and Customizing Path Ensembles and Sample Schemes},
 journal = {Journal of Chemical Theory and Computation},
 volume = {15},
 number = {2},


### PR DESCRIPTION
This just makes it so that the OPS bibtex files give correct capitalization for titles. Will leave it up for 24 hours in case someone has comments, but there's really nothing controversial in here.