### PR TITLE
Simplify Trajectory.__getattr__

### DIFF
--- a/openpathsampling/engines/features/base.py
+++ b/openpathsampling/engines/features/base.py
@@ -284,11 +284,14 @@ def attach_features(features, use_lazy_reversed=False):
                     if type(content) is str:
                         content = [content]
 
+                    def func_or_static(fnc):
+                        return callable(fnc) or (hasattr(fnc, "__func__")
+                                                 and callable(fnc.__func__))
                     if name == 'functions':
                         for c in content:
                             if hasattr(feature, c):
                                 fnc = getattr(feature, c)
-                                if callable(fnc):
+                                if func_or_static(fnc):
                                     if hasattr(cls, c):
                                         raise RuntimeWarning(
                                             'Collision: Function "%s" from feature %s already exists.' % (c, feature))

--- a/openpathsampling/engines/openmm/features/__init__.py
+++ b/openpathsampling/engines/openmm/features/__init__.py
@@ -8,3 +8,4 @@ else:
     from openpathsampling.engines.features.shared import StaticContainer, KineticContainer
     from . import masses
     from . import instantaneous_temperature
+    from . import traj_quantities

--- a/openpathsampling/engines/openmm/features/traj_quantities.py
+++ b/openpathsampling/engines/openmm/features/traj_quantities.py
@@ -13,20 +13,19 @@ def _trajectory_units(traj, feature, unit_):
         return obj
 
     vals = [getattr(snap, feature) for snap in traj]
-    print(feature, vals)
-    result = [strip_unit(val) for val in vals]
+    result = np.asarray([strip_unit(val) for val in vals])
     non_none = any([x is not None for x in result])
     if non_none:
         result = result * unit_
-    print(result)
     return result
 
 def trajectory_coordinates(traj):
-    _trajectory_units(traj, 'coordinates', unit.nanometer)
+    return _trajectory_units(traj, 'coordinates', unit.nanometer)
 
 def trajectory_box_vectors(traj):
-    _trajectory_units(traj, 'box_vectors', unit.nanometer)
+    return _trajectory_units(traj, 'box_vectors', unit.nanometer)
 
 def trajectory_velocities(traj):
-    _trajectory_units(traj, 'velocities', unit.nanometer / unit.picosecond)
+    return _trajectory_units(traj, 'velocities',
+                             unit.nanometer / unit.picosecond)
 

--- a/openpathsampling/engines/openmm/features/traj_quantities.py
+++ b/openpathsampling/engines/openmm/features/traj_quantities.py
@@ -1,0 +1,32 @@
+import numpy as np
+from simtk import unit
+
+functions = ['trajectory_coordinates', 'trajectory_box_vectors',
+             'trajectory_velocities']
+
+def _trajectory_units(traj, feature, unit_):
+    def strip_unit(obj):
+        try:
+            obj = obj.value_in_unit(unit_)
+        except AttributeError:
+            pass  # not a simtk.unit.Quantity
+        return obj
+
+    vals = [getattr(snap, feature) for snap in traj]
+    print(feature, vals)
+    result = [strip_unit(val) for val in vals]
+    non_none = any([x is not None for x in result])
+    if non_none:
+        result = result * unit_
+    print(result)
+    return result
+
+def trajectory_coordinates(traj):
+    _trajectory_units(traj, 'coordinates', unit.nanometer)
+
+def trajectory_box_vectors(traj):
+    _trajectory_units(traj, 'box_vectors', unit.nanometer)
+
+def trajectory_velocities(traj):
+    _trajectory_units(traj, 'velocities', unit.nanometer / unit.picosecond)
+

--- a/openpathsampling/engines/openmm/features/traj_quantities.py
+++ b/openpathsampling/engines/openmm/features/traj_quantities.py
@@ -19,12 +19,15 @@ def _trajectory_units(traj, feature, unit_):
         result = result * unit_
     return result
 
+@staticmethod
 def trajectory_coordinates(traj):
     return _trajectory_units(traj, 'coordinates', unit.nanometer)
 
+@staticmethod
 def trajectory_box_vectors(traj):
     return _trajectory_units(traj, 'box_vectors', unit.nanometer)
 
+@staticmethod
 def trajectory_velocities(traj):
     return _trajectory_units(traj, 'velocities',
                              unit.nanometer / unit.picosecond)

--- a/openpathsampling/engines/openmm/snapshot.py
+++ b/openpathsampling/engines/openmm/snapshot.py
@@ -39,7 +39,8 @@ class MDSnapshot(BaseSnapshot):
     features.kinetics,
     features.masses,
     features.instantaneous_temperature,
-    features.engine
+    features.engine,
+    features.traj_quantities,
 ])
 class Snapshot(BaseSnapshot):
     """

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -545,7 +545,6 @@ class Trajectory(list, StorableObject):
 
         traj = md.Trajectory(output, topology)
         box_vectors = self.box_vectors
-        print(box_vectors)
         # box_vectors is a list with an entry for each frame of the traj
         # if they're all None, we return None, not [None, None, ..., None]
         if not np.any(box_vectors):

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -105,9 +105,9 @@ class Trajectory(list, StorableObject):
     def n_snapshots(self):
         """
         Return the number of frames in the trajectory.
-        
+
         Returns
-        -------        
+        -------
         length (int) - the number of frames in the trajectory
 
         Notes
