### PR TITLE
Fix minimal install

### DIFF
--- a/openpathsampling/engines/openmm/features/__init__.py
+++ b/openpathsampling/engines/openmm/features/__init__.py
@@ -1,4 +1,10 @@
-from openpathsampling.engines.features import *
-from openpathsampling.engines.features.shared import StaticContainer, KineticContainer
-from . import masses
-from . import instantaneous_temperature
+try:
+    import simtk.openmm
+    import simtk.openmm.app
+except ImportError:
+    pass
+else:
+    from openpathsampling.engines.features import *
+    from openpathsampling.engines.features.shared import StaticContainer, KineticContainer
+    from . import masses
+    from . import instantaneous_temperature


### PR DESCRIPTION
Something seems to have changed between the last test run of #867 and when I merged it, and the minimal install is now giving an error. Fixing that here.