### PR TITLE
SimStore: Tags

### DIFF
--- a/openpathsampling/experimental/simstore/custom_json.py
+++ b/openpathsampling/experimental/simstore/custom_json.py
@@ -208,7 +208,7 @@ def uuid_object_to_dict(obj):
     dct = replace_uuid(dct, uuid_encoding=encode_uuid)
     dct.update({'__class__': obj.__class__.__name__,
                 '__module__': obj.__class__.__module__})
-    name = getattr(obj, 'name', None)
+    name = getattr(obj, '_name', None)
     if name and 'name' not in dct:
         dct['name'] = name
     return dct

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -38,7 +38,7 @@ universal_sql_meta = {
 
 def make_columns(table_name, schema, sql_schema_metadata):
     columns = []
-    if table_name not in ['uuid', 'tables']:
+    if table_name not in universal_schema:
         columns.append(sql.Column('idx', sql.Integer,
                                   primary_key=True))
         columns.append(sql.Column('uuid', sql.String))
@@ -302,7 +302,7 @@ class SQLStorageBackend(StorableNamedObject):
                 raise TypeError("Schema registration problem. Your schema "
                                 "may already have tables of the same names.")
 
-            if table_name not in ['uuid', 'tables']:
+            if table_name not in universal_schema:
                 self._add_table_to_tables_list(table_name,
                                                schema[table_name],
                                                table_to_class[table_name])
@@ -411,6 +411,14 @@ class SQLStorageBackend(StorableNamedObject):
     def load_storable_function_table(self, table_name):
         return {row['uuid']: row['value']
                 for row in self.table_iterator(table_name)}
+
+    def add_tag(self, table_name, name, content):
+        table = self.metadata.tables[table_name]
+
+        with self.engine.connect() as conn:
+            conn.execute(table.insert(), [{'name': name,
+                                           'content': content}])
+
 
     def add_to_table(self, table_name, objects):
         """Add a list of objects of a given class

--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -303,6 +303,7 @@ class StorableFunction(StorableNamedObject):
     def from_dict(cls, dct):
         source = dct.pop('source')
         kwargs = dct.pop('kwargs')
+        dct['store_source'] = False
         obj = cls(**dct, **kwargs)
         if obj.source is None:
             obj.source = source  # may still be none

--- a/openpathsampling/experimental/simstore/storage.py
+++ b/openpathsampling/experimental/simstore/storage.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 universal_schema = {
     'uuid': [('uuid', 'uuid'), ('table', 'int'), ('row', 'int')],
     'tables': [('name', 'str'), ('idx', 'int'), ('module', 'str'),
-               ('class_name', 'str')]
+               ('class_name', 'str')],
+    'tags': [('name', 'str'), ('content', 'uuid')]
 }
 
 from openpathsampling.netcdfplus import StorableNamedObject

--- a/openpathsampling/experimental/simstore/storage.py
+++ b/openpathsampling/experimental/simstore/storage.py
@@ -28,6 +28,7 @@ from .serialization_helpers import get_reload_order
 # from .serialization import Serialization
 from .serialization import ProxyObjectFactory
 from .storable_functions import StorageFunctionHandler, StorableFunction
+from .tags_table import TagsTable
 
 try:
     basestring
@@ -78,6 +79,7 @@ class GeneralStorage(StorableNamedObject):
             self.schema = backend.schema
         self.cache = MixedCache({})  # initial empty cache so it exists
         self.initialize_with_mode(self.mode)
+        self.tags = TagsTable(self)
         self._simulation_objects = self._cache_simulation_objects()
         self.cache = MixedCache(self._simulation_objects)
         self._stashed = []

--- a/openpathsampling/experimental/simstore/tags_table.py
+++ b/openpathsampling/experimental/simstore/tags_table.py
@@ -1,0 +1,39 @@
+from .wrapper import SimStoreWrapper
+from .storage import StorageTable
+from .serialization_helpers import get_uuid
+
+from collections import abc
+
+class TaggedObject(SimStoreWrapper):
+    pass  # subclass simply so it can be recognized distinct from wrapper
+
+
+class TagsTable(abc.Sequence):
+    # we inherit from Sequence, not MutableSequence, because delitem and
+    # insert don't make sense here
+    def __init__(self, storage):
+        self.storage = storage
+        self.table = 'tags'
+        self.tagged_objects = self._load_tags()
+
+    def _load_tags(self):
+        backend_iter = self.storage.backend.table_iterator(self.table)
+        tagged_objects = {row.name: row.content for row in backend_iter}
+        return tagged_objects
+
+    def __len__(self):
+        return len(self.tagged_objects)
+
+    def __getitem__(self, tag):
+        uuid = self.tagged_objects[tag]
+        wrapped = self.storage.load([uuid])[0]
+        return wrapped.content
+
+    def __setitem__(self, tag, obj):
+        if tag in self.tagged_objects:
+            raise RuntimeError("A tag named '%s' already exists." % tag)
+        wrapped = TaggedObject(obj).named(tag)
+        self.storage.save(wrapped)
+        wrapped_uuid = get_uuid(wrapped)
+        self.tagged_objects[tag] = wrapped_uuid
+        self.storage.backend.add_tag(self.table, tag, wrapped_uuid)

--- a/openpathsampling/experimental/simstore/tags_table.py
+++ b/openpathsampling/experimental/simstore/tags_table.py
@@ -1,5 +1,4 @@
 from .wrapper import SimStoreWrapper
-from .storage import StorageTable
 from .serialization_helpers import get_uuid
 
 from collections import abc
@@ -8,21 +7,45 @@ class TaggedObject(SimStoreWrapper):
     pass  # subclass simply so it can be recognized distinct from wrapper
 
 
-class TagsTable(abc.Sequence):
-    # we inherit from Sequence, not MutableSequence, because delitem and
-    # insert don't make sense here
+class TagsTable(abc.Mapping):
+    """StorageTable-like object for tags.
+
+    Tags allow storage of arbitrary objects. The ``tags`` table can contain
+    any JSON-serializable object, or any UUID-containing object that can
+    otherwise be stored by SimStore. Usage is dict-like, using a string name
+    for the tag, e.g., ``tags['initial_conditions'] = data`` to set or
+    ``data = tags['initial_conditions']`` to load.
+
+    Parameters
+    ----------
+    storage: :class:`.GeneralStorage`
+        the storage object associated with this table
+    """
+    # we inherit from Mapping, not MutableMapping, because delitem, pop,
+    # popitem, etc don't make sense here
     def __init__(self, storage):
         self.storage = storage
         self.table = 'tags'
         self.tagged_objects = self._load_tags()
 
     def _load_tags(self):
-        backend_iter = self.storage.backend.table_iterator(self.table)
-        tagged_objects = {row.name: row.content for row in backend_iter}
+        # TODO: maybe I should just make the table? Need better way for that
+        if self.storage.backend.has_table(self.table):
+            backend_iter = self.storage.backend.table_iterator(self.table)
+            tagged_objects = {row.name: row.content for row in backend_iter}
+        else:
+            tagged_objects = {}
         return tagged_objects
+
+    def __iter__(self):
+        for name in self.tagged_objects:
+            yield self[name]
 
     def __len__(self):
         return len(self.tagged_objects)
+
+    def keys(self):
+        return self.tagged_objects.keys()
 
     def __getitem__(self, tag):
         uuid = self.tagged_objects[tag]

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -16,7 +16,8 @@ class TestSQLStorageBackend(object):
         self.table_to_class = {'samples': tuple,
                                'snapshot0': tuple,
                                'snapshot1': tuple}
-        self.default_table_names = {'uuid', 'tables', 'schema', 'metadata'}
+        self.default_table_names = {'uuid', 'tables', 'schema', 'metadata',
+                                    'tags'}
 
     def _sample_data_dict(self):
         sample_list = [(0, 'ens1', 'traj1'),

--- a/openpathsampling/experimental/simstore/test_tags_table.py
+++ b/openpathsampling/experimental/simstore/test_tags_table.py
@@ -1,0 +1,101 @@
+import pytest
+from .storage import GeneralStorage
+from .sql_backend import SQLStorageBackend
+from .class_info import ClassInfo, SerializationSchema
+from .custom_json import JSONSerializerDeserializer, uuid_object_codec
+from .serialization_helpers import default_find_uuids
+
+from openpathsampling.netcdfplus import StorableObject
+
+from .tags_table import *
+
+class IntHolder(StorableObject):
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+class TestTagsTable(object):
+    def setup(self):
+        json_ser = JSONSerializerDeserializer([uuid_object_codec])
+        # TODO: add tags to serialization schema
+        serialization_schema = SerializationSchema(
+            default_info=ClassInfo(
+                table='simulation_objects',
+                cls=StorableObject,
+                serializer=json_ser.simobj_serializer,
+                deserializer=json_ser.simobj_deserializer,
+                find_uuids=default_find_uuids
+            ),
+            sfr_info=None,
+            schema={'int_holders': [('value', 'int')],
+                    '_tagged_content': [('json', 'json_obj')]
+                   },
+            class_info_list=[
+                ClassInfo(table='int_holders', cls=IntHolder),
+                ClassInfo(table='_tagged_content', cls=TaggedObject,
+                          serializer=json_ser.simobj_serializer,
+                          deserializer=json_ser.simobj_deserializer,
+                          find_uuids=default_find_uuids)
+            ]
+        )
+        for info in serialization_schema.class_info_list:
+            info.set_defaults(serialization_schema.schema)
+        backend = SQLStorageBackend(":memory:", mode='w')
+        self.storage = GeneralStorage(backend, serialization_schema,
+                                      serialization_schema.schema)
+
+        self.tags_table = TagsTable(self.storage)
+
+    def test_init(self):
+        assert self.tags_table.tagged_objects == {}
+
+    def _set_info_in_storage(self):
+        wrapped_holder = TaggedObject(IntHolder(10)).named('with-uuid')
+        tagged_num = TaggedObject(5).named('no-uuid')
+        self.storage.save([wrapped_holder, tagged_num])
+        self.storage.backend.add_tag('tags', 'with-uuid',
+                                     get_uuid(wrapped_holder))
+        self.storage.backend.add_tag('tags', 'no-uuid',
+                                     get_uuid(tagged_num))
+        assert self.storage.backend.table_len('_tagged_content') == 2
+        assert self.storage.backend.table_len('int_holders') == 1
+        assert self.storage.backend.table_len('tags') == 2
+
+    def test_load_tags(self):
+        self._set_info_in_storage()
+        tags_table = TagsTable(self.storage)
+        assert len(tags_table.tagged_objects) == 2
+
+    def test_len(self):
+        assert len(self.tags_table) == 0
+        self._set_info_in_storage()
+        tags_table = TagsTable(self.storage)
+        assert len(tags_table) == 2
+
+    def test_getitem(self):
+        self._set_info_in_storage()
+        tags_table = TagsTable(self.storage)
+        assert tags_table['no-uuid'] == 5
+        with_uuid = tags_table['with-uuid']
+        assert isinstance(with_uuid, IntHolder)
+        assert with_uuid.value == 10
+
+    def test_setitem(self):
+        self.tags_table['no-uuid'] = 5  # JSON-serializable data
+        self.tags_table['with-uuid'] = IntHolder(10)  # UUID objects
+        assert len(self.tags_table.tagged_objects) == 2
+        assert self.storage.backend.table_len('_tagged_content') == 2
+        assert self.storage.backend.table_len('int_holders') == 1
+        assert self.storage.backend.table_len('tags') == 2
+
+    def test_setitem_name_error(self):
+        self.tags_table['foo'] = 5
+        with pytest.raises(RuntimeError):
+            self.tags_table['foo'] = 6
+
+    def test_set_get_cycle(self):
+        wrapped = IntHolder(10)
+        self.tags_table['no-uuid'] = 5
+        self.tags_table['with-uuid'] = wrapped
+        assert self.tags_table['no-uuid'] == 5
+        assert self.tags_table['with-uuid'] == wrapped

--- a/openpathsampling/experimental/simstore/wrapper.py
+++ b/openpathsampling/experimental/simstore/wrapper.py
@@ -1,0 +1,13 @@
+from openpathsampling.netcdfplus import StorableNamedObject
+
+class SimStoreWrapper(StorableNamedObject):
+    """Wrapper to add UUID to and JSON-serializable content.
+
+    Parameters
+    ----------
+    content : Any
+        the JSON-serializable thing to wrap
+    """
+    def __init__(self, content):
+        super().__init__()
+        self.content = content

--- a/openpathsampling/experimental/storage/ops_storage.py
+++ b/openpathsampling/experimental/storage/ops_storage.py
@@ -297,6 +297,14 @@ class Storage(storage.GeneralStorage):
     def __reduce__(self):
         return (self.from_dict, (self.to_dict(),))
 
+    @property
+    def movechanges(self):
+        return self.move_changes
+
+    @property
+    def samplesets(self):
+        return self.sample_sets
+
     def register_from_tables(self, table_names, classes):
         lookups = {}
         table_to_class = {tbl: cls for tbl, cls in zip(table_names, classes)}


### PR DESCRIPTION
This PR adds a `tags` table to SimStore storages. As with `netcdfplus`, the `tags` table can be used to store arbitrary data. Any JSON-serializable object, or any object with a SimStore UUID, can be saved as a named tag.

This PR also includes some additional cleanup after #929 and miscellaneous support so that SimStore can be used in the OPS CLI (see also https://github.com/openpathsampling/openpathsampling-cli/pull/29). 