### PR TITLE
Fix pandas Deprepaction and Future Warnings

### DIFF
--- a/openpathsampling/numerics/wham.py
+++ b/openpathsampling/numerics/wham.py
@@ -160,8 +160,8 @@ class WHAM(object):
             )
             cleaned_df = cleaned_df.apply(
                 lambda s: [
-                    s.iloc[i] if test_f(s.iloc[i], s.iloc[i+1], s.max())
-                    else 0.0
+                    s.iloc[i]
+                    if test_f(s.iloc[i], s.iloc[i+1], s.max()) else 0.0
                     for i in range(len(s)-1)
                 ] + [s.iloc[-1]]
             )

--- a/openpathsampling/numerics/wham.py
+++ b/openpathsampling/numerics/wham.py
@@ -7,9 +7,10 @@ from __future__ import print_function
 # from several files.
 import pandas as pd
 import numpy as np
-
+import sys
 import logging
 logger = logging.getLogger(__name__)
+
 
 class WHAM(object):
     """
@@ -59,13 +60,13 @@ class WHAM(object):
     @property
     def float_format(self):
         """Float output format. Example: 10.8 (default)"""
-        return lambda x : "{:" + self._float_format + "f}".format(x)
+        return lambda x: "{:" + self._float_format + "f}".format(x)
 
     @float_format.setter
     def float_format(self, value):
         self._float_format = value
 
-    def load_files(self,fnames):  # pragma: no cover
+    def load_files(self, fnames):  # pragma: no cover
         """Load a file or files into the internal structures.
 
         Requires either pandas or something else with pandas-like read_table
@@ -87,15 +88,14 @@ class WHAM(object):
         try:
             for fname in fnames:
                 frames.append(pd.read_table(fname, index_col=0, sep=" ",
-                                            usecols=[0,1], header=None))
+                                            usecols=[0, 1], header=None))
         except TypeError:
             frames.append(pd.read_table(fnames, index_col=0, sep=" ",
-                                        usecols=[0,1], header=None))
+                                        usecols=[0, 1], header=None))
             fnames = [fnames]
         df = pd.concat(frames, axis=1)
-        df.columns=fnames
+        df.columns = fnames
         return df
-
 
     def prep_reverse_cumulative(self, df, cutoff=None, tol=None):
         """
@@ -103,7 +103,7 @@ class WHAM(object):
 
         This version assumes that the input is the result of a reversed
         cumulative histogram. That means that it cleans leading input where
-        the initial 
+        the initial
 
         Parameters
         ----------
@@ -131,7 +131,7 @@ class WHAM(object):
         hist_max = df.max(axis=0)
         raw_cutoff = cutoff*hist_max
         cleaned_df = df.apply(
-            lambda s : [x if x > raw_cutoff[s.name] else 0.0 for x in s]
+            lambda s: [x if x > raw_cutoff[s.name] else 0.0 for x in s]
         )
 
         if self.interfaces is not None:
@@ -140,10 +140,10 @@ class WHAM(object):
             if type(self.interfaces) is not pd.Series:
                 self.interfaces = pd.Series(data=self.interfaces,
                                             index=df.columns)
-            greater_almost_equal = lambda a, b : (a >= b or
-                                                  abs(a - b) < 10e-10)
+            greater_almost_equal = lambda a, b: (a >= b or
+                                                 abs(a - b) < 10e-10)
             cleaned_df = cleaned_df.apply(
-                lambda s : [
+                lambda s: [
                     (
                         s.iloc[i]
                         if greater_almost_equal(s.index[i],
@@ -155,17 +155,17 @@ class WHAM(object):
             )
         else:
             # clear duplicates of leading values
-            test_f = lambda val1, val2, val_max : (
+            test_f = lambda val1, val2, val_max: (
                 abs(val1 - val2) > tol or abs(val1 - val_max) > tol
             )
             cleaned_df = cleaned_df.apply(
-                lambda s : [
-                    s.iloc[i] if test_f(s.iloc[i], s.iloc[i+1], s.max()) else 0.0
+                lambda s: [
+                    s.iloc[i] if test_f(s.iloc[i], s.iloc[i+1], s.max())
+                    else 0.0
                     for i in range(len(s)-1)
                 ] + [s.iloc[-1]]
             )
         return cleaned_df
-
 
     def unweighting_tis(self, cleaned_df):
         """
