### PR TITLE
Fix bug in SimStore when appending to non-existent files

### DIFF
--- a/openpathsampling/experimental/simstore/memory_backend.py
+++ b/openpathsampling/experimental/simstore/memory_backend.py
@@ -1,11 +1,6 @@
 import os
 import collections
-
-try:
-    from collections import abc
-except ImportError:
-    # Py27
-    abc = collections
+from collections import abc
 
 from .storage import universal_schema
 

--- a/openpathsampling/experimental/simstore/memory_backend.py
+++ b/openpathsampling/experimental/simstore/memory_backend.py
@@ -1,6 +1,12 @@
 import os
 import collections
 
+try:
+    from collections import abc
+except ImportError:
+    # Py27
+    abc = collections
+
 from .storage import universal_schema
 
 import logging
@@ -8,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 UUIDTableRow = collections.namedtuple("UUIDTableRow", ['uuid', 'table_name'])
 
-class MemoryStorageTable(collections.abc.MutableMapping):
+class MemoryStorageTable(abc.MutableMapping):
     """Simple wrapper for a Dict; transforms Dict values to namedtuple
     """
     def __init__(self, table_name, schema_entries):

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -115,9 +115,14 @@ class SQLStorageBackend(StorableNamedObject):
         self.connection_uri = None
         self._metadata = None
         if filename is not None:
-            if self.mode == "w" and os.path.exists(filename):
+            file_exists = os.path.exists(filename)
+            if self.mode == "w" and file_exists:
                 # delete existing file; write after
                 os.remove(filename)
+
+            if self.mode == 'a' and not file_exists:
+                # act as if the mode is 'w'; note we change this back later
+                self.mode = 'w'
 
             self.connection_uri = self.filename_from_dialect(
                 filename,
@@ -125,6 +130,7 @@ class SQLStorageBackend(StorableNamedObject):
             )
             engine = sql.create_engine(self.connection_uri, **self.kwargs)
             self._initialize_from_engine(engine)
+            self.mode = mode  # in case we changed when checking existence
 
     def _initialize_from_engine(self, engine):
         self.engine = engine

--- a/openpathsampling/experimental/simstore/storage.py
+++ b/openpathsampling/experimental/simstore/storage.py
@@ -104,7 +104,7 @@ class GeneralStorage(StorableNamedObject):
             self.register_schema(self.schema, class_info_list=[],
                                  read_mode=True)
             missing = {k: v for k, v in self.backend.schema.items()
-                       if k not in self.schema}
+                       if k not in self.schema and k not in universal_schema}
             self.schema.update(missing)
             table_to_class = self.backend.table_to_class
             self._load_missing_info_tables(table_to_class)
@@ -151,11 +151,11 @@ class GeneralStorage(StorableNamedObject):
             # info.set_defaults(schema)
             # self.class_info.add_class_info(info)
 
-        if not read_mode:
-            # here's where we add the class_info to the backend
+        if not read_mode or self.backend.table_to_class == {}:
             table_to_class = {table: self.class_info[table].cls
                               for table in schema
                               if table not in ['uuid', 'tables']}
+            # here's where we add the class_info to the backend
             self.backend.register_schema(schema, table_to_class,
                                          backend_metadata)
 

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -94,9 +94,6 @@ class TestSQLStorageBackend(object):
         assert self._col_names_set('tables') == {'name', 'idx', 'module',
                                                  'class_name'}
         assert self._col_names_set('schema') == {'table', 'schema'}
