### PR TITLE
OpenMM instantaneous temp should work if positions not set

### DIFF
--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -46,7 +46,6 @@ class TestOpenMMSnapshot(object):
             velocities=self.template.velocities,
             engine=self.engine
         )
-        # self.engine.current_snapshot = self.template
 
     def test_masses_from_file(self):
         masses = self.template.masses


### PR DESCRIPTION
Currently, for an OpenMM snapshot, `snapshot.instantaneous_temperature` will raise `Exception: Particle positions have not been set` if no snapshot has been loaded into the engine (e.g., via setting `engine.current_snapshot`). Analysis will frequently not set that, and so it should be possible to calculate the instantaneous temperature without having done that.

This updates the tests for this and other OpenMM engine-based features to ensure that they work if the engine hasn't set its snapshot yet.