### PR TITLE
Set reject_bytes=False for ujson >= 3

### DIFF
--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -48,6 +48,10 @@ else:
     opcode_arg_width = 2
     opcode_no_arg_width = 0
 
+if int(ujson.__version__.split(".")[0]) <= 2:
+    ujson_kwargs = dict()
+else:
+    ujson_kwargs = {"reject_bytes": False}
 
 class ObjectJSON(object):
     """
@@ -565,7 +569,7 @@ class ObjectJSON(object):
         else:
             simplified = self.simplify(obj)
         try:
-            json_str = ujson.dumps(simplified)
+            json_str = ujson.dumps(simplified, **ujson_kwargs)
         except TypeError as e:
             err = (
                 'Cannot convert object of type `%s` to json. '


### PR DESCRIPTION
Since `ujson` version `3.0.0` tests based on openpathsampling saving start failing.

`ujson.dump()` now has default keyword `reject_bytes=True` which leads to issues for dumping CV's (which contain bytestrings).

I had to do some import `if` statements as well as this keyword is not valid for `ujson` = `2.x`  (And I supposed you still wanted to support that version.)
 