### PR TITLE
Pin ujson<2; nbconvert<6

### DIFF
--- a/devtools/testing_requirements.txt
+++ b/devtools/testing_requirements.txt
@@ -1,5 +1,5 @@
 nose
-pytest!=5.3.4
+pytest
 pytest-cov
 coveralls
 ipynbtest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 matplotlib
 sphinx
 jupyter
+nbconvert<6
 jinja2
 netcdf4
 runipy

--- a/pinned
+++ b/pinned
@@ -1,1 +1,1 @@
-pytest!=5.3.4
+ujson<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     svgwrite
     networkx
     matplotlib
-    ujson
+    ujson<2
     mdtraj
     # mdtraj is not technically required, but we co-package it because it is
     # required for many integrations with other packages


### PR DESCRIPTION
*  Pinning ujson < 2 resolves #922. (@hejung -- this is correct, right?) Long term solution is that the new storage I'm working on doesn't require ujson.
*  Pinning nbconvert < 6 fixes a [problem in current builds of docs](https://travis-ci.org/github/openpathsampling/openpathsampling/jobs/727635606#L4066-L4075). Something fails and then hangs in our custom notebook conversion sphinx plugin (written by @jhprinz and no longer maintained). Long term solution is to move to nbsphinx.
* Removed pin on pytest 5.3.4. Still shouldn't use that specific version, but pytest is up to 6.0 now, so I see no need to keep a pin to avoid a [single specific regression](https://github.com/openpathsampling/openpathsampling/pull/893#issuecomment-576643126).