### PR TITLE
Add GromacsEngine to docs

### DIFF
--- a/docs/engines/gromacs.rst
+++ b/docs/engines/gromacs.rst
@@ -1,0 +1,15 @@
+.. _gromacs:
+
+.. module:: openpathsampling.engines.gromacs
+
+Gromacs OPS Engine
+==================
+
+
+.. autosummary::
+   :toctree: ../api/generated/
+
+   Engine
+   ExternalMDSnapshot
+   engine.GromacsEngine
+

--- a/docs/examples/miscellaneous/gromacs.rst
+++ b/docs/examples/miscellaneous/gromacs.rst
@@ -1,0 +1,21 @@
+.. gromacs_ad_example:
+
+Using Gromacs for the Alanine Dipeptide example
+===============================================
+
+This is the same as the introductory example using flexible length TPS,
+except that it uses Gromacs as the MD engine instead of OpenMM.
+
+-----
+
+.. notebook:: examples/gromacs/AD_tps_1_trajectory.ipynb
+   :skip_exceptions:
+
+-----
+
+.. notebook:: examples/gromacs/AD_tps_2a_run_flex.ipynb
+   :skip_exceptions:
+
+-----
+.. notebook:: examples/gromacs/AD_tps_3a_analysis_flex.ipynb
+   :skip_exceptions:

--- a/docs/videos.rst
+++ b/docs/videos.rst
@@ -30,9 +30,9 @@ trajectory based rare events.  That workshop included a "hackathon" software
 development period, and the video includes suggestions for several such
 projects (many of which have since been added to OPS).
 
-* `More about that workshop <https://www.cecam.org/workshop1802/>`_
+* `More about that workshop <https://www.cecam.org/workshop1802/>`__
 * `Other presentations from that workshop
-  <https://training.e-cam2020.eu/spaces/5ca35151e4b0fed490540623>`_
+  <https://training.e-cam2020.eu/spaces/5ca35151e4b0fed490540623>`__
 
 .. Using OpenPathSampling
 .. ----------------------
@@ -54,7 +54,7 @@ This video comes from a "hackathon"-style workshop, and discusses various
 parts of OPS that would be of interest to new contributors to the code.
 
 * `More about that workshop
-  <https://www.lorentzcenter.nl/lc/web/2017/905/info.php3?wsid=905>`_
+  <https://www.lorentzcenter.nl/lc/web/2017/905/info.php3?wsid=905>`__
 * `Other presentations from that workshop
-  <https://training.e-cam2020.eu/collection/5a609bd0e4b070ac6b9789ca>`_
+  <https://training.e-cam2020.eu/collection/5a609bd0e4b070ac6b9789ca>`__
 

--- a/openpathsampling/analysis/channel_analysis.py
+++ b/openpathsampling/analysis/channel_analysis.py
@@ -21,12 +21,6 @@ class ChannelAnalysis(StorableNamedObject):
     replica: int
         replica ID to analyze from the steps, default is 0.
 
-    Attributes
-    ----------
-    treat_multiples
-    switching_matrix
-    residence_times
-    total_time
     """
     def __init__(self, steps, channels, replica=0):
         super(ChannelAnalysis, self).__init__()
@@ -138,16 +132,18 @@ class ChannelAnalysis(StorableNamedObject):
     @property
     def treat_multiples(self):
         """
-        string :
-            method for handling paths that match multiple channels. Allowed
-            values are
-            * 'newest': use the most recent channel entered
-            * 'oldest': use the least recent channel entered
-            * 'multiple': treat multiple channels as a new type of channel,
-               e.g., 'a' and 'b' because 'a,b'
-            * 'all': treat each channel individually, despite overlaps. For
-              switching, this is the same as ???. For status, this is the
-              same as 'multiple'
+        string : method for handling paths that match multiple channels
+
+        Allowed values are:
+
+        * 'newest': use the most recent channel entered
+        * 'oldest': use the least recent channel entered
+        * 'multiple': treat multiple channels as a new type of channel, e.g.,
+          'a' and 'b' becomes 'a,b'
+        * 'all': treat each channel individually, despite overlaps. For
+          switching, this is the same as ???. For status, this is the
+          same as 'multiple'
+
         """
         return self._treat_multiples
 
@@ -430,7 +426,7 @@ class ChannelAnalysis(StorableNamedObject):
     @property
     def residence_times(self):
         """