@@ -189,13 +189,12 @@ class WHAM(object):
             unweighting values for the input dataframe
         """
         unweighting = cleaned_df.copy().applymap(
-            lambda x : 1.0 if x > 0.0 else 0.0
+            lambda x: 1.0 if x > 0.0 else 0.0
         )
         return unweighting
 
-
     def sum_k_Hk_Q(self, cleaned_df):
-        """Sum over histograms for each histogram bin. Length is n_bins
+        r"""Sum over histograms for each histogram bin. Length is n_bins
 
         Called ``sum_hist`` in other codes, or :math:`\sum_k H_k(Q)` in F&S.
         This is the sum over histograms of values for a given histogram bin.
@@ -211,7 +210,6 @@ class WHAM(object):
             sum over histograms for each bin (length is n_bins)
         """
         return cleaned_df.sum(axis=1)
-
 
     def n_entries(self, cleaned_df):
         """List of counts of entries per histogram. Length is n_hists
@@ -231,7 +229,6 @@ class WHAM(object):
         """
         return cleaned_df.sum(axis=0)
 
-
     def weighted_counts_tis(self, unweighting, n_entries):
         """
         Product of unweighting and n_entries.
@@ -249,14 +246,13 @@ class WHAM(object):
         pandas.DataFrame
             weighted counts matrix, size n_hists by n_dims
         """
-        weighted_counts = unweighting.apply(lambda s : [x * n_entries[s.name]
-                                                        for x in s])
+        weighted_counts = unweighting.apply(lambda s: [x * n_entries[s.name]
+                                                       for x in s])
         return weighted_counts
 
-
-    def generate_lnZ(self, lnZ, unweighting, weighted_counts,
-                            sum_k_Hk_Q, tol=None):
-        """
+    def generate_lnZ(self, lnZ, unweighting, weighted_counts, sum_k_Hk_Q,
+                     tol=None):
+        r"""
         Perform the WHAM iteration to estimate ln(Z_i) for each histogram.
 
         Parameters
@@ -286,12 +282,11 @@ class WHAM(object):
         diff = self.tol + 1  # always start above the tolerance
         iteration = 0
         hists = weighted_counts.columns
-        bins = weighted_counts.index
         # TODO: probably faster if we make wc this a sparse matrix
         wc = weighted_counts.values
         unw = unweighting.values
         lnZ_old = pd.Series(data=lnZ, index=hists)
-        Z_new = pd.Series(index=hists)
+        Z_new = pd.Series(index=hists, dtype='float64')
         sum_k_Hk_byQ = sum_k_Hk_Q.values
         while diff > tol and iteration < self.max_iter:
             Z_old = np.exp(lnZ_old)
@@ -325,7 +320,7 @@ class WHAM(object):
                 # multiplication, which numpy can do very quickly.
                 #############################################################
 
-                w_i = unw[:,i]
+                w_i = unw[:, i]
 
                 # numerator: w_{i,Q} * sum_k_Hk_byQ
                 numerator_byQ = np.multiply(w_i, sum_k_Hk_byQ)
@@ -351,7 +346,6 @@ class WHAM(object):
         self.convergence = (iteration, diff)
         return lnZ_old
 
-
     def get_diff(self, lnZ_old, lnZ_new, iteration):
         """Calculate the difference for this iteration.
 
@@ -372,7 +366,7 @@ class WHAM(object):
             difference between old and new to use for convergence testing
         """
         # get error
-        diff=0
+        diff = 0
         diff = sum(abs(lnZ_old - lnZ_new))
         # check status (mainly for debugging)
         if (iteration % self.sample_every == 0):  # pragma: no cover
@@ -381,7 +375,6 @@ class WHAM(object):
             logger.debug("   lnZ = " + str(lnZ_old))
             logger.debug("lnZnew = " + str(lnZ_new))
         return diff
-
 
     def output_histogram(self, lnZ, sum_k_Hk_Q, weighted_counts):
         """Recombine the data into a joined histogram
@@ -404,7 +397,8 @@ class WHAM(object):
         """
         Z = np.exp(lnZ)
         Z0_over_Zi = Z.iloc[0] / Z
