### PR TITLE
Add PathSampling.run_until_decorrelated

### DIFF
--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -1,5 +1,6 @@
 import time
 import logging
+import os
 
 import openpathsampling as paths
 from .path_simulator import PathSimulator, MCStep
@@ -185,6 +186,41 @@ class PathSampling(PathSimulator):
         #         self.step = len(self.storage.steps)
         n_steps_to_run = n_steps - self.step
         self.run(n_steps_to_run)
+
+    def run_until_decorrelated(self):
+        """Run until all trajectories are decorrelated.
+
+        This runs until all the replicas in ``self.sample_set`` have
+        decorrelated from their initial conditions. "Decorrelated" here is
+        meant in the sense commonly used in one-way shooting: this runs
+        until no configurations from the original trajectories remain.
+        """
+        originals = {s.replica: s.trajectory for s in self.sample_set}
+        current = self.sample_set
+
+        # cache the output stream; force the primary `run` method to not
+        # output anything
+        original_output_stream = self.output_stream
+        self.output_stream = open(os.devnull, 'w')
+
+        def n_correlated(sample_set, originals):
+            return sum([originals[r].is_correlated(sample_set[r])
+                        for r in originals])
+
+        original_output_stream.write("Decorrelating trajectories....\n")
+        to_decorrelate = n_correlated(self.sample_set, originals)
+        # walrus in py38!
+        while to_decorrelate:
+            out_str = "Step {}: {} of {} trajectories still correlated\n"
+            paths.tools.refresh_output(
+                out_str.format(self.step + 1, to_decorrelate, len(originals)),
+                refresh=False,
+                output_stream=original_output_stream
+            )
+            self.run(1)
+            to_decorrelate = n_correlated(self.sample_set, originals)
+
+        self.output_stream = original_output_stream
 
     def run(self, n_steps):
         mcstep = None

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -648,3 +648,35 @@ class TestDirectSimulation(object):
         assert_equal(len(traj), 201)
         read_store.close()
         os.remove(tmpfile)
+
+
+class TestPathSampling(object):
+    def setup(self):
+        paths.InterfaceSet._reset()
+        self.cv = paths.FunctionCV("x", lambda x: x.xyz[0][0])
+        self.state_A = paths.CVDefinedVolume(self.cv, float("-inf"), 0.0)
+        self.state_B = paths.CVDefinedVolume(self.cv, 1.0, float("inf"))
+        pes = paths.engines.toy.LinearSlope([0, 0, 0], 0)
+        integ = paths.engines.toy.LangevinBAOABIntegrator(0.01, 0.1, 2.5)
+        topology = paths.engines.toy.Topology(n_spatial=3, masses=[1.0],
+                                              pes=pes)
+        self.engine = paths.engines.toy.Engine(options={'integ': integ},
+                                               topology=topology)
+        network = paths.TPSNetwork(self.state_A, self.state_B)
+        init_traj = make_1d_traj([-0.1, 0.2, 0.5, 0.8, 1.1])
+        scheme = paths.OneWayShootingMoveScheme(
+            network=network,
+            selector=paths.UniformSelector(),
+            engine=self.engine
+        )
+        init_cond = scheme.initial_conditions_from_trajectories(init_traj)
+        self.sim = PathSampling(storage=None, move_scheme=scheme,
+                                sample_set=init_cond)
+
+    def test_run_until_decorrelated(self):
+        def all_snaps(sample_set):
+            return set(sum([s.trajectory for s in sample_set], []))
+        initial_snaps = all_snaps(self.sim.sample_set)
+        self.sim.run_until_decorrelated()
+        final_snaps = all_snaps(self.sim.sample_set)
+        assert initial_snaps & final_snaps == set([])


### PR DESCRIPTION
This adds a function to the `PathSampling` path simulator to tell it to run until all trajectories in the initial sample set are decorrelated (in the one-way shooting sense of "not having any configurations in common with the original trajectories.")

This definition of decorrelation is an absolute bare minimum requirement for equilibration, and so you could imagine equilibration strategies such as "run twice as long as it takes to get a decorrelated trajectory" or "run as long as it takes to get a decorrelated trajectory, plus N additional steps." This function will facilitate that.