### PR TITLE
Add progress meter adapter classes

### DIFF
--- a/openpathsampling/progress.py
+++ b/openpathsampling/progress.py
@@ -1,0 +1,95 @@
+"""
+Wrappers for progress bars. Mainly intended to use tqdm if it is available
+on the user's system, but in principle, other progress bars could be used as
+well.
+"""
+
+try:
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover
+    HAS_TQDM = False
+else:  # pragma: no cover
+    HAS_TQDM = True
+
+
+def silent_progress(iterable, *args, **kwargs):
+    """No progress output: ignores all options, and just gives the iterator
+
+    Parameters
+    ----------
+    iterable : iterable
+        thing to iterate over
+    """
+    return iter(iterable)
+
+
+def DefaultProgress(**kwargs):  # pragma: no cover
+    """Factory for getting the default progress behavior.
+
+    Currently, uses tqdm if it is available; silent progress otherwise. In
+    the future, we may add global configuration (e.g., rcparams) to allow
+    users to customize this behavior.
+    """
+    # TODO: eventually, add some sort of rcparams support for this
+    if HAS_TQDM:
+        return TqdmPartial(**kwargs)
+    else:
+        return silent_progress
+
+
+class TqdmPartial(object):
+    """Progress bar wrapper for tqdm-based progress meters.
+
+    Note that additional tqdm parameters can be set *after* initialization.
+
+    Parameters
+    ----------
+    desc : str
+        label for the progress bar
+    leave : bool
+        whether to leave to progress bar visible after completion (default
+        True)
+    """
+    def __init__(self, desc=None, leave=True, file=None):
+        self.kwargs = {'desc': desc,
+                       'leave': leave,
+                       'file': file}
+
+    def __getattr__(self, attr):
+        if attr != 'kwargs':
+            return self.kwargs[attr]
+        else:
+            return super(TqdmPartial, self).__getattr__(attr)
+
+    def __setattr__(self, attr, value):
+        if attr != 'kwargs':
+            self.kwargs[attr] = value
+        else:  # pragma: no cover
+            super(TqdmPartial, self).__setattr__(attr, value)
+
+    def __call__(self, iterable, **kwargs):
+        tqdm_kwargs = self.kwargs
+        tqdm_kwargs = {k: v for k, v in self.kwargs.items()}
+        tqdm_kwargs.update(kwargs)
+        return tqdm(iterable, **tqdm_kwargs)
+
+
+class SimpleProgress(object):
+    """Mix-in for classes that need a progress meter.
+
+    Note that this will use the names ``progress`` and ``_progress``.
+    """
+    @property
+    def progress(self):
+        if not hasattr(self, '_progress'):
+            self._progress = DefaultProgress()
+        return self._progress
+
+    @progress.setter
+    def progress(self, value):
+        if value == 'tqdm':
+            value = TqdmPartial()
+        elif value in ['silent', None]:
+            value = silent_progress
+        # else we assume it's already an AnalysisProgress
+        self._progress = value

--- a/openpathsampling/tests/test_progress.py
+++ b/openpathsampling/tests/test_progress.py
@@ -1,0 +1,62 @@
+import pytest
+
+from openpathsampling.progress import *
+
+def test_silent_progress(capsys):
+    out, err = capsys.readouterr()
+    x = [1, 2, 3]
+    prog = silent_progress(x, desc='foo', leave=True)
+    y = [xx**2 for xx in x]
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+
+
+class TestTqdmPartial(object):
+    def setup(self):
+        _ = pytest.importorskip('tqdm')
+        self.tqdm_partial = TqdmPartial(desc="foo")
+
+    def test_get_attr(self):
+        assert self.tqdm_partial.desc == "foo"
+        assert self.tqdm_partial.leave is True
+        assert self.tqdm_partial.file is None
+
+    def test_get_kwargs(self):
+        assert self.tqdm_partial.kwargs == {'desc': 'foo', 'leave': True,
+                                            'file': None}
+
+    def test_set_attr(self):
+        self.tqdm_partial.file = "bar"
+        assert self.tqdm_partial.kwargs['file'] == "bar"
+
+    def test_call(self, capsys):
+        out, err = capsys.readouterr()
+        xx = [x for x in self.tqdm_partial([1, 2, 3])]
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err != ""
+
+class TestSimpleProgress(object):
+    def setup(self):
+        self.progress = SimpleProgress()
+
+    def test_progress_getter(self):
+        assert not hasattr(self.progress, '_progress')
+        prog = self.progress.progress
+        assert prog is not None
+        assert hasattr(self.progress, '_progress')
+
+    def test_progress_setter(self):
+        prog = self.progress.progress
+        assert prog is not None
+        self.progress.progress = 'silent'
+        assert self.progress.progress is silent_progress
+        self.progress.progress = 'tqdm'
+        assert isinstance(self.progress.progress, TqdmPartial)
+        self.progress.progress = None
+        assert self.progress.progress is silent_progress
+        my_tqdm = TqdmPartial()
+        self.progress.progress = my_tqdm
+        assert self.progress.progress is my_tqdm
+        pass


### PR DESCRIPTION
One of the annoying things when working with OPS is that sometimes analysis takes a while, and there's no indicator of how long it will take. This PR starts to add optional progress indicators (using `tqdm`) to our analysis tools, by creating a mix-in class that allows users to set the `progress` attribute. Classes that use the mix-in should not define either a `progress` attribute or a `_progress` attribute.

The code here doesn't require tqdm, but uses it if it is present on the user's system (which, I think, it almost always is).

Really, these are adapter classes and we could interface with other progress meters as well, not just tqdm. Also, although I'm mainly focused on analysis, there's no reason (in principle) that this couldn't be used for simulations as well.

Eventually we'll move any long-running analysis tools toward using this, but note that you can already just wrap an iterable (like `storage.steps`) with tqdm (even without this PR) and you'll usually get the desired behavior. There are a few exceptions, where the iterable is pre-processed before the main analysis is performed.

(I actually wrote most of this code months ago, but in the process I found and fixed a bug in tqdm. I was waiting until that bugfix made it into a tqdm release, and in the meantime, completely forgot about this.)