-        output = pd.Series(index=sum_k_Hk_Q.index, name="WHAM")
+        output = pd.Series(index=sum_k_Hk_Q.index, name="WHAM",
+                           dtype='float64')
         for val in sum_k_Hk_Q.index:
             sum_w_over_Z = sum([
                 weighted_counts.loc[val, hist_i] * Z0_over_Zi[hist_i]
@@ -438,7 +432,7 @@ class WHAM(object):
         pandas.Series
             initial guess for values of ln(Z_i) for each histogram
         """
-        df = cleaned_df.apply(lambda s : s/s.max())
+        df = cleaned_df.apply(lambda s: s/s.max())
         # pandas magic, see http://stackoverflow.com/questions/18327624
         first_nonzero = df.apply(lambda s: s[s == 1.0].index[0])
         df = df.loc[first_nonzero]
@@ -464,7 +458,7 @@ class WHAM(object):
         RuntimeError
             if the input doesn't have enough of an overlap
         """
-        for col_idx in range(1,len(cleaned_df.columns)):
+        for col_idx in range(1, len(cleaned_df.columns)):
             col = cleaned_df.columns[col_idx]
             prev_col = cleaned_df.columns[col_idx - 1]
 
@@ -503,7 +497,7 @@ class WHAM(object):
         n_entries = self.n_entries(cleaned)
         unweighting = self.unweighting_tis(cleaned)
         weighted_counts = self.weighted_counts_tis(unweighting,
-                                                          n_entries)
+                                                   n_entries)
         try:
             lnZ = self.generate_lnZ(guess, unweighting, weighted_counts,
                                     sum_k_Hk_Q)
@@ -540,7 +534,6 @@ def parsing(parseargs):  # pragma: no cover
     return opts, args
 
 
-import sys, os
 if __name__ == "__main__":  # pragma: no cover
     opts, args = parsing(sys.argv[1:])
     wham = WHAM(tol=opts.tol, max_iter=opts.max_iter, cutoff=opts.cutoff)
@@ -558,5 +551,5 @@ if __name__ == "__main__":  # pragma: no cover
         wham_hist = wham.wham_bam_histogram(df)
         print(wham_hist.to_string(
             header=False,
-            float_format=lambda x : "{:10.8f}".format(x)
+            float_format=lambda x: "{:10.8f}".format(x)
         ))

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -1,21 +1,15 @@
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
-from nose.tools import (assert_equal, assert_not_equal,
-                        assert_almost_equal, raises)
-from nose.plugins.skip import Skip, SkipTest
-from .test_helpers import (
-    true_func, assert_equal_array_array, make_1d_traj, data_filename,
-    assert_items_equal
-)
-
+from pandas.testing import assert_frame_equal
+from nose.tools import assert_equal
+from .test_helpers import assert_items_equal
 import openpathsampling as paths
-from openpathsampling.high_level.interface_set import GenericVolumeInterfaceSet
 
 import logging
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
 
 class TestResamplingStatistics(object):
     # NOTE: we test the mean_df and std_df functions within this
@@ -90,6 +84,7 @@ class TestResamplingStatistics(object):
             check_dtype=False
         )
 
+
 class TestBlockResampling(object):
     def setup(self):
         self.samples = list(range(100))
@@ -129,7 +124,8 @@ class TestBlockResampling(object):
         assert_items_equal(resampler_2.unassigned, list(range(96, 100)))
 
     def test_n_per_block_initialization(self):
-        resampler = paths.numerics.BlockResampling(self.samples, n_per_block=10)
+        resampler = paths.numerics.BlockResampling(self.samples,
+                                                   n_per_block=10)
         assert_equal(resampler.n_total_samples, 100)
         assert_equal(resampler.n_blocks, 10)
         assert_equal(resampler.n_per_block, 10)

--- a/openpathsampling/tests/test_tis_analysis.py
+++ b/openpathsampling/tests/test_tis_analysis.py
@@ -994,7 +994,7 @@ class TestStandardTISAnalysis(TestTISAnalysis):
         StandardTISAnalysis(
             network=network,
             flux_method=DictFlux({(t.stateA, t.interfaces[0]): 0.1
-                                 for t in network.sampling_transitions})
+                                  for t in network.sampling_transitions})
         )
 
     def test_init_ensemble_histogrammer_max_lambda(self):

--- a/openpathsampling/tests/test_tis_analysis.py
+++ b/openpathsampling/tests/test_tis_analysis.py
@@ -1,28 +1,23 @@
 import itertools
 import random
