### PR TITLE
Fix collections.abc DeprecationWarning in sample.py

### DIFF
--- a/openpathsampling/sample.py
+++ b/openpathsampling/sample.py
@@ -7,7 +7,8 @@ from openpathsampling.netcdfplus import DelayedLoader
 
 from openpathsampling.tools import refresh_output
 
-from collections import Counter, Mapping
+from collections import Counter
+from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 

--- a/openpathsampling/sample.py
+++ b/openpathsampling/sample.py
@@ -8,7 +8,13 @@ from openpathsampling.netcdfplus import DelayedLoader
 from openpathsampling.tools import refresh_output
 
 from collections import Counter
-from collections.abc import Mapping
+
+import sys
+if sys.version_info > (3, ):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Going from 5570cd31 to ace9d7e7 and running the tests surfaced another 
```
/home/sroet/github_files/openpathsampling/openpathsampling/sample.py:10: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Counter, Mapping
```

This solves that one (`Counter` still has to be imported from base `collections`)