### PR TITLE
"Hooks" for PathSampling

### DIFF
--- a/openpathsampling/beta/hooks.py
+++ b/openpathsampling/beta/hooks.py
@@ -106,7 +106,10 @@ class StorageHook(PathSimulatorHook):
     def after_step(self, sim, step_number, step_info, state, results,
                    hook_state):
         if self.storage is not None:
-            self.storage.save(results)
+            try:
+                self.storage.stash(results)
+            except AttributeError:
+                self.storage.save(results)
             if step_number % self.frequency == 0:
                 self.storage.sync_all()
 

--- a/openpathsampling/beta/hooks.py
+++ b/openpathsampling/beta/hooks.py
@@ -113,10 +113,6 @@ class StorageHook(PathSimulatorHook):
     def after_simulation(self, sim, hook_state):
         if self.storage is not None:
             self.storage.sync_all()
-        if sim.storage is not None:
-            if self.storage is not sim.storage:
-                # can/should call sync_all only once per storage
-                sim.storage.sync_all()
 
 
 class ShootFromSnapshotsOutputHook(PathSimulatorHook):

--- a/openpathsampling/beta/hooks.py
+++ b/openpathsampling/beta/hooks.py
@@ -60,6 +60,7 @@ class StorageHook(PathSimulatorHook):
     """
     implemented_for = ['before_simulation', 'after_step',
                        'after_simulation']
+
     def __init__(self, storage=None, frequency=None):
         self.storage = storage
         self.frequency = frequency
@@ -348,14 +349,15 @@ class PathSamplingOutputHook(PathSimulatorHook):
         self._initial_time = time.time()
 
     def before_step(self, sim, step_number, step_info, state):
-        nn, n_steps = step_info
-        elapsed = time.time() - self._initial_time
-        paths.tools.refresh_output(
-            "Working on Monte Carlo cycle number " + str(step_number)
-            + "\n" + paths.tools.progress_string(nn, n_steps, elapsed),
-            refresh=self.allow_refresh,
-            output_stream=self.output_stream
-        )
+        if step_number % self.status_update_frequency == 0:
+            nn, n_steps = step_info
+            elapsed = time.time() - self._initial_time
+            paths.tools.refresh_output(
+                "Working on Monte Carlo cycle number " + str(step_number)
+                + "\n" + paths.tools.progress_string(nn, n_steps, elapsed),
+                refresh=self.allow_refresh,
+                output_stream=self.output_stream
+            )
 
     def after_simulation(self, sim):
         paths.tools.refresh_output(

--- a/openpathsampling/beta/hooks.py
+++ b/openpathsampling/beta/hooks.py
@@ -114,7 +114,11 @@ class StorageHook(PathSimulatorHook):
 
     def after_simulation(self, sim, hook_state):
         if self.storage is not None:
-            sim.storage.sync_all()
+            self.storage.sync_all()
+        if sim.storage is not None:
+            if self.storage is not sim.storage:
+                # can/should call sync_all only once per storage
+                sim.storage.sync_all()
 
 
 class ShootFromSnapshotsOutputHook(PathSimulatorHook):
@@ -253,7 +257,7 @@ class LiveVisualizerHook(PathSimulatorHook):
     def status_update_frequency(self, val):
         self._status_update_frequency = val
 
-    def before_simulation(self, sim):
+    def before_simulation(self, sim, **kwargs):
         self._simulation = sim
 
     def after_step(self, sim, step_number, step_info, state, results,
@@ -344,7 +348,7 @@ class PathSamplingOutputHook(PathSimulatorHook):
     def status_update_frequency(self, val):
         self._status_update_frequency = val
 
-    def before_simulation(self, sim):
+    def before_simulation(self, sim, **kwargs):
         self._simulation = sim
         self._initial_time = time.time()
 
@@ -359,7 +363,7 @@ class PathSamplingOutputHook(PathSimulatorHook):
                 output_stream=self.output_stream
             )
 
-    def after_simulation(self, sim):
+    def after_simulation(self, sim, hook_state):
         paths.tools.refresh_output(
             "DONE! Completed " + str(sim.step) + " Monte Carlo cycles.\n",
             refresh=False,

--- a/openpathsampling/beta/hooks.py
+++ b/openpathsampling/beta/hooks.py
@@ -53,6 +53,10 @@ class StorageHook(PathSimulatorHook):
         if self.storage is not None:
             self.storage.save(results)
             if step_number % self.frequency == 0:
+                if sim.sample_set is not None:
+                    # some PathSimulators never set their sample_set
+                    # but PathSimulator.__init__ sets it to None
+                    sim.sample_set.sanity_check()
                 self.storage.sync_all()
 
     def after_simulation(self, sim, hook_state):
@@ -96,10 +100,113 @@ class ShootFromSnapshotsOutputHook(PathSimulatorHook):
         )
 
 
-# TODO: here are some other hooks to implement in the future
-# class LiveVisualizerHook(PathSimulatorHook):
-    # pass
+class LiveVisualizerHook(PathSimulatorHook):
+    """
+    LiveVisualization using the :class:`openpathsampling.StepVisualizer2D`.
+
+    Updates every `simulation.status_update_frequency` MCSteps, where
+    simulation is the `PathSimulator` this hook is attached to.
+
+    NOTE: You will have to set PathSimulator.allow_refresh = False
+          **before** the first simulation run. Otherwise the LiveVisualization
+          will get refreshed away (i.e. deleted) right after creation.
+
+    Parameters
+    ----------
+    live_visualizer : :class:`openpathsampling.StepVisualizer2D`
+        default `None` uses the simulations live_visualizer
+    status_update_frequency : int
+        number of steps between two refreshs of the visualization;
+        default `None` uses the simulations value (PathSampling default=1)
+    """
+    # NOTE: we visualize after step, because otherwise the 'next' MCstep
+    #       would depend on the 'previous' one just for viualization
+    #       this deviates from the previous implementation but avoids
+    #       having to pass the previous MCstep to before_step hooks
+    implemented_for = ['before_simulation', 'after_step']
+    def __init__(self, live_visualizer=None, status_update_frequency=None):
+        self.live_visualizer = live_visualizer
+        self.status_update_frequency = status_update_frequency
+
+    def before_simulation(self, sim):
+        if self.live_visualizer is None:
+            self.live_visualizer = sim.live_visualizer
+        if self.status_update_frequency is None:
+            self.status_update_frequency = sim.status_update_frequency
+        # TODO/FIXME: when a user modifies sim.status_update_frequency
+        #    the hook does not update (as I think most people would expect)
+        #    instead you would have to modify the hook or attach a new one
+        #    the way below reproduces the current/previous behaviour, but makes
+        #    it pointless to pass them to init if we overwrite anyway...
+        #    we could modify them to properties in pathsampling and set them
+        #    here too if modified? Or recreate the corresponding hook?
+        #if self.live_visualizer is not sim.live_visualizer:
+        #    self.live_visualizer = sim.live_visualizer
+        #if self.status_update_frequency is not sim.status_update_frequency:
+        #    self.status_update_frequency = sim.status_update_frequency
+
+    def after_step(self, sim, step_number, step_info, state, results,
+                   hook_state):
+        if step_number % self.status_update_frequency == 0:
+            # do we visualize this step?
+            if self.live_visualizer is not None and results is not None:
+                # do we visualize at all?
+                self.live_visualizer.draw_ipynb(results)
 
 
-# class PathSamplingOutputHook(PathSimulatorHook):
-    # pass
+class PathSamplingOutputHook(PathSimulatorHook):
+    """
+    Default (serial) output for PathSamplingSimulation objects.
+
+    Updates every `PathSampling.status_update_frequency` MCSteps.
+
+    Parameters
+    ----------
+    output_stream : stream
+        where to write the results; default ``None`` uses the simulation's
+        ``output_stream``
+    allow_refresh : bool
+        whether to allow refresh (see :meth:`.refresh_output`); default
+        ``None`` uses the simulation's value
+    status_update_frequency : int
+        number of steps between two refreshs of the visualization;
+        default `None` uses the simulations value (PathSampling default=1)
+    """
+    implemented_for = ['before_simulation', 'before_step', 'after_simulation']
+
+    def __init__(self, output_stream=None, allow_refresh=None,
+                 status_update_frequency=None):
+        self.output_stream = output_stream
+        self.allow_refresh = allow_refresh
+        self.status_update_frequency = status_update_frequency
+
+    def before_simulation(self, sim):
+        if self.output_stream is None:
+            self.output_stream = sim.output_stream
+        if self.allow_refresh is None:
+            self.allow_refresh = sim.allow_refresh
+        if self.status_update_frequency is None:
+            self.status_update_frequency = sim.status_update_frequency
+        # TODO/FIXME: same considerations as for LiveVisualizerHook!
+        #if self.output_stream is not sim.output_stream:
+        #    self.output_stream = sim.output_stream
+        #if self.allow_refresh is not sim.allow_refresh:
+        #    self.allow_refresh = sim.allow_refresh
+        #if self.status_update_frequency is not sim.status_update_frequency:
+        #    self.status_update_frequency = sim.status_update_frequency
+
+    def before_step(self, sim, step_number, step_info, state):
+        nn, n_steps, elapsed = step_info
+        paths.tools.refresh_output(
+            "Working on Monte Carlo cycle number " + str(step_number)
+            + "\n" + paths.tools.progress_string(nn, n_steps, elapsed),
+            refresh=self.allow_refresh,
+            output_stream=self.output_stream
+        )
+
+    def after_simulation(self, sim):
+        paths.tools.refresh_output(
+            "DONE! Completed " + str(sim.step) + " Monte Carlo cycles.\n",
+            refresh=False,
+            output_stream=self.output_stream
+        )

--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -253,22 +253,20 @@ class PathSampling(PathSimulator):
         self.output_stream = original_output_stream
 
     def run(self, n_steps):
-        mcstep = None
         hook_state = None
         self.run_hooks('before_simulation', sim=self)
         for nn in range(n_steps):
-            self.run_one_step()
+            step_info = nn, n_steps
+            hook_state, mcstep = self.run_one_step(step_info, hook_state)
 
         # after simulation hooks
         self.run_hooks('after_simulation', sim=self)
 
-    def run_one_step(self):
+    def run_one_step(self, step_info, hook_state=None):
         # bookkeeping and before_step hooks
         self.step += 1
         logger.info("Beginning MC cycle " + str(self.step))
         step_number = self.step
-        # TODO: anything else we could want in the step info?
-        step_info = (nn, n_steps)
         self.run_hooks('before_step', sim=self, step_number=step_number,
                        step_info=step_info, state=self.sample_set)
 
@@ -306,3 +304,4 @@ class PathSampling(PathSimulator):
                                     results=mcstep,
                                     hook_state=hook_state
                                     )
+        return hook_state, mcstep

--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -265,6 +265,7 @@ class PathSampling(PathSimulator):
             time_start = time.time()
             elapsed_total = time.time() - initial_time
             # TODO: anything else we could want in the step info?
+            #       atm this is tailored for PathSamplingOutputHook
             step_info = (nn, n_steps, elapsed_total)
             self.run_hooks('before_step', sim=self, step_number=step_number,
                            step_info=step_info, state=self.sample_set)

--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -244,17 +244,17 @@ class PathSampling(PathSimulator):
 
     def run(self, n_steps):
         hook_state = None
-        self.run_hooks('before_simulation', sim=self)
+        self.run_hooks('before_simulation', sim=self, n_steps=n_steps)
         for nn in range(n_steps):
             step_info = nn, n_steps
             hook_state, mcstep = self.run_one_step(step_info, hook_state)
 
         # after simulation hooks
-        self.run_hooks('after_simulation', sim=self)
+        self.run_hooks('after_simulation', sim=self, hook_state=hook_state)
 
     def run_until_n_accepted(self, n_accepted):
         hook_state = None
-        self.run_hooks('before_simulation', sim=self)
+        self.run_hooks('before_simulation', sim=self, n_accepted=n_accepted)
         cur_acc = 0
         step_count = 0
         while cur_acc < n_accepted:
@@ -265,7 +265,7 @@ class PathSampling(PathSimulator):
                 cur_acc += 1
 
         # after simulation hooks
-        self.run_hooks('after_simulation', sim=self)
+        self.run_hooks('after_simulation', sim=self, hook_state=hook_state)
 
     def run_one_step(self, step_info, hook_state=None):
         # bookkeeping and before_step hooks

--- a/openpathsampling/step_visualizer_2D.py
+++ b/openpathsampling/step_visualizer_2D.py
@@ -75,36 +75,36 @@ class StepVisualizer2D(object):
             self.draw_arrowhead(trial, accepted=False)
         return self.fig
 
-
     def draw_background(self):
         # draw the background
-        if self.background is None:
-            self.fig, ax = plt.subplots()
+        if self.background is not None:
+            if self._save_bg_axes is None:
+                self._save_bg_axes = self.background.axes
+            self.fig = self.background
+            for ax in self.fig.axes:
+                self.fig.delaxes(ax)
+            for ax in self._save_bg_axes:
+                self.fig.add_axes(ax)
+            self.ax = self.fig.axes[0].twinx()
+            self.ax.cla()
+        else:
+            # create empty figure and axis
+            self.fig, self.ax = plt.subplots()
+            # set the empty axis and figure as our new 'background'
+            # this avoids flickering if we always recreate the figure
             self.background = self.fig
-            ax.set_xlim(self.xlim)
-            ax.set_ylim(self.ylim)
-
-        if self._save_bg_axes is None:
             self._save_bg_axes = self.background.axes
-        self.fig = self.background
-        for ax in self.fig.axes:
-            self.fig.delaxes(ax)
-        for ax in self._save_bg_axes:
-            self.fig.add_axes(ax)
-
-        self.ax = self.fig.axes[0].twinx()
-        self.ax.cla()
+            # create a copy axis to draw on
+            self.ax = self.fig.axes[0].twinx()
 
         self.ax.set_xlim(self.xlim)
         self.ax.set_ylim(self.ylim)
         return
 
-
     def draw(self, mcstep):
         self.draw_samples(mcstep.active)
         self.draw_trials(mcstep.change)
         return self.fig
-
 
     def draw_ipynb(self, mcstep):
         try:

--- a/openpathsampling/tests/pathsimulators/test_hooks.py
+++ b/openpathsampling/tests/pathsimulators/test_hooks.py
@@ -186,8 +186,6 @@ class TestStorageHook(object):
         self.storage.save.assert_called_once()
         if step_num in [0, 10]:
             self.storage.sync_all.assert_called_once()
-            # also check that we performed the sample sanity-ckeck
-            self.simulation.sample_set.sanity_check.assert_called_once()
 
     def test_after_simulation(self):
         self.hook.after_simulation(self.simulation, {})

--- a/openpathsampling/tests/pathsimulators/test_hooks.py
+++ b/openpathsampling/tests/pathsimulators/test_hooks.py
@@ -232,7 +232,8 @@ class TestPathSamplingOutputHook(object):
                                     allow_refresh=False)
         self.empty_hook = PathSamplingOutputHook()
         self.hook = PathSamplingOutputHook(output_stream=self.stream,
-                                           allow_refresh=False)
+                                           allow_refresh=False,
+                                           status_update_frequency=1)
 
     @pytest.mark.parametrize('hook_name', ['empty', 'std'])
     def test_before_simulation(self, hook_name):

--- a/openpathsampling/tests/pathsimulators/test_hooks.py
+++ b/openpathsampling/tests/pathsimulators/test_hooks.py
@@ -7,6 +7,11 @@ import io
 import sys
 import time
 import re
+if ((sys.version_info.major < 3)
+        or (sys.version_info.major == 3 and sys.version_info.minor < 4)):
+    # re.fullmatch was introduced in py v3.4
+    # but match should also do the trick
+    re.fullmatch = re.match
 
 import pytest
 try:

--- a/openpathsampling/tests/pathsimulators/test_hooks.py
+++ b/openpathsampling/tests/pathsimulators/test_hooks.py
@@ -292,6 +292,6 @@ class TestPathSamplingOutputHook(object):
     def test_after_simulation(self):
         # set step_number in PathSampling Mock
         self.simulation.configure_mock(step=2)
-        self.hook.after_simulation(self.simulation)
+        self.hook.after_simulation(self.simulation, hook_state={})
         contents = self.stream.getvalue()
         assert contents == "DONE! Completed 2 Monte Carlo cycles.\n"


### PR DESCRIPTION
This builds on #755 and should only be merged after that.

It adds hook support to the `PathSampling`, the `PathSamplingOutputHook` and the `LiveVisualizerHook` including tests.

Please let me know if htere is anything to improve!
I also have some open questions/TODOs, in particular:
1. if a user sets any attribute that controls the behaviour of the hook on the `PathSimulator` object it is only read once at the start of the simulation and only if the hooks value for that attribute is `None` (see e.g. `output_stream`, `save_frequency` and `storage`). This is potentially confusing, as I would expect to be able to set these attributes on the `PathSimulator` to influence the behaviour of the currently attached hooks. I am mot really sure how to adress this. Potential solutions include removing these attributes from the `PathSimulator` and only set them on hook creation. Another option is to make them properties to either (re)set the respective attributes on the hooks (or at least warn the user that it could not work as intended) if he/she sets the attributes on the `Pathsimulator`

2. Previously the LiveVisualizer was called before the MCstep but visualizing the previous step. I moved the LiveVisualization to after step. This enables visualization of the step that just finished and avoids that the beginning of the next step depends on the previous one. But it also means that visualization only works if the serial OutputHook has `allow_refresh=False`, otherwise the plot will get refreshed away.

3. The `step_info` passed to the `after_step` hooks from the `PathSampling` is specifically tailored for the `PathSamplingOutputHook`, i.e. it only takes the variables the OutputHook needs (current step, total steps, total elapsed time). @dwhswenson any ideas what else we could want/need in there in the future?
