### PR TITLE
DirectSimulation should use engine.start/.stop

### DIFF
--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -78,6 +78,7 @@ class ExternalEngine(DynamicsEngine):
         self.first_frame_in_file = first_frame_in_file
         self._traj_num = -1
         self._current_snapshot = template
+        self.n_frames_since_start = None
 
     @property
     def current_snapshot(self):

--- a/openpathsampling/pathsimulators/direct_md.py
+++ b/openpathsampling/pathsimulators/direct_md.py
@@ -132,7 +132,7 @@ class DirectSimulation(PathSimulator):
             if self.storage is not None:
                 local_traj += [frame]
 
-        self.engine.stop()
+        self.engine.stop(local_traj)
 
         if self.storage is not None:
             self.storage.save(local_traj)

--- a/openpathsampling/pathsimulators/direct_md.py
+++ b/openpathsampling/pathsimulators/direct_md.py
@@ -84,6 +84,7 @@ class DirectSimulation(PathSimulator):
         was_in_interface = {p: None for p in self.flux_pairs}
         local_traj = paths.Trajectory([self.initial_snapshot])
         self.engine.current_snapshot = self.initial_snapshot
+        self.engine.start()
         for step in xrange(n_steps):
             frame = self.engine.generate_next_frame()
 
@@ -130,6 +131,8 @@ class DirectSimulation(PathSimulator):
 
             if self.storage is not None:
                 local_traj += [frame]
+
+        self.engine.stop()
 
         if self.storage is not None:
             self.storage.save(local_traj)


### PR DESCRIPTION
From an email report from a user:

> I tried to follow this example: 
>
> http://openpathsampling.org/latest/examples/mistis.html#toy-model-mistis
>
> to set up openpathsampling.DirectSimulation for my flux_pairs, but got this error: 
> 
> ```python
> AttributeError: 'GromacsEngine' has no attribute 'n_frames_since_start', nor does its options dictionary
> ```

Two problems, both solved in this PR:

1. `ExternalEngine.n_frames_since_start` is only set in its `.start()` method. It should be set (to `None`) in `__init__`.
2. `DirectSimulation` is not using the `.start()` and `.stop()` methods. This didn't matter for OpenMM/toy engine, but does for external engines like Gromacs.

NOTE: I would not recommend using `DirectSimulation` on external engines. `DirectSimulation` is mainly useful to get fluxes from toy engine runs or other simulations where you don't want to save trajectory frames. It's better to run a trajectory normally and use `TrajectoryTransitionAnalysis`.