### PR TITLE
Python 3.8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,4 @@ env:
     - CONDA_PY=2.7
     - CONDA_PY=3.6
     - CONDA_PY=3.7
+    - CONDA_PY=3.8


### PR DESCRIPTION
This adds Python 3.8 to our testing matrix. I'm not sure how long it will take conda-forge to make it available, since I'm making this PR literally minutes after conda-forge/python merged the new version.

Resolves #864.