### PR TITLE
Improve CV storage error message about missing templates

### DIFF
--- a/openpathsampling/netcdfplus/stores/attribute.py
+++ b/openpathsampling/netcdfplus/stores/attribute.py
@@ -128,8 +128,9 @@ class PseudoAttributeStore(UniqueNamedObjectStore):
 
             else:
                 raise RuntimeError(
-                    'Need either at least one stored snapshot or a '
-                    'template snapshot to determine type and shape of the CV.')
+                    'Need either at least one stored object to use as a '
+                    'template to determine type and shape of the CV. '
+                    'No items in store: ' + str(self.key_store(cv)))
 
         self.key_store(cv).add_attribute(
             ValueStore,


### PR DESCRIPTION
In netcdfplus, storing CVs (`PseudoAttribute`s) requires a template object to be already stored. Originally we only had CVs that mapped snapshots to computed values, but eventually @jhprinz added the ability to use other objects (like trajectories) as inputs. However, the error message didn't get updated, and it is very confusing to get an error message saying to save a snapshot when you already have a snapshot saved (but need to save a trajectory).

This whole issue will be irrelevant with SimStore, but might as well fix the confusing error message.