### PR TITLE
fix for filname counter of gromacs engine (fixes #942)

### DIFF
--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -303,7 +303,7 @@ class GromacsEngine(ExternalEngine):
             num_str = '{:07d}'.format(number + 1)
             self.output_file = self.trajectory_filename(number + 1)
             init_filename = "initial_frame.trr"
-            self.filename_setter.reset(number)
+            self.filename_setter.reset(number + 1)
         else:
             num_str = number
             self.output_file = self.trajectory_filename(num_str)

--- a/openpathsampling/tests/test_gromacs_engine.py
+++ b/openpathsampling/tests/test_gromacs_engine.py
@@ -90,7 +90,7 @@ class TestGromacsEngine(object):
         self.engine = Engine(gro="conf.gro",
                              mdp="md.mdp",
                              top="topol.top",
-                             options={},
+                             options={'mdrun_args': '-nt 1'},
                              base_dir=self.test_dir,
                              prefix="project")
 
@@ -227,7 +227,7 @@ class TestGromacsEngine(object):
 
         traj_0 = self.engine.trajectory_filename(0)
         snap = self.engine.read_frame_from_file(traj_0, 0)
-        self.engine.set_filenames(0)
+        self.engine.filename_setter.reset(0)
 
         ens = paths.LengthEnsemble(5)
         traj = self.engine.generate(snap, running=[ens.can_append])


### PR DESCRIPTION
Closes #942. As proposed there I slightly modified the test to reset the counter via its own `reset()` method instead of via the engines `set_filenames()` method. 
Engine works and test pass with and without the counter reset in `set_filenames()`, so it is now a matter of preference if we want to have that reset in `set_filenames()`. I left it in for now, was not sure what your preference is here.