-        dict {string: list of int} :
+        Dict[string, List[int]] :
             number of steps spent in each channel for each "stay" in that
             channel; allows calculations of distribution properties. Depends
             on ``treat_multiples``, see details there.
@@ -446,7 +442,7 @@ class ChannelAnalysis(StorableNamedObject):
     @property
     def total_time(self):
         """
-        dict {string: int} :
+        Dict[string, int] :
             total number of steps spent in each channel for each "stay" in
             that channel. Depends on ``treat_multiples``, see details there.
         """

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -93,6 +93,7 @@ class DynamicsEngine(StorableNamedObject):
     on_retry : str or callable
         the behaviour when a try is started. Since you have already generated
         some trajectory you might not restart completely. Possibilities are
+
         1.  `full` will restart completely and use the initial frames (default)
         2.  `50%` will cut the existing in half but keeping at least the initial
         3.  `remove_interval` will remove as many frames as the `interval`

--- a/openpathsampling/engines/external_snapshots/snapshot.py
+++ b/openpathsampling/engines/external_snapshots/snapshot.py
@@ -91,7 +91,7 @@ class ExternalMDSnapshot(BaseSnapshot):
         """Remove internal details from snapshot.
 
         These details should always be accessible later using
-        :method:`.load_details`. Removing them allows them memory to be
+        :meth:`.load_details`. Removing them allows them memory to be
         freed.
         """
         self._xyz = None

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -90,10 +90,11 @@ class GromacsEngine(ExternalEngine):
     options : dict
         Dictionary of option name to value. Gromacs-specific option names
         are
-            * ``gmx_prefix``: Prefix to gromacs commands, which are run as
-              ``{gmx_prefix}command``. Default is 'gmx ' (note the space).
-              This allows you to use either Gromacs 4 or Gromacs 5, as well
-              as specifying the path to your version of Gromacs.
+
+            * ``gmx_executable``: Prefix to gromacs commands, which are run
+              as ``{gmx_prefix}command``. Default is 'gmx ' (note the
+              space).  This allows you to use either Gromacs 4 or Gromacs 5,
+              as well as specifying the path to your version of Gromacs.
             * ``grompp_args``: Additional arguments to ``grompp``. The
               defaults take ``-c {self.gro} -f {self.mdp} -p {self.top}
               -t {self.input_file}``, where the input filename is set by

--- a/openpathsampling/engines/snapshot.py
+++ b/openpathsampling/engines/snapshot.py
@@ -17,19 +17,17 @@ from . import features as feats
 class BaseSnapshot(StorableObject):
     """
     Simulation snapshot. Contains references to a configuration and momentum
+
+    Parameters
+    ----------
+    topology : openpathsamping.Topology, default: None
+        The corresponding topology used with this Snapshot. Can also be None
+        and means no topology is specified.
     """
 
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, topology=None):
-        """
-        Attributes
-        ----------
-        topology : openpathsamping.Topology, default: None
-            The corresponding topology used with this Snapshot. Can also be None
-            and means no topology is specified.
-        """
-
         super(BaseSnapshot, self).__init__()
 
         self._reversed = None

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -265,20 +265,19 @@ class CVDefinedVolume(Volume):
     """
     Volume defined by a range of a collective variable `collectivevariable`.
 
-    Contains all snapshots `snap` for which `lamba_min <
+    Contains all snapshots `snap` for which `lamba_min <=
     collectivevariable(snap)` and `lambda_max > collectivevariable(snap)`.
+
+    Parameters
+    ----------
+    collectivevariable : :class:`.CollectiveVariable`
+        the CV to base the volume on
+    lambda_min : float
+        minimum value of the CV
+    lambda_max : float
+        maximum value of the CV
     """
     def __init__(self, collectivevariable, lambda_min=0.0, lambda_max=1.0):
-        '''
-        Attributes
-        ----------
-        collectivevariable : CollectiveVariable
-            the collectivevariable object
-        lambda_min : float
-            the minimal allowed collectivevariable
-        lambda_max: float
-            the maximal allowed collectivevariable
-        '''
         super(CVDefinedVolume, self).__init__()
         self.collectivevariable = collectivevariable
         try:


### PR DESCRIPTION
We've had the Gromacs engine working in OPS since version 1.1, and the docstrings were in place and there was an example in the `examples/` directory. However, none of this stuff had made it to the website. This PR puts it there.

While I'm at it, I'm going to try to clean up a few complaints that I see coming from sphinx.