-from nose.tools import (assert_equal, assert_not_equal, assert_almost_equal,
-                        raises)
-from nose.plugins.skip import Skip, SkipTest
-from .test_helpers import (
-    true_func, assert_equal_array_array, make_1d_traj, data_filename,
-    MoverWithSignature, RandomMDEngine, assert_frame_equal,
-    assert_items_equal
-)
+from nose.tools import assert_equal, assert_almost_equal, raises
+from .test_helpers import (make_1d_traj, MoverWithSignature, RandomMDEngine,
+                           assert_frame_equal, assert_items_equal)
 
 from openpathsampling.analysis.tis import *
-from openpathsampling.analysis.tis.core import \
-    steps_to_weighted_trajectories
+from openpathsampling.analysis.tis.core import steps_to_weighted_trajectories
 from openpathsampling.analysis.tis.flux import default_flux_sort
 import openpathsampling as paths
 
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 
 import logging
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
 
 def make_tis_traj_fixed_steps(n_steps, step_size=0.1, reverse=False):
     if reverse:
@@ -35,6 +30,7 @@ def make_tis_traj_fixed_steps(n_steps, step_size=0.1, reverse=False):
               for i in range(n_steps + 2)]
     falling = list(reversed(rising))[1:]
     return make_1d_traj(rising + falling)
+
 
 class TestMultiEnsembleSamplingAnalyzer(object):
     # this only has to check the error generation; everything else gets
@@ -72,7 +68,6 @@ class TISAnalysisTester(object):
         )
 
         all_ensembles = ensembles_AB + ensembles_BA
-        replicas = range(len(all_ensembles))
 
         # This encodes how the SampleSets are at each time step. This is the
         # trajectory number (from trajs_AB/trajs_BA) for each ensemble
@@ -89,7 +84,6 @@ class TISAnalysisTester(object):
         for descr in descriptions:
             set_trajectories = ([self.trajs_AB[d] for d in descr[:3]]
                                 + [self.trajs_BA[d] for d in descr[3:]])
-            zipped = zip(set_trajectories, all_ensembles, replicas)
             sample_set = paths.SampleSet([
                 paths.Sample(trajectory=traj,
                              ensemble=ens,
@@ -233,7 +227,6 @@ class TestFluxToPandas(TISAnalysisTester):
                                           names=["State", "Interface"])
         self.expected_series = pd.Series(values, name="Flux", index=index)
 
-
     def test_default_flux_sort(self):
         shuffled = self.all_pairs[:]
         random.shuffle(shuffled)
@@ -251,20 +244,20 @@ class TestFluxToPandas(TISAnalysisTester):
 
     @raises(KeyError)
     def test_flux_matrix_pd_unknown_str(self):
-        series = flux_matrix_pd(self.fluxes, sort_method="foo")
+        flux_matrix_pd(self.fluxes, sort_method="foo")
 
 
 class TestDictFlux(TISAnalysisTester):
     def setup(self):
         super(TestDictFlux, self).setup()
         self.innermost_interface_A = \
-                self.sampling_ensembles_for_transition(self.mistis,
-                                                       self.state_A,
-                                                       self.state_B)[0]
+            self.sampling_ensembles_for_transition(self.mistis,
+                                                   self.state_A,
+                                                   self.state_B)[0]
         self.innermost_interface_B = \
-                self.sampling_ensembles_for_transition(self.mistis,
-                                                       self.state_B,
-                                                       self.state_A)[0]
+            self.sampling_ensembles_for_transition(self.mistis,
+                                                   self.state_B,
+                                                   self.state_A)[0]
 
         self.flux_dict = {(self.state_A, self.innermost_interface_A): 1.0,
                           (self.state_B, self.innermost_interface_B): 1.0}
@@ -379,7 +372,7 @@ class TestMinusMoveFlux(TISAnalysisTester):
     def test_get_minus_steps(self):
         all_mistis_steps = self.mistis_steps + self.mistis_minus_steps
         mistis_minus_steps = \
-                self.mistis_minus_flux._get_minus_steps(all_mistis_steps)
+            self.mistis_minus_flux._get_minus_steps(all_mistis_steps)
         assert_equal(len(mistis_minus_steps), len(self.mistis_minus_steps))
         assert_items_equal(mistis_minus_steps, self.mistis_minus_steps)
         # this could be repeated for MSTIS, but why?
@@ -390,12 +383,12 @@ class TestMinusMoveFlux(TISAnalysisTester):
         expected_flux = 1.0 / (avg_t_in + avg_t_out)
 
         mistis_flux = \
-                self.mistis_minus_flux.calculate(self.mistis_minus_steps)
+            self.mistis_minus_flux.calculate(self.mistis_minus_steps)
         for flux in mistis_flux.values():  # all values are the same
             assert_almost_equal(flux, expected_flux)
 
         mstis_flux = \
-                self.mstis_minus_flux.calculate(self.mstis_minus_steps)
+            self.mstis_minus_flux.calculate(self.mstis_minus_steps)
         for flux in mstis_flux.values():  # all values are the same
             assert_almost_equal(flux, expected_flux)
 
@@ -416,7 +409,7 @@ class TestMinusMoveFlux(TISAnalysisTester):
         ])
         scheme = paths.DefaultScheme(bad_mistis)
         scheme.build_move_decision_tree()
