### PR TITLE
Release 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ install:
   - if [ -z "$MINIMAL" ] ; then source devtools/conda_install_reqs.sh; else pip install -r devtools/minimal.txt -r devtools/minimal_testing.txt; fi
   - pip install autorelease
   - pip install --no-deps -e .
-
-before_script:
+    #before_script:  # TODO: return this to before_script; fix autorelease
   - python --version
   - python -c "import openpathsampling"
   - source devtools/ci/git_hash.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ before_install:
 install:
   - export OPS_ENV="openpathsampling-py${CONDA_PY}"
   - if [ -z "$MINIMAL" ] ; then source devtools/conda_install_reqs.sh; else pip install -r devtools/minimal.txt -r devtools/minimal_testing.txt; fi
-  - pip install autorelease
+  # for the first OPS install, we will run the ops_fixes autorelease branch
+  - pip install git+https://github.com/dwhswenson/autorelease.git@ops_fixes
+  #- pip install autorelease
   - pip install --no-deps -e .
 
 before_script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+version: ~> 1.0
+
 language: python
 filter_secrets: false   # https://github.com/travis-ci/travis-ci/issues/8934
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
   - if [ -z "$MINIMAL" ] ; then source devtools/conda_install_reqs.sh; else pip install -r devtools/minimal.txt -r devtools/minimal_testing.txt; fi
   - pip install autorelease
   - pip install --no-deps -e .
-    #before_script:  # TODO: return this to before_script; fix autorelease
+
+before_script: 
   - python --version
   - python -c "import openpathsampling"
   - source devtools/ci/git_hash.sh
@@ -40,10 +41,10 @@ addons:
 env:
   global:
     - TWINE_USERNAME="dwhswenson"
-    # TWINE_PASSWORD
-    - secure: "zs/3PN46wXFzTDli8LE9jJmNov27xAy7REaTK4s3DV9Ocmf5grqIUbUfFfa7XyOvamr6C7TSHib1SqQvEbHv416AcOD9FWZm9iNj0MO2dBimyXrvR50TFKG/dcp0Qzlp54hYFM4bEzWJZUVN120xynIKgfy74YBOA8DQ6B7FlyY="
-    # AUTORELEASE_TOKEN
-    - secure: "r9u8xvXo3avaloOogrqIVF/oFDeMLSYvZbBYv3y3nBN17p3I9C2FhUbu/VpiRBA0kX6U2BsAHh5DF8ymRD254/f3s8L1BapanLfmoRjp9cXAJ95RZhZ8Cxw9W36VEGcIa+JG1G31oqabEBW4ozQmXsGPSYI3+wfFmhchJPpaDRE="
+    # TWINE_PASSWORD (set via web)
+    #- secure: "zs/3PN46wXFzTDli8LE9jJmNov27xAy7REaTK4s3DV9Ocmf5grqIUbUfFfa7XyOvamr6C7TSHib1SqQvEbHv416AcOD9FWZm9iNj0MO2dBimyXrvR50TFKG/dcp0Qzlp54hYFM4bEzWJZUVN120xynIKgfy74YBOA8DQ6B7FlyY="
+    # AUTORELEASE_TOKEN (set via web)
+    #- secure: "r9u8xvXo3avaloOogrqIVF/oFDeMLSYvZbBYv3y3nBN17p3I9C2FhUbu/VpiRBA0kX6U2BsAHh5DF8ymRD254/f3s8L1BapanLfmoRjp9cXAJ95RZhZ8Cxw9W36VEGcIa+JG1G31oqabEBW4ozQmXsGPSYI3+wfFmhchJPpaDRE="
     - secure: "NJvoSrLNd2ZR3HluJjEqI36gD5lsucwIvgnYjNmM4cwnnA77aLV9FRYTwlLRZn3XY9FL8KOzL5l0amNzMD7sQrf7bWwWv7iCUBddH549q9RSgiuOugtodYJ6VaXi76hk1rOgcJpDoCj9wTCIlMtWibPUzr1QHmdihfdM2iA2kkE="
     - secure: "l9NJkZDD0ALhkErUvhRrreLsrcWErd+CXpWv8dxHGtkjemNx6CwVtyL+a30jz/QwMANSZbKll/cPK5yJQvuwDaWxja6UPLLKVNGtma+CmwKcIC/wwTwbMoxcS62fyLJ3kS0qR8oCQz2nCPKiYyRGADtPLWVMZckY1SJfNYcKuCM="
     - secure: "kb37xmsSV3pEnESnINzwlW2Cju/UFzA/G+m+NsihAwO8RMPZwKCrZK/rptgkUDACXJxom5M690WEukQkHnOt+OTrWhu7WKZgYeVuWUs2++RohYv/m5npaOHMMn+uYmF328v4PvPmXxbD02zzg5Tgdn82x8oa6J8BKX8ohOQ6Xpg="
