### PR TITLE
Progress indicators for path density; move summary

### DIFF
--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -1,5 +1,6 @@
 import openpathsampling as paths
 from openpathsampling.numerics import SparseHistogram
+from openpathsampling.progress import SimpleProgress
 
 from collections import Counter
 import numpy as np
@@ -230,7 +231,7 @@ class BresenhamLikeInterpolation(BresenhamInterpolation):
 
 # should path histogram be moved to the generic histogram.py? Seems to be
 # independent of the fact that this is actually OPS
-class PathHistogram(SparseHistogram):
+class PathHistogram(SimpleProgress, SparseHistogram):
     """
     N-dim sparse histogram for trajectories.
 
@@ -312,7 +313,8 @@ class PathHistogram(SparseHistogram):
         """
         if weights is None:
             weights = [1.0] * len(trajectories)
-        for (traj, w) in zip(trajectories, weights):
+        for (traj, w) in self.progress(list(zip(trajectories, weights))):
+            # list so that progress can know the length
             self.add_trajectory(traj, w)
         return self._histogram.copy()
 
@@ -384,7 +386,7 @@ class PathDensityHistogram(PathHistogram):
             weights = [1.0] * len(trajectories)
 
         # TODO: add something so that we don't recalc the same traj twice
-        for (traj, w) in zip(trajectories, weights):
+        for (traj, w) in self.progress(list(zip(trajectories, weights))):
             cv_traj = [cv(traj) for cv in self.cvs]
             self.add_trajectory(list(zip(*cv_traj)), w)
 

--- a/openpathsampling/high_level/move_scheme.py
+++ b/openpathsampling/high_level/move_scheme.py
@@ -4,6 +4,7 @@ import warnings
 
 import openpathsampling as paths
 from openpathsampling.tools import refresh_output
+from openpathsampling.progress import SimpleProgress
 
 from . import move_strategy
 from .move_strategy import levels as strategy_levels
@@ -21,7 +22,7 @@ MoveAcceptanceAnalysisLine = collections.namedtuple(
     'move_name n_accepted n_trials expected_frequency'
 )
 
-class MoveAcceptanceAnalysis(object):
+class MoveAcceptanceAnalysis(SimpleProgress):
     """Class to manage analysis of move acceptance.
 
     One of the powerful things about OPS is the :class:`.MoveChange` object,
@@ -69,7 +70,7 @@ class MoveAcceptanceAnalysis(object):
         self : :class:`.MoveAcceptanceAnalysis`
             returns self for possible chaining
         """
-        for step in steps:
+        for step in self.progress(steps):
             self._calculate_step_acceptance(step)
         self._n_steps += len(steps)
         return self

--- a/openpathsampling/tests/test_movescheme.py
+++ b/openpathsampling/tests/test_movescheme.py
@@ -93,6 +93,8 @@ def _make_null_mover_step(mccycle, path_sim_mover, null_mover):
 
 class TestMoveAcceptanceAnalysis(object):
     def setup(self):
+        self.HAS_TQDM = paths.progress.HAS_TQDM
+        paths.progress.HAS_TQDM = False
         paths.InterfaceSet._reset()
         cvA = paths.FunctionCV(name="xA", f=lambda s : s.xyz[0][0])
         cvB = paths.FunctionCV(name="xB", f=lambda s : -s.xyz[0][0])
@@ -143,6 +145,9 @@ class TestMoveAcceptanceAnalysis(object):
         self.analysis = {'empty': acceptance_empty,
                          'normal': acceptance,
                          'with_null': acceptance_null}
+
+    def teardown(self):
+        paths.progress.HAS_TQDM = self.HAS_TQDM
 
     @pytest.mark.parametrize('step_num', [0, 1, 2, 3, 4])
     def test_calculate_step_acceptance(self, step_num):

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -27,9 +27,14 @@ from collections import Counter
 
 class PathHistogramTester(object):
     def setup(self):
+        self.HAS_TQDM = paths.progress.HAS_TQDM
+        paths.progress.HAS_TQDM = False
         self.trajectory = [(0.1, 0.3), (2.1, 3.1), (1.7, 1.4),
                            (1.6, 0.6), (0.1, 1.4), (2.2, 3.3)]
         self.diag = [(0.25, 0.25), (2.25, 2.25)]
+
+    def teardown(self):
+        paths.progress.HAS_TQDM = self.HAS_TQDM
 
     def test_nopertraj(self):
         counter = collections.Counter(self.expected_bins)
@@ -130,9 +135,14 @@ class TestPathHistogramBesenhamInterpolate(PathHistogramTester):
 class TestPathHistogram(object):
     # tests of fundamental things in PathHistogram, not interpolators
     def setup(self):
+        self.HAS_TQDM = paths.progress.HAS_TQDM
+        paths.progress.HAS_TQDM = False
         self.trajectory = [(0.1, 0.3), (2.1, 3.1), (1.7, 1.4),
                            (1.6, 0.6), (0.1, 1.4), (2.2, 3.3)]
         self.diag = [(0.25, 0.25), (2.25, 2.25)]
+
+    def teardown(self):
+        paths.progress.HAS_TQDM = self.HAS_TQDM
 
     def test_add_with_weight(self):
         hist = PathHistogram(left_bin_edges=(0.0, 0.0),
@@ -190,6 +200,8 @@ class TestPathHistogram(object):
 
 class TestPathDensityHistogram(object):
     def setup(self):
+        self.HAS_TQDM = paths.progress.HAS_TQDM
+        paths.progress.HAS_TQDM = False
         id_cv = paths.FunctionCV("Id",
                                  lambda snap : snap.xyz[0][0])
         sin_cv = paths.FunctionCV("sin",
@@ -205,6 +217,9 @@ class TestPathDensityHistogram(object):
         # interpolate: (1, 0, 0)
         self.traj2 = make_1d_traj([0.6, 0.7])
         # [(2, 1, 0), (2, 1, 1)]
+
+    def teardown(self):
+        paths.progress.HAS_TQDM = self.HAS_TQDM
 
     def test_histogram_no_weights(self):
         hist = PathDensityHistogram(self.cvs, self.left_bin_edges,


### PR DESCRIPTION
This adds progress indicators (i.e., tqdm support; introduced in #882) for path density/path histogram objects, as well as for the `move_summary`. With tqdm installed, you automatically get progress bars for these analyses.