-        minus_flux = MinusMoveFlux(scheme)
+        MinusMoveFlux(scheme)
 
 
 class TestPathLengthHistogrammer(TISAnalysisTester):
@@ -512,11 +505,10 @@ class TestFullHistogramMaxLambda(TISAnalysisTester):
             interfaces=mistis_AB.interfaces.volumes,
             orderparameter=mistis_AB.orderparameter
         )
-        mistis_AB_histogrammer = FullHistogramMaxLambdas(
-            transition=modified_transition,
-            hist_parameters={'bin_width': 0.1, 'bin_range': (-0.1, 1.1)}
-        )
-
+        FullHistogramMaxLambdas(transition=modified_transition,
+                                hist_parameters={'bin_width': 0.1,
+                                                 'bin_range': (-0.1, 1.1)
+                                                 })
 
 
 class TestConditionalTransitionProbability(TISAnalysisTester):
@@ -605,7 +597,7 @@ class TestTotalCrossingProbability(TISAnalysisTester):
         mstis_BA_tcp = TotalCrossingProbability(mstis_BA_max_lambda)
         tcp_BA = mstis_BA_tcp.calculate(self.mstis_steps)
         for (x, result) in results.items():
-            assert_almost_equal(tcp_AB(x), result)
+            assert_almost_equal(tcp_BA(x), result)
 
 
 class TestStandardTransitionProbability(TISAnalysisTester):
@@ -743,6 +735,7 @@ class TestTransitionDictResults(TISAnalysisTester):
         assert_frame_equal(pd_mistis, pd_mstis)
         assert_frame_equal(pd_mistis, pd_result)
 
+
 class TestTISAnalysis(TISAnalysisTester):
     def _make_tis_analysis(self, network):
         # NOTE: this might be useful as a description of the overall nested
@@ -784,7 +777,7 @@ class TestTISAnalysis(TISAnalysisTester):
 
     def test_bad_access_cached_results(self):
         no_results = self._make_tis_analysis(self.mistis)
-        rate = self.mistis_analysis._access_cached_result('rate')
+        _ = self.mistis_analysis._access_cached_result('rate')
         # use a try/except here instead of @raises so that we also test that
         # the calculated version (previous line) works as expected
         try:
