### PR TITLE
Workaround for conda trying to remove setuptools on update

### DIFF
--- a/devtools/ci/miniconda_install.sh
+++ b/devtools/ci/miniconda_install.sh
@@ -29,4 +29,8 @@ export PATH=$HOME/miniconda${pyV}/bin:$PATH
 conda config --add channels http://conda.anaconda.org/omnia
 conda config --add channels http://conda.anaconda.org/conda-forge
 
+# next two lines are workaround for conda/conda#9337
+pip uninstall -y setuptools
+conda install --yes setuptools
+
 conda update --yes conda


### PR DESCRIPTION
Tests are failing because of https://github.com/conda/conda/issues/9337. Will merge this immediately once I get tests passing. Only affects CI.