### PR TITLE
Refactor RandomVelocity so engine can do the work

### DIFF
--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -45,6 +45,11 @@ class SnapshotModifier(StorableNamedObject):
     def extract_subset(self, full_array, subset=None):
         """Extracts elements from full_array according to self.subset_mask
 
+        Note that, if ``subset`` and ``self.subset`` are None, this returns
+        ``full_array``. If you intend to modify the object returned by this
+        functions, you should ensure that your input ``full_array`` is a
+        copy of any orginal immutable data.
+
         Parameters
         ----------
         full_array : list-like
@@ -55,7 +60,7 @@ class SnapshotModifier(StorableNamedObject):
 
         Returns
         -------
-        list
+        list-like
             the elements of full_array which are selected by
             self.subset_mask, or full_array if subset and self.subset_mask
             are None
@@ -80,6 +85,9 @@ class SnapshotModifier(StorableNamedObject):
         modified : list-like
             array containing len(self.subset_mask) elements which will
             replace those in `full_array`
+        subset_mask : list of int or None
+            the subset to use; see ``SnapshotModifier.subset_mask``. Default
+            (None) uses the value of ``self.subset_mask``.
 
         Returns
         -------

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -130,7 +130,17 @@ class RandomVelocities(SnapshotModifier):
         self.beta = beta
         self.engine = engine
 
+    def _default_random_velocities(self, snapshot, beta):
+        pass
+
     def __call__(self, snapshot):
+        # if self.engine:
+            # try:
+                # make_snapshot = self.engine.randomize_velocities
+            # except AttributeError:
+                # make_snapshot = self._default(make_snapshot)
+        # new_snap = self.make_snapshot(snapshot)
+
         # raises AttributeError is snapshot doesn't support velocities
         velocities = copy.copy(snapshot.velocities)  # copy.copy for units
         vel_subset = self.extract_subset(velocities)

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -42,24 +42,31 @@ class SnapshotModifier(StorableNamedObject):
         super(SnapshotModifier, self).__init__()
         self.subset_mask = subset_mask
 
-    def extract_subset(self, full_array):
+    def extract_subset(self, full_array, subset=None):
         """Extracts elements from full_array according to self.subset_mask
 
         Parameters
         ----------
         full_array : list-like
             the input array
+        subset : list of int or None
+            the subset to use; see ``SnapshotModifier.subset_mask``. Default
+            (None) uses the value of ``self.subset_mask``.
 
         Returns
         -------
         list
             the elements of full_array which are selected by
-            self.subset_mask, or full_array if self.subset_mask is None
+            self.subset_mask, or full_array if subset and self.subset_mask
+            are None
         """
-        if self.subset_mask is None:
+        if subset is None:
+            subset = self.subset_mast
+
+        if subset is None:
             return full_array
         else:
-            return [full_array[i] for i in self.subset_mask]
+            return [full_array[i] for i in subset]
 
     def apply_to_subset(self, full_array, modified):
         """Replaces elements of full_array according to self.subset_mask
@@ -131,9 +138,10 @@ class RandomVelocities(SnapshotModifier):
         self.beta = beta
         self.engine = engine
 
-    def _default_random_velocities(self, snapshot, beta):
+    def _default_random_velocities(self, snapshot, beta, subset=None):
         if beta is None:
             raise RuntimeError("Engine can't use RandomVelocities")
+
         # raises AttributeError is snapshot doesn't support velocities
         velocities = copy.copy(snapshot.velocities)  # copy.copy for units
         vel_subset = self.extract_subset(velocities)

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -4,6 +4,7 @@ from builtins import zip
 from builtins import range
 from past.utils import old_div
 from builtins import object
+import pytest
 from nose.tools import (assert_equal, assert_not_equal, raises,
                         assert_almost_equal, assert_true)
 from nose.plugins.skip import SkipTest
@@ -190,6 +191,12 @@ class TestRandomizeVelocities(object):
                                   self.snap_2x3D.velocities[1])
         for val in new_2x3D.velocities[0]:
             assert_not_equal(val, 0.0)
+
+    def test_no_beta_bad_engine(self):
+        engine = self.snap_2x3D.engine
+        randomizer = RandomVelocities(engine=engine)
+        with pytest.raises(RuntimeError):
+            randomizer(self.snap_2x3D)
 
     def test_with_openmm_snapshot(self):
         # note: this is only a smoke test; correctness depends on OpenMM's


### PR DESCRIPTION
This will make it so that the preferred way to randomize velocities is in the engine. If the engine knows how to randomize, then we prefer to have the engine create the random snapshot. If not, we fall back on the approaches we have previously implemented (which require that the engine has implemented `apply_constraints`, which should apply the velocity constraints as well; e.g., RATTLE).

To use this, engines should define a method `randomize_velocities(snapshots, beta=None, subset_mask=None)` which returns a snapshot with the randomized and constrained velocities.

This is the first step toward #889.

- [x] Refactor `RandomVelocities.__call__`
- [x] Add support for `subset_mask`
- [x] Ensure full coverage in tests