### PR TITLE
fix numpy 1.19 DeprecationWarning: tostring() 

### DIFF
--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -1,8 +1,6 @@
-import openpathsampling as paths
 import collections
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 from openpathsampling.progress import SimpleProgress
 
@@ -10,6 +8,7 @@ try:
     from collections import abc
 except ImportError:
     import collections as abc
+
 
 # based on http://stackoverflow.com/a/3387975
 class TransformedDict(abc.MutableMapping):
@@ -72,7 +71,7 @@ class SnapshotByCoordinateDict(TransformedDict):
     (e.g., committor analysis).
     """
     def __init__(self, *args, **kwargs):
-        hash_fcn = lambda x : x.coordinates.tostring()
+        hash_fcn = lambda x: x.coordinates.tobytes()
         super(SnapshotByCoordinateDict, self).__init__(hash_fcn,
                                                        *args, **kwargs)
 
@@ -108,7 +107,7 @@ class ShootingPointAnalysis(SimpleProgress, SnapshotByCoordinateDict):
             MC steps to analyze
         """
         for step in self.progress(steps):
-            total = self.analyze_single_step(step)
+            self.analyze_single_step(step)
 
     def analyze_single_step(self, step):
         """
@@ -136,7 +135,7 @@ class ShootingPointAnalysis(SimpleProgress, SnapshotByCoordinateDict):
 
             total = collections.Counter(
                 {state: sum([int(state(pt)) for pt in test_points])
-                            for state in self.states}
+                 for state in self.states}
             )
             total_count = sum(total.values())
             # TODO: clarify assertion (at least one endpoint in state)
@@ -197,7 +196,7 @@ class ShootingPointAnalysis(SimpleProgress, SnapshotByCoordinateDict):
         analyzer = ShootingPointAnalysis(None, states)
         for step in run_results:
             key = step[0]
-            total = collections.Counter({step[1] : 1})
+            total = collections.Counter({step[1]: 1})
             try:
                 analyzer[key] += total
             except KeyError:
@@ -226,12 +225,13 @@ class ShootingPointAnalysis(SimpleProgress, SnapshotByCoordinateDict):
             mapping labels given by label_function to the committor value
         """
         if label_function is None:
-            label_function = lambda s : s
+            label_function = lambda s: s
         results = {}
         for k in self:
             out_key = label_function(k)
             counter_k = self[k]
-            committor = float(counter_k[state]) / sum([counter_k[s] for s in self.states])
+            committor = float(counter_k[state]) / sum([counter_k[s]
+                                                       for s in self.states])
             results[out_key] = committor
         return results
 
