### PR TITLE
Add interface_set to API docs

### DIFF
--- a/docs/api_sections.rst
+++ b/docs/api_sections.rst
@@ -17,6 +17,7 @@ OpenPathSampling API
     pathsimulator
     storage
     treemixin
+    interface_set
     network
     engines/index
     netcdfplus/index

--- a/docs/interface_set.rst
+++ b/docs/interface_set.rst
@@ -1,0 +1,32 @@
+.. _interface_set:
+
+.. currentmodule:: openpathsampling.high_level.interface_set
+
+Interface Sets
+==============
+
+In transition interface sampling and related methods, we need to define a
+set of interfaces for each sampling transition. In OPS, this is essentially
+just a list of volumes. However, it can be useful for that list to carry
+some addition information (such as the associated collective variable), so
+the :class:`.InterfaceSet` is a way to package that information.
+
+For TIS, you will usually use the :class:`.VolumeInterfaceSet` or
+:class:`.PeriodicVolumeInterfaceSet`.
+
+Abstract classes
+----------------
+.. autosummary::
+   :toctree: api/generated
+
+   InterfaceSet
+   GenericVolumeInterfaceSet
+
+Interface Sets for TIS
+----------------------
+.. autosummary::
+   :toctree: api/generated
+
+   VolumeInterfaceSet
+   PeriodicVolumeInterfaceSet
+


### PR DESCRIPTION
This adds a place in the API docs for interface sets.

This PR only touches the docs, and can't be controversial, so I'll merge as soon as it passes tests. (If anyone wants to improve wording/fix typos, that can be done in a separate PR).
