### PR TITLE
Fix pandas API change: set_value -> at

### DIFF
--- a/openpathsampling/high_level/network.py
+++ b/openpathsampling/high_level/network.py
@@ -705,9 +705,12 @@ class MSTISNetwork(TISNetwork):
 
         for trans in self.transitions.values():
             rate = trans.rate(steps)
-            self._rate_matrix.set_value(trans.stateA.name,
-                                        trans.stateB.name,
-                                        rate)
+            # self._rate_matrix.set_value(trans.stateA.name,
+                                        # trans.stateB.name,
+                                        # rate)
+            name_A = trans.stateA.name
+            name_B = trans.stateB.name
+            self._rate_matrix.at[name_A, name_B] = rate
             #print trans.stateA.name, trans.stateB.name,
             #print rate
 
@@ -972,8 +975,11 @@ class MISTISNetwork(TISNetwork):
                 # probability automatically
 
             rate = trans.rate(steps)
-            self._rate_matrix.set_value(trans.stateA.name,
-                                        trans.stateB.name,
-                                        rate)
+            # self._rate_matrix.set_value(trans.stateA.name,
+                                        # trans.stateB.name,
+                                        # rate)
+            name_A = trans.stateA.name
+            name_B = trans.stateB.name
+            self._rate_matrix.at[name_A, name_B] = rate
 
         return self._rate_matrix


### PR DESCRIPTION
Pandas 1.0 has been released! And long-deprecated the `.set_value` method for setting dataframe values has been removed. This fixes the places where we were using that (in TIS rate matrix calculations).