-        for f in ['test1.sql', 'test2.sql']:
-            if os.path.isfile(f):
-                os.remove(f)
 
     def test_register_schema(self):
         new_schema = {
@@ -258,4 +255,3 @@ class TestSQLStorageBackend(object):
             expected = tuple(samp_dct[k]
                              for k in ['replica', 'ensemble', 'trajectory'])
             assert row[2:] == expected
-

--- a/openpathsampling/experimental/simstore/tools.py
+++ b/openpathsampling/experimental/simstore/tools.py
@@ -1,11 +1,12 @@
 import itertools
 import collections
+from collections import abc
 from numpy import ndarray
 
 import logging
 logger = logging.getLogger(__name__)
 
-class SimpleNamespace(collections.abc.MutableMapping):
+class SimpleNamespace(abc.MutableMapping):
     # types.SimpleNameSpace in 3.3+
     # this variants acts as either a dict or a namespace for getting
     def __init__(self, **kwargs):
@@ -46,10 +47,10 @@ def is_string(obj):
     return isinstance(obj, basestring)
 
 def is_mappable(obj):
-    return isinstance(obj, collections.abc.Mapping)
+    return isinstance(obj, abc.Mapping)
 
 def is_iterable(obj):
-    return isinstance(obj, collections.abc.Iterable) and not is_string(obj)
+    return isinstance(obj, abc.Iterable) and not is_string(obj)
 
 def is_numpy_iterable(obj):
     return isinstance(obj, ndarray)
@@ -138,15 +139,15 @@ def flatten_iterable(ll):
     return flatten(ll, lambda x: x, (list, tuple, set))
 
 def flatten_all(obj):
-    is_mappable = lambda x: isinstance(x, collections.abc.Mapping)
+    is_mappable = lambda x: isinstance(x, abc.Mapping)
     return flatten(obj,
                    lambda x: x.values() if is_mappable(x) else x.__iter__(),
-                   (collections.abc.Mapping, collections.abc.Iterable),
+                   (abc.Mapping, abc.Iterable),
                    (basestring, ndarray))
 
 def nested_update(original, update):
     for (k, v) in update.items():
-        if isinstance(v, collections.abc.Mapping):
+        if isinstance(v, abc.Mapping):
             original[k] = nested_update(original.get(k, {}), v)
         else:
             original[k] = v

--- a/openpathsampling/experimental/simstore/tools.py
+++ b/openpathsampling/experimental/simstore/tools.py
@@ -5,7 +5,7 @@ from numpy import ndarray
 import logging
 logger = logging.getLogger(__name__)
 
-class SimpleNamespace(collections.MutableMapping):
+class SimpleNamespace(collections.abc.MutableMapping):
     # types.SimpleNameSpace in 3.3+
     # this variants acts as either a dict or a namespace for getting
     def __init__(self, **kwargs):
@@ -46,10 +46,10 @@ def is_string(obj):
     return isinstance(obj, basestring)
 
 def is_mappable(obj):
-    return isinstance(obj, collections.Mapping)
+    return isinstance(obj, collections.abc.Mapping)
 
 def is_iterable(obj):
-    return isinstance(obj, collections.Iterable) and not is_string(obj)
+    return isinstance(obj, collections.abc.Iterable) and not is_string(obj)
 
 def is_numpy_iterable(obj):
     return isinstance(obj, ndarray)
@@ -138,15 +138,15 @@ def flatten_iterable(ll):
     return flatten(ll, lambda x: x, (list, tuple, set))
 
 def flatten_all(obj):
-    is_mappable = lambda x: isinstance(x, collections.Mapping)
+    is_mappable = lambda x: isinstance(x, collections.abc.Mapping)
     return flatten(obj,
                    lambda x: x.values() if is_mappable(x) else x.__iter__(),
-                   (collections.Mapping, collections.Iterable),
+                   (collections.abc.Mapping, collections.abc.Iterable),
                    (basestring, ndarray))
 
 def nested_update(original, update):
     for (k, v) in update.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             original[k] = nested_update(original.get(k, {}), v)
         else:
             original[k] = v


### PR DESCRIPTION
Pretty much what the title says. Before, there was an error if you opened a new file as append, because it tried to read the non-existent schema from the file.

Also cleans up some deprecations from importing ABCs from `collections`, not `collections.abc` (SimStore is Python 3+.)