### PR TITLE
Fix missing newline in the VisitAllStatesEnsemble

### DIFF
--- a/openpathsampling/ensembles/visit_all_states.py
+++ b/openpathsampling/ensembles/visit_all_states.py
@@ -29,7 +29,7 @@ def default_state_progress_report(n_steps, found_states, all_states,
     if timestep is not None:
         report_str += " [{}]".format(str(n_steps * timestep))
     report_str += (". Found states [{found_states}]. "
-                   "Looking for [{missing_states}].")
+                   "Looking for [{missing_states}].\n")
     found_states_str = ",".join([s.name for s in found_states])
     # list comprehension instead of sets (to preseve order)
     missing_states = [s for s in all_states if s not in found_states]

--- a/openpathsampling/tests/test_visit_all_states.py
+++ b/openpathsampling/tests/test_visit_all_states.py
@@ -21,9 +21,9 @@ def test_default_state_progress_report():
 
     f = default_state_progress_report  # keep on one line
     assert f(n_steps, found_vol, all_vol) == \
-            "Ran 100 frames. Found states [A,B]. Looking for [C,D]."
+            "Ran 100 frames. Found states [A,B]. Looking for [C,D].\n"
     assert f(n_steps, found_vol, all_vol, tstep) == \
-            "Ran 100 frames [50.0]. Found states [A,B]. Looking for [C,D]."
+            "Ran 100 frames [50.0]. Found states [A,B]. Looking for [C,D].\n"
 
 def extract_info_from_default_report(report):
     pattern = (r"Ran ([0-9]*) frames. Found states \[(.*)\]\. "
@@ -42,9 +42,9 @@ def extract_info_from_default_report(report):
 
 def test_extract_info_from_default_report():
     reports = {
-        0: "Ran 0 frames. Found states []. Looking for [A,B,C,D].",
-        3: "Ran 3 frames. Found states [A,B]. Looking for [C,D].",
-        7: "Ran 7 frames. Found states [A,B,C,D]. Looking for []."
+        0: "Ran 0 frames. Found states []. Looking for [A,B,C,D].\n",
+        3: "Ran 3 frames. Found states [A,B]. Looking for [C,D].\n",
+        7: "Ran 7 frames. Found states [A,B,C,D]. Looking for [].\n"
     }
     results = {
         0: [0, {}, {'A', 'B', 'C', 'D'}],


### PR DESCRIPTION
This is a tiny fix. Missing a newline prevented refresh from working correctly in a terminal (apparently it wasn't a problem in notebooks, where I had used it before).

Literally adds 2 characters. I'll merge as soon as tests pass; no need to wait for review.