@@ -267,8 +267,8 @@ class ShootingPointAnalysis(SimpleProgress, SnapshotByCoordinateDict):
         """
         rehashed = self.rehash(new_hash)
         r_store = rehashed.store
-        count_all = {k : sum(r_store[k].values()) for k in r_store}
-        count_state = {k : r_store[k][state] for k in r_store}
+        count_all = {k: sum(r_store[k].values()) for k in r_store}
+        count_state = {k: r_store[k][state] for k in r_store}
         ndim = self._get_key_dim(list(r_store.keys())[0])
         if ndim == 1:
             (all_hist, b) = np.histogram(list(count_all.keys()),

--- a/openpathsampling/tests/test_network.py
+++ b/openpathsampling/tests/test_network.py
@@ -336,13 +336,13 @@ class TestMISTISNetwork(TestMultipleStateTIS):
             (self.stateA, self.ifacesA, self.stateC)
         ], strict_sampling=True)
         transAB = [trans for trans in strict.sampling_transitions
-                   if (trans.stateA == self.stateA and 
+                   if (trans.stateA == self.stateA and
                        trans.stateB == self.stateB)][0]
         transAC = [trans for trans in strict.sampling_transitions
-                   if (trans.stateA == self.stateA and 
+                   if (trans.stateA == self.stateA and
                        trans.stateB == self.stateC)][0]
         transBA = [trans for trans in strict.sampling_transitions
-                   if (trans.stateA == self.stateB and 
+                   if (trans.stateA == self.stateB and
                        trans.stateB == self.stateA)][0]
         ensAB = transAB.ensembles[0]
         ensAC = transAC.ensembles[0]

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -7,7 +7,7 @@ from builtins import object
 from .test_helpers import (raises_with_message_like, data_filename,
                            CalvinistDynamics, make_1d_traj,
                            assert_items_equal)
-from nose.tools import (assert_equal, assert_not_equal, raises,
+from nose.tools import (assert_equal, raises,
                         assert_almost_equal, assert_true)
 # from nose.plugins.skip import SkipTest
 
@@ -24,10 +24,11 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.engines').setLevel(logging.CRITICAL)
 
+
 class TestAbstract(object):
     @raises_with_message_like(TypeError, "Can't instantiate abstract class")
     def test_abstract_volume(self):
-        mover = PathSimulator()
+        PathSimulator()
 
 
 class TestFullBootstrapping(object):
@@ -70,11 +71,11 @@ class TestFullBootstrapping(object):
         bootstrap_AB_maxlength = paths.FullBootstrapping(
             transition=self.tisAB,
             snapshot=self.snapA,
-            initial_max_length = 3,
+            initial_max_length=3,
             engine=engine
         )
         bootstrap_AB_maxlength.output_stream = open(os.devnull, "w")
-        gs = bootstrap_AB_maxlength.run(build_attempts=1)
+        bootstrap_AB_maxlength.run(build_attempts=1)
 
     def test_first_traj_ensemble(self):
         traj_starts_in = make_1d_traj([-0.2, -0.1, 0.1, -0.1])
@@ -147,7 +148,7 @@ class TestFullBootstrapping(object):
         bootstrap2.output_stream = open(os.devnull, "w")
         # make sure this is where we get the error
         try:
-            gs2 = bootstrap2.run()
+            bootstrap2.run()
         except RuntimeError:
             pass
 
@@ -160,7 +161,7 @@ class TestFullBootstrapping(object):
             engine=engine,
         )
         bootstrap.output_stream = open(os.devnull, "w")
-        gs = bootstrap.run(max_ensemble_rounds=1)
+        bootstrap.run(max_ensemble_rounds=1)
 
 
 class TestShootFromSnapshotsSimulation(object):
@@ -172,7 +173,7 @@ class TestShootFromSnapshotsSimulation(object):
         # As a test system, let's use 1D motion on a flat potential. If the
         # velocity is positive, you right the state on the right. If it is
         # negative, you hit the state on the left.
-        pes = toys.LinearSlope(m=[0.0], c=[0.0]) # flat line
+        pes = toys.LinearSlope(m=[0.0], c=[0.0])  # flat line
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
         integrator = toys.LeapfrogVerletIntegrator(0.1)
         options = {
@@ -184,7 +185,7 @@ class TestShootFromSnapshotsSimulation(object):
         self.snap0 = toys.Snapshot(coordinates=np.array([[0.0]]),
                                    velocities=np.array([[1.0]]),
                                    engine=self.engine)
-        cv = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
+        cv = paths.FunctionCV("Id", lambda snap: snap.coordinates[0][0])
         starting_volume = paths.CVDefinedVolume(cv, -0.01, 0.01)
         forward_ensemble = paths.LengthEnsemble(5)
         backward_ensemble = paths.LengthEnsemble(3)
@@ -235,7 +236,7 @@ class TestCommittorSimulation(object):
         # As a test system, let's use 1D motion on a flat potential. If the
         # velocity is positive, you right the state on the right. If it is
         # negative, you hit the state on the left.
-        pes = toys.LinearSlope(m=[0.0], c=[0.0]) # flat line
+        pes = toys.LinearSlope(m=[0.0], c=[0.0])  # flat line
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
         integrator = toys.LeapfrogVerletIntegrator(0.1)
         options = {
@@ -247,12 +248,12 @@ class TestCommittorSimulation(object):
         self.snap0 = toys.Snapshot(coordinates=np.array([[0.0]]),
                                    velocities=np.array([[1.0]]),
                                    engine=self.engine)
-        cv = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
+        cv = paths.FunctionCV("Id", lambda snap: snap.coordinates[0][0])
         self.left = paths.CVDefinedVolume(cv, float("-inf"), -1.0)
         self.right = paths.CVDefinedVolume(cv, 1.0, float("inf"))
-        self.state_labels = {"Left" : self.left,
-                             "Right" : self.right,
-                             "None" : ~(self.left | self.right)}
+        self.state_labels = {"Left": self.left,
+                             "Right": self.right,
+                             "None": ~(self.left | self.right)}
 
         randomizer = paths.NoModification()
 
@@ -295,7 +296,7 @@ class TestCommittorSimulation(object):
     def test_committor_run(self):
         self.simulation.run(n_per_snapshot=20)
         assert_equal(len(self.simulation.storage.steps), 20)
-        counts = {'fwd' : 0, 'bkwd' : 0}
+        counts = {'fwd': 0, 'bkwd': 0}
         for step in self.simulation.storage.steps:
             step.active.sanity_check()  # traj is in ensemble
             traj = step.active[0].trajectory
@@ -402,10 +403,10 @@ class TestCommittorSimulation(object):
         sim.output_stream = open(os.devnull, 'w')
         sim.run(50)
         assert_equal(len(sim.storage.steps), 50)
-        counts = {'None-Right' : 0,
-                  'Left-None' : 0,
-                  'None-Left' : 0,
-                  'Right-None' : 0}
+        counts = {'None-Right': 0,
+                  'Left-None': 0,
+                  'None-Left': 0,
+                  'Right-None': 0}
         for step in sim.storage.steps:
             step.active.sanity_check()  # traj is in ensemble
             traj = step.active[0].trajectory
@@ -422,6 +423,7 @@ class TestCommittorSimulation(object):
         assert_true(counts['None-Right'] > 0)
         assert_equal(sum(counts.values()), 50)
 
+
 class TestDirectSimulation(object):
     def setup(self):
         pes = toys.HarmonicOscillator(A=[1.0], omega=[1.0], x0=[0.0])
@@ -436,7 +438,7 @@ class TestDirectSimulation(object):
         self.snap0 = toys.Snapshot(coordinates=np.array([[0.0]]),
                                    velocities=np.array([[1.0]]),
                                    engine=self.engine)
-        cv = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
+        cv = paths.FunctionCV("Id", lambda snap: snap.coordinates[0][0])
         self.cv = cv
         self.center = paths.CVDefinedVolume(cv, -0.2, 0.2)
         self.interface = paths.CVDefinedVolume(cv, -0.3, 0.3)
@@ -492,8 +494,8 @@ class TestDirectSimulation(object):
                       (self.center, self.extra): 1,
                       (self.extra, self.center): 1})
         assert_equal(self.sim.transitions,
-                     {(self.center, self.outside) : [3, 2],
-                      (self.outside, self.center) : [3],
+                     {(self.center, self.outside): [3, 2],
+                      (self.outside, self.center): [3],
                       (self.center, self.extra): [3],
                       (self.extra, self.center): [2]})
 
@@ -562,18 +564,24 @@ class TestDirectSimulation(object):
         # interface alpha); and `X_ab` (outside interface alpha and beta).
         cv1 = self.cv
         cv2 = paths.FunctionCV("abs_sin",
-                               lambda snap : np.abs(np.sin(snap.xyz[0][0])))
-        state = paths.CVDefinedVolume(cv1, old_div(-np.pi,8.0), old_div(np.pi,8.0))
-        other_state = paths.CVDefinedVolume(cv1, -5.0/8.0*np.pi, -3.0/8.0*np.pi)
+                               lambda snap: np.abs(np.sin(snap.xyz[0][0])))
+        state = paths.CVDefinedVolume(cv1,
+                                      old_div(-np.pi, 8.0),
+                                      old_div(np.pi, 8.0))
+        other_state = paths.CVDefinedVolume(cv1,
+                                            -5.0/8.0 * np.pi,
+                                            -3.0/8.0 * np.pi)
         alpha = paths.CVDefinedVolume(cv1, float("-inf"), 3.0/8.0*np.pi)
-        beta = paths.CVDefinedVolume(cv2, float("-inf"), old_div(np.sqrt(2),2.0))
+        beta = paths.CVDefinedVolume(cv2,
+                                     float("-inf"),
+                                     old_div(np.sqrt(2), 2.0))
         # approx     alpha: x < 1.17   beta: abs(sin(x)) < 0.70
         S = 0              # cv1 =  0.00; cv2 = 0.00
-        I = old_div(np.pi,5.0)      # cv1 =  0.63; cv2 = 0.59
+        I = old_div(np.pi, 5.0)      # cv1 =  0.63; cv2 = 0.59
         X_a = np.pi        # cv1 =  3.14; cv2 = 0.00
-        X_b = old_div(-np.pi,3.0)   # cv1 = -1.05; cv2 = 0.87
-        X_ab = old_div(np.pi,2.0)   # cv1 =  1.57; cv2 = 1.00
-        other = old_div(-np.pi,2.0) # cv1 = -1.57; cv2 = 1.00
+        X_b = old_div(-np.pi, 3.0)    # cv1 = -1.05; cv2 = 0.87
+        X_ab = old_div(np.pi, 2.0)    # cv1 =  1.57; cv2 = 1.00
+        other = old_div(-np.pi, 2.0)  # cv1 = -1.57; cv2 = 1.00
         # That hack is utterly crazy, but I'm kinda proud of it!
         predetermined = [S, S, I, X_a,   # (2) first exit
                          S, X_a,         # (4) cross A
@@ -690,6 +698,6 @@ class TestPathSampling(object):
         final_snaps = all_snaps(self.sim.sample_set)
         assert initial_snaps & final_snaps == set([])
         # test time reversal
-        init_xyz = set(s.xyz.tostring() for s in initial_snaps)
-        final_xyz = set(s.xyz.tostring() for s in final_snaps)
+        init_xyz = set(s.xyz.tobytes() for s in initial_snaps)
+        final_xyz = set(s.xyz.tobytes() for s in final_snaps)
         assert init_xyz & final_xyz == set([])

--- a/openpathsampling/tests/test_shooting_point_analysis.py
+++ b/openpathsampling/tests/test_shooting_point_analysis.py
@@ -4,9 +4,8 @@ from builtins import zip
 from builtins import range
 from past.utils import old_div
 from builtins import object
-from nose.tools import (assert_equal, assert_not_equal, raises,
+from nose.tools import (assert_equal, raises,
                         assert_almost_equal, assert_true, assert_in)
-from nose.plugins.skip import SkipTest
 from numpy.testing import assert_array_almost_equal
 from .test_helpers import (make_1d_traj, data_filename, assert_items_equal,
                            assert_same_items)
@@ -30,9 +29,9 @@ logging.getLogger('openpathsampling.sample').setLevel(logging.CRITICAL)
 
 class TestTransformedDict(object):
     def setup(self):
-        self.untransformed = {(0, 1) : "a", (1, 2) : "b", (2, 3) : "c"}
-        self.transformed = {0 : "a", 1 : "b", 2 : "c"}
-        self.hash_function = lambda x : x[0]
+        self.untransformed = {(0, 1): "a", (1, 2): "b", (2, 3): "c"}
+        self.transformed = {0: "a", 1: "b", 2: "c"}
+        self.hash_function = lambda x: x[0]
         self.empty = TransformedDict(self.hash_function, {})
         self.test_dict = TransformedDict(self.hash_function,
                                          self.untransformed)
@@ -40,24 +39,24 @@ class TestTransformedDict(object):
     def test_initialization(self):
         assert_equal(self.test_dict.store, self.transformed)
         assert_equal(self.test_dict.hash_representatives,
-                     {0: (0,1), 1: (1,2), 2: (2,3)})
+                     {0: (0, 1), 1: (1, 2), 2: (2, 3)})
 
     def test_set_get(self):
-        self.empty[(5,6)] = "d"
+        self.empty[(5, 6)] = "d"
         assert_equal(self.empty.store, {5: "d"})
-        assert_equal(self.empty.hash_representatives, {5: (5,6)})
-        assert_equal(self.empty[(5,6)], "d")
+        assert_equal(self.empty.hash_representatives, {5: (5, 6)})
+        assert_equal(self.empty[(5, 6)], "d")
 
     def test_update(self):
-        self.test_dict.update({(5,6): "d"})
+        self.test_dict.update({(5, 6): "d"})
         assert_equal(self.test_dict.store,
-                     {0 : "a", 1 : "b", 2 : "c", 5 : "d"})
+                     {0: "a", 1: "b", 2: "c", 5: "d"})
         assert_equal(self.test_dict.hash_representatives,
-                     {0: (0,1), 1: (1,2), 2: (2,3), 5: (5,6)})
+                     {0: (0, 1), 1: (1, 2), 2: (2, 3), 5: (5, 6)})
 
     def test_del(self):
         del self.test_dict[(0, 1)]
-        assert_equal(self.test_dict.store, {1 : "b", 2 : "c"})
+        assert_equal(self.test_dict.store, {1: "b", 2: "c"})
 
     def test_iter(self):
         iterated = [k for k in self.test_dict]
@@ -69,10 +68,10 @@ class TestTransformedDict(object):
         assert_equal(len(self.empty), 0)
 
     def test_rehash(self):
-        rehashed = self.test_dict.rehash(lambda x : x[1])
+        rehashed = self.test_dict.rehash(lambda x: x[1])
         assert_equal(rehashed.store, {1: "a", 2: "b", 3: "c"})
         assert_equal(rehashed.hash_representatives,
-                     {1: (0,1), 2: (1,2), 3: (2,3)})
+                     {1: (0, 1), 2: (1, 2), 3: (2, 3)})
 
 
 class TestSnapshotByCoordinateDict(object):
@@ -80,8 +79,8 @@ class TestSnapshotByCoordinateDict(object):
         self.empty_dict = SnapshotByCoordinateDict()
         coords_A = np.array([[0.0, 0.0]])
         coords_B = np.array([[1.0, 1.0]])
-        self.key_A = coords_A.tostring()
-        self.key_B = coords_B.tostring()
+        self.key_A = coords_A.tobytes()
+        self.key_B = coords_B.tobytes()
         self.snapA1 = peng.toy.Snapshot(coordinates=coords_A,
                                         velocities=np.array([[0.0, 0.0]]))
         self.snapA2 = peng.toy.Snapshot(coordinates=coords_A,
@@ -105,7 +104,7 @@ class TestShootingPointAnalysis(object):
         paths.progress.HAS_TQDM = False
         # taken from the TestCommittorSimulation
         import openpathsampling.engines.toy as toys
-        pes = toys.LinearSlope(m=[0.0], c=[0.0]) # flat line
+        pes = toys.LinearSlope(m=[0.0], c=[0.0])  # flat line
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
         descriptor = peng.SnapshotDescriptor.construct(
             toys.Snapshot,
@@ -128,7 +127,7 @@ class TestShootingPointAnalysis(object):
             'n_steps_per_frame': 5
         }
         self.engine = toys.Engine(options=options, topology=topology)
-        cv = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
+        cv = paths.FunctionCV("Id", lambda snap: snap.coordinates[0][0])
         self.left = paths.CVDefinedVolume(cv, float("-inf"), -1.0)
         self.right = paths.CVDefinedVolume(cv, 1.0, float("inf"))
 
@@ -155,7 +154,7 @@ class TestShootingPointAnalysis(object):
         self.storage.close()
         if os.path.isfile(self.filename):
             os.remove(self.filename)
-        paths.EngineMover.default_engine = None # set by Committor
+        paths.EngineMover.default_engine = None  # set by Committor
 
     def test_shooting_point_analysis(self):
         assert_equal(len(self.analyzer), 2)
@@ -185,7 +184,7 @@ class TestShootingPointAnalysis(object):
         ensemble = network.all_ensembles[0]
         mover = paths.PathReversalMover(ensemble)
         scheme = paths.LockedMoveScheme(mover, network)
-        init_conds=scheme.initial_conditions_from_trajectories([init_traj])
+        init_conds = scheme.initial_conditions_from_trajectories([init_traj])
         assert_equal(len(init_conds), 1)
         self.storage.close()
         self.storage = paths.Storage(self.filename, "w")
@@ -223,7 +222,7 @@ class TestShootingPointAnalysis(object):
             assert_equal(committor_B[snap],
                          old_div(float(self.analyzer[snap][self.right]), 20.0))
 
-        rehash = lambda snap : 2 * snap.xyz[0][0]
+        rehash = lambda snap: 2 * snap.xyz[0][0]
         committor_A_rehash = self.analyzer.committor(self.left, rehash)
         orig_values = sorted(committor_A.values())
         rehash_values = sorted(committor_A_rehash.values())
@@ -232,7 +231,7 @@ class TestShootingPointAnalysis(object):
             assert_in(rehash(snap), list(committor_A_rehash.keys()))
 
     def test_committor_histogram_1d(self):
-        rehash = lambda snap : 2 * snap.xyz[0][0]
+        rehash = lambda snap: 2 * snap.xyz[0][0]
         input_bins = [-0.05, 0.05, 0.15, 0.25, 0.35, 0.45]
         hist, bins = self.analyzer.committor_histogram(rehash, self.left,
                                                        input_bins)
@@ -244,18 +243,18 @@ class TestShootingPointAnalysis(object):
         assert_array_almost_equal(bins, input_bins)
 
     def test_committor_histogram_2d(self):
-        rehash = lambda snap : (snap.xyz[0][0], 2 * snap.xyz[0][0])
+        rehash = lambda snap: (snap.xyz[0][0], 2 * snap.xyz[0][0])
         input_bins = [-0.05, 0.05, 0.15, 0.25, 0.35, 0.45]
         hist, b_x, b_y = self.analyzer.committor_histogram(rehash, self.left,
                                                            input_bins)
-        assert_equal(hist.shape, (5,5))
+        assert_equal(hist.shape, (5, 5))
         for i in range(5):
             for j in range(5):
-                if (i,j) in [(0, 0), (1, 2)]:
+                if (i, j) in [(0, 0), (1, 2)]:
                     pass
-                    assert_true(hist[(i,j)] > 0)
+                    assert_true(hist[(i, j)] > 0)
                 else:
-                    assert_true(np.isnan(hist[(i,j)]))
+                    assert_true(np.isnan(hist[(i, j)]))
 
         # this may change later to bins[0]==bins[1]==input_bins
         assert_array_almost_equal(input_bins, b_x)
@@ -264,16 +263,15 @@ class TestShootingPointAnalysis(object):
     @raises(RuntimeError)
     def test_committor_histogram_3d(self):
         # only 1D and 2D are supported
-        rehash = lambda snap : (snap.xyz[0][0], 2 * snap.xyz[0][0], 0.0)
+        rehash = lambda snap: (snap.xyz[0][0], 2 * snap.xyz[0][0], 0.0)
         input_bins = [-0.05, 0.05, 0.15, 0.25, 0.35, 0.45]
         hist, b_x, b_y = self.analyzer.committor_histogram(rehash, self.left,
                                                            input_bins)
 
     def test_to_pandas(self):
         df1 = self.analyzer.to_pandas()
-        df2 = self.analyzer.to_pandas(lambda x : x.xyz[0][0])
-        assert_equal(df1.shape, (2,2))
+        df2 = self.analyzer.to_pandas(lambda x: x.xyz[0][0])
+        assert_equal(df1.shape, (2, 2))
         assert_items_equal(df1.index, list(range(2)))
         assert_same_items(df2.index, [0.0, 0.1])
         assert_same_items(df1.columns, [self.left.name, self.right.name])
-


### PR DESCRIPTION
Since `numpy=1.19` `array.tostring()` is deprecated, and should be replaced with `.tobytes()` (present in `numpy >=1.9`), this PR does that for OPS.

The leftover `>40000` warnings in the test suite come from `NetCDF4` which has been fixed in [this PR](https://github.com/Unidata/netcdf4-python/pull/1024) (I tested this locally and it passes without these DerpecationWarnings).

Also cleaned some `pep8` complaints on the files I touched.