@@ -54,4 +55,4 @@ env:
     - CONDA_PY=3.7
 
 import:
-  - dwhswenson/autorelease:autorelease-travis.yml@v0.1.0
+  - dwhswenson/autorelease:autorelease-travis.yml@ops_fixes

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - deactivate  # virtual envs don't play nice with conda
   - export PYTHONUNBUFFERED=true  # immediately flush stdout to terminal
   - source devtools/ci/miniconda_install.sh
-  - conda install -y pyyaml
+  #- conda install -y pyyaml  # I don't think this is needed now...
 
 install:
   - export OPS_ENV="openpathsampling-py${CONDA_PY}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ version: ~> 1.0
 language: python
 filter_secrets: false   # https://github.com/travis-ci/travis-ci/issues/8934
 
+branches:
+  only:
+    - master
+    - stable
+    - docs_deploy  # used for experimenting with docs builds
+    - /^v\d+(\.\d+)+/
+
+
 notifications:
   webhooks: https://coveralls.io/webhook
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openpathsampling-dev
-  version: "1.1.0.dev0"
+  version: "1.1.0"
 
 source:
   path: ../../

--- a/openpathsampling/engines/openmm/topology.py
+++ b/openpathsampling/engines/openmm/topology.py
@@ -1,7 +1,6 @@
 import mdtraj as md
 import numpy as np
 import pandas as pd
-from simtk.openmm import XmlSerializer
 
 from openpathsampling.engines import Topology
 

--- a/openpathsampling/netcdfplus/netcdfplus.py
+++ b/openpathsampling/netcdfplus/netcdfplus.py
@@ -385,8 +385,12 @@ class NetCDFPlus(netCDF4.Dataset):
     @staticmethod
     def _cmp_version(v1, v2):
         # we only look at x.y.z parts
-        q1 = v1.split('.')[:3]
-        q2 = v2.split('.')[:3]
+        def version_parts(v):
+            return v.split('-')[0].split('+')[0].split('.')[:3]
+        q1 = version_parts(v1)
+        q2 = version_parts(v2)
+        # q1 = v1.split('.')[:3]
+        # q2 = v2.split('.')[:3]
         # q1 = v1.split('-')[0].split('.')
         # q2 = v2.split('-')[0].split('.')
         for v1, v2 in zip(q1, q2):

--- a/openpathsampling/netcdfplus/version.py
+++ b/openpathsampling/netcdfplus/version.py
@@ -1,5 +1,5 @@
-short_version = '1.1.0.dev0'
-version = '1.1.0.dev0'
-full_version = '1.1.0.dev0'
+short_version = '1.1.0'
+version = '1.1.0'
+full_version = '1.1.0'
 git_revision = 'alpha'
 release = False