@@ -127,64 +127,46 @@ class Trajectory(list, StorableObject):
         Fallback to access Snapshot properties
 
         """
-        if len(self) > 0:
-            snapshot_class = self[0].__class__
-            if hasattr(snapshot_class, item) or \
-                    hasattr(snapshot_class, '__features__') \
-                    and item in snapshot_class.__features__.variables:
-                first = getattr(self[0], item)
-                #if type(first) is u.Quantity:
-                if is_simtk_quantity_type(first):
-                    inner = first._value
-                    if type(inner) is np.ndarray:
-                        dtype = inner.dtype
-
-                        out = np.empty(tuple([len(self)] +
-                                             list(inner.shape)), dtype=dtype)
-
-                        for idx, s in enumerate(list.__iter__(self)):
-                            np.copyto(out[idx], getattr(s, item)._value)
-
-                        return out * first.unit
-                    else:
-                        out = [None] * len(self)
-
-                        for idx, s in enumerate(list.__iter__(self)):
-                            out[idx] = getattr(s, item)
-
-                        return out
-                elif type(first) is np.ndarray:
-                    dtype = first.dtype
-
-                    out = np.empty(tuple([len(self)] +
-                                         list(first.shape)), dtype=dtype)
-
-                    for idx, s in enumerate(list.__iter__(self)):
-                        np.copyto(out[idx], getattr(s, item))
-
-                    return out
-                else:
-                    out = [None] * len(self)
-
-                    for idx, s in enumerate(list.__iter__(self)):
-                        out[idx] = getattr(s, item)
-
-                    return out
-
-            else:
-                std_msg = "'{0}' object has no attribute '{1}'"
-                snap_msg = "Cannot delegate to snapshots. "
-                snap_msg += "'{2}' has no attribute '{1}'"
-                spacer = "\n                "
-                msg = (std_msg + spacer + snap_msg).format(
-                    str(self.__class__.__name__), 
-                    item,
-                    snapshot_class.__name__
-                )
-                raise AttributeError(msg)
-
-        else:
+        if len(self) == 0:
             return []
+
+        snapshot_class = self[0].__class__
+        def is_snapshot_attr(cls, item):
+            return hasattr(cls, item) or (hasattr(cls, '__features__') and
+                                         item in cls.__features__.variables)
+
+        if is_snapshot_attr(snapshot_class, item):
+            print("looking for " + item)
+            # if there's a trajectory_item in features, that should be a
+            # function to return a trajectory
+            traj_item = "trajectory_" + item
+            if traj_item in snapshot_class.__features__.functions:
+                print("found " + traj_item)
+                traj_func = getattr(snapshot_class, traj_item)
+                return traj_func(self)
+
+            # get the results
+            out = [getattr(snap, item) for snap in self]
+
+            # if the first result is a numpy object, return the whole as a
+            # numpy array
+            if isinstance(out[0], np.ndarray):
+                out = np.array(out)
+
+            return out
+
+        # behavior when it can't be delegated to snapshot
+        std_msg = "'{0}' object has no attribute '{1}'"
+        snap_msg = "Cannot delegate to snapshots. "
+        snap_msg += "'{2}' has no attribute '{1}'"
+        spacer = "\n                "
+        msg = (std_msg + spacer + snap_msg).format(
+            str(self.__class__.__name__),
+            item,
+            snapshot_class.__name__
+        )
+        raise AttributeError(msg)
+
 
     # ==========================================================================
     # LIST INHERITANCE FUNCTIONS
@@ -565,6 +547,7 @@ class Trajectory(list, StorableObject):
 
         traj = md.Trajectory(output, topology)
         box_vectors = self.box_vectors
+        print(box_vectors)
         # box_vectors is a list with an entry for each frame of the traj
         # if they're all None, we return None, not [None, None, ..., None]
         if not np.any(box_vectors):

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -136,12 +136,10 @@ class Trajectory(list, StorableObject):
                                          item in cls.__features__.variables)
 
         if is_snapshot_attr(snapshot_class, item):
-            print("looking for " + item)
             # if there's a trajectory_item in features, that should be a
             # function to return a trajectory
             traj_item = "trajectory_" + item
             if traj_item in snapshot_class.__features__.functions:
-                print("found " + traj_item)
                 traj_func = getattr(snapshot_class, traj_item)
                 return traj_func(self)
 

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -87,7 +87,6 @@ class TestOpenMMSnapshot(object):
         assert_is(traj_1.unitcell_vectors, None)
 
         snap_2 = self.engine.current_snapshot
-        print(snap_2.box_vectors)
         traj_2 = snap_2.md
         assert_equal(len(traj_2), 1)
         assert_is_not(traj_2.xyz, None)

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -87,6 +87,7 @@ class TestOpenMMSnapshot(object):
         assert_is(traj_1.unitcell_vectors, None)
 
         snap_2 = self.engine.current_snapshot
+        print(snap_2.box_vectors)
         traj_2 = snap_2.md
         assert_equal(len(traj_2), 1)
         assert_is_not(traj_2.xyz, None)


### PR DESCRIPTION
This simplifies `Trajectory.__getattr__` and may fix #878.

It adds a small restriction on snapshot "features" -- if you have a snapshot feature named `foo`, and if you create a function-type snapshot feature called `trajectory_foo`, then `trajectory_foo` must be a function that takes a trajectory and returns the values for `foo`. (I don't think this is going to cause any problems for anyone.)

I'm using those trajectory function features for the following: With the OpenMM engine, a trajectory returns a `simtk.unit.Quantity` wrapping a numpy array of the results of some snapshot feature, as opposed to making a list/numpy array containing multiple `Quantity` objects. I've now moved the code that supports this behavior into the OpenMM engine (as trajectory function features specific to it), instead of the base `Trajectory` object.

This allows us to remove more OpenMM-specific code that made `Trajectory.__getattr__` a much more complicated and hard-to-maintain function before.