### PR TITLE
Add information to MinusMove change.details

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -2474,6 +2474,23 @@ class MinusMover(SubPathMover):
 
         super(MinusMover, self).__init__(mover)
 
+    def move(self, sample_set):
+        change = super(MinusMover, self).move(sample_set)
+        cond_seq_changes = change.subchanges[0].subchanges[0].subchanges
+        seg_swap = None
+        if len(cond_seq_changes) >= 2:
+            seg_swap = cond_seq_changes[1].subchanges[0].trials
+
+        ext_traj = None
+        if len(cond_seq_changes) >= 3:
+            ext_traj = cond_seq_changes[2].subchanges[0].trials[0].trajectory
+
+        details = Details(segment_swap_samples=seg_swap,
+                          extension_trajectory=ext_traj)
+        if change.details is None:
+            change.details = details
+
+        return change
 
 class SingleReplicaMinusMover(MinusMover):
     """
@@ -2539,6 +2556,10 @@ class SingleReplicaMinusMover(MinusMover):
 
         # we skip MinusMover's init and go to the grandparent
         super(MinusMover, self).__init__(mover)
+
+    def move(self, sample_set):
+        # skip the MinusMover's implementation
+        return super(MinusMover, self).move(sample_set)
 
 
 class PathSimulatorMover(SubPathMover):

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -1211,6 +1211,8 @@ class TestMinusMover(object):
         seg_dir = {}
         for i in range(100):
             change = self.mover.move(gs)
+            assert change.details.segment_swap_samples is not None
+            assert change.details.extension_trajectory is not None
             samples = change.results
             sub_samples = change.subchange.subchange.results
             assert_equal(len(samples), 2)
@@ -1261,9 +1263,11 @@ class TestMinusMover(object):
             ensemble=self.innermost
         )
         gs = SampleSet([samp_other_ensemble, self.minus_sample])
-        
+
         change = self.mover.move(gs)
         assert_equal(len(change.trials), 1)
+        assert change.details.segment_swap_samples is not None
+        assert change.details.extension_trajectory is None
 
         sub = change.subchange.subchange
         assert_equal(self.innermost(innermost_other_ensemble), False)
@@ -1280,9 +1284,11 @@ class TestMinusMover(object):
             ensemble=self.innermost
         )
         gs = SampleSet([samp_crosses_to_state, self.minus_sample])
-        
+
         change = self.mover.move(gs)
         assert_equal(len(change.trials), 1) # stop after failed repex
+        assert change.details.segment_swap_samples is not None
+        assert change.details.extension_trajectory is None
 
         sub = change.subchange.subchange
         assert_equal(self.innermost(innermost_crosses_to_state), True)
@@ -1308,6 +1314,8 @@ class TestMinusMover(object):
         assert_equal(self.minus(minus_crosses_to_state), True)
 
         change = self.mover.move(gs)
+        assert change.details.segment_swap_samples is not None
+        assert change.details.extension_trajectory is None
         sub = change.subchange.subchange
         assert_equal(len(sub.trials), 3)  # stop after failed repex
         assert_equal(len(change.trials), 1)
@@ -1325,7 +1333,7 @@ class TestMinusMover(object):
             trajectory=traj_bad_extension,
             ensemble=self.innermost
         )
-        
+
         assert_equal(self.innermost(traj_bad_extension), True)
 
         gs = SampleSet([self.minus_sample, samp_bad_extension])
@@ -1334,6 +1342,8 @@ class TestMinusMover(object):
 
         sub = change.subchange.subchange
         assert_equal(len(sub.trials), 4)
+        assert change.details.segment_swap_samples is not None
+        assert change.details.extension_trajectory is not None
 
         # after filtering there are only 2 trials
         assert_equal(len(change.trials), 2)


### PR DESCRIPTION
Currently, the `MinusMove` saves no details. Theoretically, that's fine, because everything is accessible in its subchanges. But practically speaking, asking users to spelunk through the subchanges is a terrible user experience. This brings a couple of things into a `Details` object saved by the `MinusMove` in its `change`:

* `segment_swap_samples` : The samples used in the initial replica exchange between the innermost ensemble and the "segment" of the minus ensemble.
* `extension_trajectory`: The trial trajectory made by the extension phase of the minus move.

Idea comes from #873.