### PR TITLE
support ujson v3 (part 2)

### DIFF
--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -560,7 +560,7 @@ class ObjectJSON(object):
 
     def to_json(self, obj, base_type=''):
         simplified = self.simplify(obj, base_type)
-        return ujson.dumps(simplified)
+        return ujson.dumps(simplified, **ujson_kwargs)
 
     def to_json_object(self, obj):
         if hasattr(obj, 'base_cls') \


### PR DESCRIPTION
This is the same that @sroet did in #917. I only added the `ujson_kwargs` to another call to `ujson.dumps`.