@@ -813,7 +806,7 @@ class TestTISAnalysis(TISAnalysisTester):
 
     def test_flux_through_state(self):
         flux_dict = {(t.stateA, t.interfaces[0]): 0.1
-                      for t in self.mistis.sampling_transitions}
+                     for t in self.mistis.sampling_transitions}
         flux_dict.update({(self.state_A, self.state_A): 0.5})
         tis = TISAnalysis(
             network=self.mistis,
@@ -861,7 +854,6 @@ class TestTISAnalysis(TISAnalysisTester):
         for trans_pair in pairs:
             assert_almost_equal(mistis_tp[trans_pair], 0.125)
             assert_almost_equal(mstis_tp[trans_pair], 0.125)
-
 
     def test_transition_probability(self):
         pairs = [(self.state_A, self.state_B), (self.state_B, self.state_A)]
@@ -989,21 +981,21 @@ class TestStandardTISAnalysis(TestTISAnalysis):
     @raises(TypeError)
     def test_bad_no_flux(self):
         network = self.mistis
-        tis_analysis = StandardTISAnalysis(
-            network=network,
-            max_lambda_calcs={t: {'bin_width': 0.1,
-                                  'bin_range': (-0.1, 1.1)}
-                              for t in network.sampling_transitions},
-        )
+        StandardTISAnalysis(network=network,
+                            max_lambda_calcs={
+                                t: {'bin_width': 0.1,
+                                    'bin_range': (-0.1, 1.1)}
+                                for t in network.sampling_transitions}
+                            )
 
     @raises(RuntimeError)
     def test_bad_max_lambda_calcs(self):
         network = self.mistis
-        tis_analysis = StandardTISAnalysis(
-            network=network,
-            flux_method=DictFlux({(t.stateA, t.interfaces[0]): 0.1
-                                  for t in network.sampling_transitions}),
-        )
+        StandardTISAnalysis(network=network,
+                            flux_method=DictFlux(
+                                {(t.stateA, t.interfaces[0]): 0.1
+                                 for t in network.sampling_transitions})
+                            )
 
     def test_init_ensemble_histogrammer_max_lambda(self):
         network = self.mistis
@@ -1057,7 +1049,7 @@ class TestStandardTISAnalysis(TestTISAnalysis):
                 samp = paths.Sample(trajectory=traj,
                                     ensemble=minus_ens,
                                     replica=replica[state])
-                sample_set = paths.SampleSet([samp])
+                _ = paths.SampleSet([samp])
                 change = paths.AcceptedSampleMoveChange(
                     samples=[samp],
                     mover=minus_mover,
@@ -1101,5 +1093,3 @@ class TestStandardTISAnalysis(TestTISAnalysis):
         # think this is a problem in the fake data, not the simulation.
         for flux in analysis.flux_matrix.values():
             assert_almost_equal(flux, expected_flux)
-
-

--- a/openpathsampling/tests/test_tis_analysis.py
+++ b/openpathsampling/tests/test_tis_analysis.py
@@ -505,10 +505,10 @@ class TestFullHistogramMaxLambda(TISAnalysisTester):
             interfaces=mistis_AB.interfaces.volumes,
             orderparameter=mistis_AB.orderparameter
         )
-        FullHistogramMaxLambdas(transition=modified_transition,
-                                hist_parameters={'bin_width': 0.1,
-                                                 'bin_range': (-0.1, 1.1)
-                                                 })
+        FullHistogramMaxLambdas(
+            transition=modified_transition,
+            hist_parameters={'bin_width': 0.1, 'bin_range': (-0.1, 1.1)}
+        )
 
 
 class TestConditionalTransitionProbability(TISAnalysisTester):
@@ -981,21 +981,21 @@ class TestStandardTISAnalysis(TestTISAnalysis):
     @raises(TypeError)
     def test_bad_no_flux(self):
         network = self.mistis
-        StandardTISAnalysis(network=network,
-                            max_lambda_calcs={
-                                t: {'bin_width': 0.1,
-                                    'bin_range': (-0.1, 1.1)}
-                                for t in network.sampling_transitions}
-                            )
+        StandardTISAnalysis(
+            network=network,
+            max_lambda_calcs={t: {'bin_width': 0.1,
+                                  'bin_range': (-0.1, 1.1)}
+                              for t in network.sampling_transitions}
+        )
 
     @raises(RuntimeError)
     def test_bad_max_lambda_calcs(self):
         network = self.mistis
-        StandardTISAnalysis(network=network,
-                            flux_method=DictFlux(
-                                {(t.stateA, t.interfaces[0]): 0.1
+        StandardTISAnalysis(
+            network=network,
+            flux_method=DictFlux({(t.stateA, t.interfaces[0]): 0.1
                                  for t in network.sampling_transitions})
-                            )
+        )
 
     def test_init_ensemble_histogrammer_max_lambda(self):
         network = self.mistis


### PR DESCRIPTION
This started with the warnings:
```python
DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
    Z_new = pd.Series(index=hists)
```
and 
```python
FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
```
Which led to the same warnings as #881 after touching the files.

This also fixes some pep8 complaints and a small logic error in `TestTotalCrossingProbability.test_calculate()` where the result was checked for AB twice instead of both `AB` and `BA` 