--- a/openpathsampling/tests/test_attribute.py
+++ b/openpathsampling/tests/test_attribute.py
@@ -3,6 +3,7 @@
 """
 
 from .test_helpers import data_filename, assert_close_unit, make_1d_traj, md
+import pytest
 
 from nose.plugins.skip import SkipTest
 
@@ -18,6 +19,7 @@ class TestFunctionPseudoAttribute(object):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.mdtraj = md.load(data_filename("ala_small_traj.pdb"))
+        pytest.importorskip("simtk.unit")
         self.traj_topology = peng.trajectory_from_mdtraj(self.mdtraj)
         self.traj_simple = peng.trajectory_from_mdtraj(
             self.mdtraj,

--- a/openpathsampling/tests/test_collectivevariable.py
+++ b/openpathsampling/tests/test_collectivevariable.py
@@ -7,6 +7,7 @@ from builtins import zip
 from builtins import object
 from .test_helpers import data_filename, assert_close_unit, md
 
+import pytest
 from nose.plugins.skip import SkipTest
 
 import numpy as np
@@ -32,6 +33,7 @@ class TestFunctionCV(object):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.mdtraj = md.load(data_filename("ala_small_traj.pdb"))
+        _ = pytest.importorskip('simtk.unit')
         self.traj_topology = peng.trajectory_from_mdtraj(self.mdtraj)
         self.traj_simple = peng.trajectory_from_mdtraj(
             self.mdtraj,

--- a/openpathsampling/tests/test_mdtraj_support.py
+++ b/openpathsampling/tests/test_mdtraj_support.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from builtins import object
 import logging
 
+import pytest
+
 from nose.tools import (
     assert_equal, assert_not_equal, raises
 )
@@ -29,6 +31,7 @@ class TestMDTrajSupport(object):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.md_trajectory = md.load(data_filename("ala_small_traj.pdb"))
+        _ = pytest.importorskip("simtk.unit")
         self.ops_trajectory = trajectory_from_mdtraj(self.md_trajectory)
         self.md_topology = self.ops_trajectory.topology.mdtraj
 

--- a/openpathsampling/tests/test_openmm_tools.py
+++ b/openpathsampling/tests/test_openmm_tools.py
@@ -89,6 +89,8 @@ def test_reduced_box_vectors():
     else:
         raise AssertionError("Box already reduced")
 
+    if not HAS_OPENMM:
+        pytest.skip()
     snap = mock_snapshot_with_box_vector(box * nm)
     reduced_box = reduced_box_vectors(snap).value_in_unit(nm)
     check_reduced_box_vectors(reduced_box)
@@ -122,7 +124,7 @@ def test_reduce_trajectory_box_vectors():
 
 
 def test_load_trr_with_velocities():
-    if not HAS_MDTRAJ:
+    if not (HAS_MDTRAJ and HAS_OPENMM):
         pytest.skip()
     box_vect_dir = "reduce_box_vects"
     gro = data_filename(box_vect_dir + "/dna.gro")
@@ -134,7 +136,7 @@ def test_load_trr_with_velocities():
 
 
 def test_load_trr_no_velocities():
-    if not HAS_MDTRAJ:
+    if not (HAS_MDTRAJ and HAS_OPENMM):
         pytest.skip()
     box_vect_dir = "reduce_box_vects"
     gro = data_filename(box_vect_dir + "/dna.gro")

--- a/openpathsampling/tests/test_storage.py
+++ b/openpathsampling/tests/test_storage.py
@@ -8,6 +8,8 @@ from builtins import range
 from builtins import object
 import os
 
+import pytest
+
 from nose.tools import (assert_equal)
 
 import openpathsampling as paths
@@ -28,6 +30,7 @@ class TestStorage(object):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.mdtraj = md.load(data_filename("ala_small_traj.pdb"))
+        _ = pytest.importorskip('simtk.unit')
         self.traj = peng.trajectory_from_mdtraj(
             self.mdtraj, simple_topology=True)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openpathsampling
-version = 1.1.0.dev0
+version = 1.1.0
 description = A Python package for path sampling simulations
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
The marquee feature in OPS 1.1 is the addition of GROMACS support. That also introduces the external engine framework, which can be used by other MD engines.

Another important change is that OPS is now pip-installable and can be installed through conda's `conda-forge` channel (starting with 1.1, new versions of OPS will *not* be in the `omnia` channel). Also note that many tools that previously were bundled with OPS now are not. In particular, if you want to use any of the following packages, you must install them separately:

* OpenMM
* OpenMMTools
* PyEMMA
* MSMBuilder
* Jupyter

They're all just a `conda install` away, and as soon as they're in your environment, OPS will interface with them as before.

Deprecations: CVs based on MSMBuilder featurizers are deprecated. MSMBuilder can no longer be tested in our standard test setup. We haven't removed support, but we can't recommend using it.

## New features
* External Engine (#144)
* Gromacs engine (#819)
* Path density: Bresenham interpolation (#875)
* Simplify `Trajectory.__getattr__` (#879)
* Add information to MinusMove change.details (#874)

## Bugs fixed
* Fix bug with left_bin_edge in histogram (#851 @sroet)
* Fix problems with storage for nonperiodic systems (#835 [part from @ajsilveira])
* Fix Py3 bug in getting function name when CV storage raises error  (#830 @ajsilveira)

## Miscellaneous improvements
* Reduce install requirements; make PyPI/conda-forge possible(#867, #876)
* Use Autorelease for version/release management (#883)
* Add subpackages as a space for user contributions (#849)
* Some toy engine reprs (#880)
* Various improvements to documentation (#881 @sroet, #859, #856 @sroet, #847, #770 @hejung)
* Various improvements to CI/testing (#877, #866, #848)
* Deprecate MSMBuilder (#853) #Deprecations