### PR TITLE
`run_until_decorrelated` should account for time reversibility

### DIFF
--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -187,7 +187,7 @@ class PathSampling(PathSimulator):
         n_steps_to_run = n_steps - self.step
         self.run(n_steps_to_run)
 
-    def run_until_decorrelated(self):
+    def run_until_decorrelated(self, time_reversal=True):
         """Run until all trajectories are decorrelated.
 
         This runs until all the replicas in ``self.sample_set`` have
@@ -204,7 +204,8 @@ class PathSampling(PathSimulator):
         self.output_stream = open(os.devnull, 'w')
 
         def n_correlated(sample_set, originals):
-            return sum([originals[r].is_correlated(sample_set[r])
+            return sum([originals[r].is_correlated(sample_set[r],
+                                                   time_reversal)
                         for r in originals])
 
         original_output_stream.write("Decorrelating trajectories....\n")
@@ -219,6 +220,12 @@ class PathSampling(PathSimulator):
             )
             self.run(1)
             to_decorrelate = n_correlated(self.sample_set, originals)
+
+        paths.tools.refresh_output(
+            "Step {}: All trajectories decorrelated!\n".format(self.step+1),
+            refresh=False,
+            output_stream=original_output_stream
+        )
 
         self.output_stream = original_output_stream
 


### PR DESCRIPTION
PR #884 added a `run_until_decorrelated` function to the `PathSampling` path simulator. However, that function didn't use the decorrelated trajectory check that accounts for time reversibility (i.e., it allowed a path reversal to count as decorrelating a trajectory). Since this is intended for equilibration, that doesn't make sense: it should require that the frame be completely replaced (since initial frames may come from nonphysical trajectories).

This fixes that by default, providing `run_until_decorrelated` with a `time_reversal` argument like that in `Trajectory.is_decorrelated`. In this case, that argument default to `True`.

This also updates so that the output for the final step makes it clear that all trajectories have decorrelated, and switches the testing to use a TIS network with path reversals possible.