### PR TITLE
SimStore: Support for OpenMM snapshots

### DIFF
--- a/openpathsampling/engines/features/kinetics.py
+++ b/openpathsampling/engines/features/kinetics.py
@@ -7,6 +7,15 @@ flip = ['is_reversed']
 
 dimensions = ['n_atoms', 'n_spatial']
 
+_vel_unit = "simtk(unit.nanometer/unit.picosecond)"
+_vel_str = "ndarray.float32({{n_atom}},{{n_spatial}})"
+schema_entries = [(
+    'kinetics', [
+        ('velocities', _vel_unit + "*" + _vel_str),
+        ('is_reversed', 'bool'),  # I think is_reversed can be removed...
+    ]
+)]
+
 
 def netcdfplus_init(store):
     kinetic_store = KineticContainerStore()

--- a/openpathsampling/engines/features/kinetics.py
+++ b/openpathsampling/engines/features/kinetics.py
@@ -8,13 +8,14 @@ flip = ['is_reversed']
 dimensions = ['n_atoms', 'n_spatial']
 
 _vel_unit = "simtk(unit.nanometer/unit.picosecond)"
-_vel_str = "ndarray.float32({{n_atom}},{{n_spatial}})"
-schema_entries = [(
-    'kinetics', [
+_vel_str = "ndarray.float32({n_atoms},{n_spatial})"
+schema_entries = [
+    ('kinetics', [
         ('velocities', _vel_unit + "*" + _vel_str),
-        ('is_reversed', 'bool'),  # I think is_reversed can be removed...
-    ]
-)]
+        ('engine', 'uuid'),
+    ]),
+    ('is_reversed', 'bool'),
+]
 
 
 def netcdfplus_init(store):
@@ -59,7 +60,7 @@ def velocities(self):
 @velocities.setter
 def velocities(self, value):
     if value is not None:
-        kc = KineticContainer(velocities=value)
+        kc = KineticContainer(velocities=value, engine=self.engine)
     else:
         kc = None
 

--- a/openpathsampling/engines/features/shared.py
+++ b/openpathsampling/engines/features/shared.py
@@ -76,8 +76,8 @@ class StaticContainer(StorableObject):
         """
 
         return StaticContainer(coordinates=self.coordinates,
-                               box_vectors=self.box_vectors
-                               )
+                               box_vectors=self.box_vectors,
+                               engine=self.engine)
 
     def to_dict(self):
         # note: to_dict not used here in SimStore, so no need to change
@@ -118,7 +118,8 @@ class StaticContainerStore(ObjectStore):
         if not np.count_nonzero(box_vectors):
             box_vectors = None
 
-        configuration = StaticContainer(coordinates=coordinates, box_vectors=box_vectors)
+        configuration = StaticContainer(coordinates=coordinates,
+                                        box_vectors=box_vectors)
 
         return configuration
 
@@ -202,7 +203,8 @@ class KineticContainer(StorableObject):
         Momentum()
             the shallow copy
         """
-        this = KineticContainer(velocities=self.velocities)
+        this = KineticContainer(velocities=self.velocities,
+                                engine=self.engine)
         return this
 
     def to_dict(self):

--- a/openpathsampling/engines/features/shared.py
+++ b/openpathsampling/engines/features/shared.py
@@ -27,6 +27,7 @@ def unmask_quantity(quantity):
         return quantity
     return np.array(quantity.value_in_unit(q_unit)) * q_unit
 
+
 # =============================================================================
 # SIMULATION CONFIGURATION
 # =============================================================================
@@ -36,53 +37,24 @@ class StaticContainer(StorableObject):
     Simulation configuration. Only Coordinates, the associated boxvectors
     and the potential_energy
 
-    Attributes
+    Parameters
     ----------
     coordinates : simtk.unit.Quantity wrapping Nx3 np array of dimension length
         atomic coordinates
     box_vectors : periodic box vectors
         the periodic box vectors
-
+    engine : :class:`.DynamicsEngine`
+        the engine that creating this data
     """
 
     # Class variables to store the global storage and the system context
     # describing the system to be saved as configuration_indices
 
-    def __init__(self, coordinates, box_vectors):
-        """
-        Create a simulation configuration from either an OpenMM context or
-        individually-specified components.
-
-        Parameters
-        ----------
-        coordinates
-        box_vectors
-        """
-
+    def __init__(self, coordinates, box_vectors, engine=None):
         super(StaticContainer, self).__init__()
-
         self.coordinates = copy.deepcopy(coordinates)
         self.box_vectors = copy.deepcopy(box_vectors)
-
-        # if self.coordinates is not None:
-        #     # Check for nans in coordinates, and raise an exception if
-        #     # something is wrong.
-        #     if type(self.coordinates) is unit.Quantity:
-        #         coords = self.coordinates._value
-        #     else:
-        #         coords = self.coordinates
-        #
-        #     if np.any(np.isnan(coords)):
-        #         bad_atoms = [i for i in range(len(coords))
-        #                      if np.any(np.isnan(coords[i]))]
-        #         raise ValueError("Coordinates went 'nan' for atoms: " +
-        #                          str(bad_atoms))
-
-        return
-
-    # =========================================================================
-    # Comparison functions
-    # =========================================================================
+        self.engine = engine
 
     @property
     def n_atoms(self):
@@ -90,10 +62,6 @@ class StaticContainer(StorableObject):
         Returns the number of atoms in the configuration
         """
         return self.coordinates.shape[0]
-
-    # =========================================================================
-    # Utility functions
-    # =========================================================================
 
     def copy(self):
         """
@@ -112,6 +80,7 @@ class StaticContainer(StorableObject):
                                )
 
     def to_dict(self):
+        # note: to_dict not used here in SimStore, so no need to change
         return {
             'coordinates': self.coordinates,
             'box_vectors': self.box_vectors
@@ -214,26 +183,14 @@ class KineticContainer(StorableObject):
     ----------
     velocities : simtk.unit.Quantity wrapping Nx3 np array of dimension length
         atomic velocities
-
+    engine : :class:`.DynamicsEngine`
+        the engine that creating this data
     """
 
-    def __init__(self, velocities):
-        """
-        Create a simulation momentum from either an OpenMM context or
-        individually-specified components.
-
-        Parameters
-        ----------
-        velocities
-        """
-
+    def __init__(self, velocities, engine=None):
         super(KineticContainer, self).__init__()
-
         self.velocities = copy.deepcopy(velocities)
-
-    # =========================================================================
-    # Utility functions
-    # =========================================================================
+        self.engine = engine
 
     def copy(self):
         """
@@ -245,9 +202,7 @@ class KineticContainer(StorableObject):
         Momentum()
             the shallow copy
         """
-
         this = KineticContainer(velocities=self.velocities)
-
         return this
 
     def to_dict(self):

--- a/openpathsampling/engines/features/statics.py
+++ b/openpathsampling/engines/features/statics.py
@@ -12,8 +12,8 @@ dimensions = ['n_atoms', 'n_spatial']
 
 _length_unit = "simtk(unit.nanometer)"
 _array32 = "ndarray.float32"
-schema_entries = [(
-    'statics', [
+schema_entries = [
+    ('statics', [
         ('coordinates',
          '{length_unit}*{array32}({{n_atoms}},{{n_spatial}})'.format(
              length_unit=_length_unit, array32=_array32
@@ -21,9 +21,10 @@ schema_entries = [(
         ('box_vectors',
          '{length_unit}*{array32}({{n_spatial}},{{n_spatial}})'.format(
              length_unit=_length_unit, array32=_array32
-        ))
-    ]
-)]
+        )),
+        ('engine', 'uuid'),
+    ]),
+]
 
 
 def netcdfplus_init(store):
@@ -62,7 +63,9 @@ def coordinates(snapshot):
 @coordinates.setter
 def coordinates(self, value):
     if value is not None:
-        sc = StaticContainer(coordinates=value, box_vectors=self.box_vectors)
+        sc = StaticContainer(coordinates=value,
+                             box_vectors=self.box_vectors,
+                             engine=self.engine)
     else:
         sc = None
 
@@ -87,7 +90,9 @@ def box_vectors(snapshot):
 @box_vectors.setter
 def box_vectors(self, value):
     if value is not None:
-        sc = StaticContainer(box_vectors=value, coordinates=self.coordinates)
+        sc = StaticContainer(box_vectors=value,
+                             coordinates=self.coordinates,
+                             engine=self.engine)
     else:
         sc = None
 

--- a/openpathsampling/engines/features/statics.py
+++ b/openpathsampling/engines/features/statics.py
@@ -10,9 +10,19 @@ storables = ['statics']
 
 dimensions = ['n_atoms', 'n_spatial']
 
+_length_unit = "simtk(unit.nanometer)"
+_array32 = "ndarray.float32"
 schema_entries = [(
-    'statics', [('coordinates', 'ndarray.float32({n_atoms},{n_spatial})'),
-                ('box_vectors', 'ndarray.float32({n_spatial},{n_spatial})')]
+    'statics', [
+        ('coordinates',
+         '{length_unit}*{array32}({{n_atoms}},{{n_spatial}})'.format(
+             length_unit=_length_unit, array32=_array32
+        )),
+        ('box_vectors',
+         '{length_unit}*{array32}({{n_spatial}},{{n_spatial}})'.format(
+             length_unit=_length_unit, array32=_array32
+        ))
+    ]
 )]
 
 

--- a/openpathsampling/engines/openmm/snapshot.py
+++ b/openpathsampling/engines/openmm/snapshot.py
@@ -93,10 +93,15 @@ class Snapshot(BaseSnapshot):
         if statics is None:
             statics = Snapshot.StaticContainer(
                 coordinates=coordinates,
-                box_vectors=box_vectors)
+                box_vectors=box_vectors,
+                engine=engine
+            )
 
         if kinetics is None:
-            kinetics = Snapshot.KineticContainer(velocities=velocities)
+            kinetics = Snapshot.KineticContainer(
+                velocities=velocities,
+                engine=engine
+            )
 
         return Snapshot(
             engine=engine,

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -256,9 +256,11 @@ def trajectory_from_mdtraj(mdtrajectory, simple_topology=False,
 
         statics = Snapshot.StaticContainer(
             coordinates=coord,
-            box_vectors=box_v
+            box_vectors=box_v,
+            engine=engine
         )
-        kinetics = Snapshot.KineticContainer(velocities=vel)
+        kinetics = Snapshot.KineticContainer(velocities=vel,
+                                             engine=engine)
 
         snap = Snapshot(
             statics=statics,

--- a/openpathsampling/experimental/simstore/attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/attribute_handlers.py
@@ -29,6 +29,7 @@ class StandardHandler(AttributeHandler):
     def __init__(self, type_info):
         super().__init__(type_info)
         self.backend_type = type_info
+        self.type_size = None
 
     @classmethod
     def is_my_type(cls, type_str):
@@ -71,6 +72,7 @@ class NDArrayHandler(AttributeHandler):
         super().__init__(type_info)
         self.dtype, self.shape = type_info
         self.backend_type = 'ndarray'
+        self.type_size = None  # TODO: change this based on dtype/shape
 
     @classmethod
     def is_my_type(cls, type_str):

--- a/openpathsampling/experimental/simstore/attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/attribute_handlers.py
@@ -3,6 +3,16 @@ import numpy as np
 
 
 class AttributeHandler(object):
+    """Abstract object to handler a given attribute type.
+
+    Each attribute in a schema entry will generate an instance of this for
+    the appropriate type. Different subclasses handle different types that
+    are supported by SimStore.
+
+    Note that you'll usually use this with the :method:`.from_type_string`
+    constructor, which returns None if the type string doesn't match what
+    this class handles.
+    """
     def __init__(self, type_info):
         self.type_info = type_info
 
@@ -13,18 +23,58 @@ class AttributeHandler(object):
 
     @classmethod
     def from_type_string(cls, type_str):
+        """Generate attribute handler based on a given type string.
+
+        Parameters
+        ----------
+        type_str: str
+            the specific type string in a format understood by SimStore
+
+        Returns
+        -------
+        :class:`.AttributeHandler` or None:
+            an attribute handler for the given type string, or None if this
+            class doesn't know how to handle that type
+        """
         type_info = cls.is_my_type(type_str)
         if type_info:
             return cls(type_info)
 
     def serialize(self, obj):
+        """Serialize the object.
+
+        Default serialization just returns the object.
+
+        Parameters
+        ----------
+        obj : Any
+            object to be serialized
+
+        Returns
+        -------
+        Any:
+            version ready to be written to disk; typically str or bytes but
+            standard types are also allowed (bool, float, int, etc.)
+        """
         return obj
 
     def deserialize(self, data, caches=None):
+        """Deserialize the serialized form.
+
+        Parameters
+        ----------
+        data: Any
+            bytes to deserialize (usually as str or bytes)
+        caches: Dict
+            mapping of identifiers to known objects that might be components
+            of this object; mainly used when deserializing UUID objects.
+        """
         return data
 
 
 class StandardHandler(AttributeHandler):
+    """Attribute handler for common standard types
+    """
     standard_types = ['str', 'int', 'float', 'function']
     def __init__(self, type_info):
         super().__init__(type_info)
@@ -68,6 +118,13 @@ class JSONObjHandler(StandardHandler):
 
 
 class NDArrayHandler(AttributeHandler):
+    """Attribute handler for NumPy ndarrays.
+
+    Parameters
+    ----------
+    type_info: Tuple
+        dtype and shape of the array
+    """
     def __init__(self, type_info):
         super().__init__(type_info)
         self.dtype, self.shape = type_info

--- a/openpathsampling/experimental/simstore/attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/attribute_handlers.py
@@ -1,34 +1,85 @@
 from .my_types import parse_ndarray_type
+import numpy as np
 
 
-class HandlerFactory(object):
-    def is_my_type(self, type_str):
+class AttributeHandler(object):
+    def __init__(self, type_info):
+        self.type_info = type_info
+
+    @staticmethod
+    def is_my_type(type_str):
+        """Returns type info (possibly tuple) if true, None if false"""
+        raise NotImplementedError()
+
+    @classmethod
+    def from_type_string(cls, type_str):
+        type_info = cls.is_my_type(type_str)
+        if type_info:
+            return cls(type_info)
+
+    def serialize(self, obj):
+        return obj
+
+    def deserialize(self, data, caches=None):
+        return data
+
+
+class StandardHandler(AttributeHandler):
+    standard_types = ['str', 'int', 'float', 'function']
+    def __init__(self, type_info):
+        super().__init__(type_info)
+        self.backend_type = type_info
+
+    @classmethod
+    def is_my_type(cls, type_str):
+        if type_str in cls.standard_types:
+            return type_str
+
+
+# TODO: these have not yet been implemented, but this is how it should all
+# work -- everything should be managed through attribute handlers, instead
+# of separate functions for serialize/deserialize
+class UUIDHandler(StandardHandler):
+    standard_types = ['uuid', 'lazy']
+    def serialize(self, obj):
         pass
 
-    def serializer(self, type_str):
+    def deserialize(self, data, caches=None):
         pass
 
-    def deserializer(self, type_str):
+
+class ListUUIDHandler(StandardHandler):
+    standard_types = ['list_uuid']
+    def serialize(self, obj):
         pass
 
-class NDArrayHandlerFactory(HandlerFactory):
-    def is_my_type(self, type_str):
-        as_ndarray = parse_ndarray_type(type_str)
-
-    def serializer(self, type_str):
-        as_ndarray = self.is_my_type(type_str)
-        if as_ndarray:
-            dtype, shape = as_ndarray
-            handler = lambda data, _: \
-                    np.fromstring(data, dtype=dtype).reshape(shape)
-            return handler
-
-    def deserializer(self, type_str):
-        as_ndarray = self.is_my_type(type_str)
-        if as_ndarray:
-            dtype, shape = as_ndarray
-            return lambda arr: \
-                    arr.astype(dtype=dtype, copy=False).tostring()
+    def deserialize(self, data, caches=None):
+        pass
 
 
+class JSONObjHandler(StandardHandler):
+    standard_types = ['json_obj']
+    def serialize(self, obj):
+        pass
 
+    def deserialize(self, data, caches=None):
+        pass
+
+
+class NDArrayHandler(AttributeHandler):
+    def __init__(self, type_info):
+        super().__init__(type_info)
+        self.dtype, self.shape = type_info
+        self.backend_type = 'ndarray'
+
+    @classmethod
+    def is_my_type(cls, type_str):
+        return parse_ndarray_type(type_str)
+
+    def serialize(self, obj):
+        return obj.astype(dtype=self.dtype, copy=False).tostring()
+
+    def deserialize(self, data, caches=None):
+        return np.fromstring(data, dtype=self.dtype).reshape(self.shape)
+
+DEFAULT_HANDLERS = [NDArrayHandler, StandardHandler]

--- a/openpathsampling/experimental/simstore/attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/attribute_handlers.py
@@ -1,0 +1,34 @@
+from .my_types import parse_ndarray_type
+
+
+class HandlerFactory(object):
+    def is_my_type(self, type_str):
+        pass
+
+    def serializer(self, type_str):
+        pass
+
+    def deserializer(self, type_str):
+        pass
+
+class NDArrayHandlerFactory(HandlerFactory):
+    def is_my_type(self, type_str):
+        as_ndarray = parse_ndarray_type(type_str)
+
+    def serializer(self, type_str):
+        as_ndarray = self.is_my_type(type_str)
+        if as_ndarray:
+            dtype, shape = as_ndarray
+            handler = lambda data, _: \
+                    np.fromstring(data, dtype=dtype).reshape(shape)
+            return handler
+
+    def deserializer(self, type_str):
+        as_ndarray = self.is_my_type(type_str)
+        if as_ndarray:
+            dtype, shape = as_ndarray
+            return lambda arr: \
+                    arr.astype(dtype=dtype, copy=False).tostring()
+
+
+

--- a/openpathsampling/experimental/simstore/class_info.py
+++ b/openpathsampling/experimental/simstore/class_info.py
@@ -147,6 +147,25 @@ class SerializationSchema(object):
         return dup
 
     def backend_type(self, type_name):
+        """Obtain the general type name from a specific type string
+
+        Example: this tells that no matter what the specific shape of a
+        numpy array is, the backend should register it as a NumPy array. In
+        addition, this can (in the future will) provide a length value to
+        tell the backend how many bytes to allocate for an array.
+
+        Parameters
+        ----------
+        type_name: str
+            specfic type string for an attribute
+
+        Returns
+        -------
+        Tuple[str, Any]
+            the type name as known to the backend, and the length
+            information for fixed length columns (length aspect not yet
+            implemented)
+        """
         for handler in self.attribute_handlers:
             if handler.is_my_type(type_name):
                 handler_obj = handler.from_type_string(type_name)

--- a/openpathsampling/experimental/simstore/class_info.py
+++ b/openpathsampling/experimental/simstore/class_info.py
@@ -146,6 +146,14 @@ class SerializationSchema(object):
         )
         return dup
 
+    def backend_type(self, type_name):
+        for handler in self.attribute_handlers:
+            if handler.is_my_type(type_name):
+                handler_obj = handler.from_type_string(type_name)
+                return handler_obj.backend_type, handler_obj.type_size
+        # current default is to return the input; may change
+        return type_name, None
+
     def register_info(self, class_info_list, schema=None):
         schema = tools.none_to_default(schema, {})
         self.schema.update(schema)

--- a/openpathsampling/experimental/simstore/class_lookup.py
+++ b/openpathsampling/experimental/simstore/class_lookup.py
@@ -14,6 +14,14 @@ class ClassIsSomething(object):
         self._true_set = set()
         self._false_set = set()
 
+    def force_true(self, cls):
+        self._false_set.discard(cls)
+        self._true_set.add(cls)
+
+    def force_false(self, cls):
+        self._true_set.discard(cls)
+        self._false_set.add(cls)
+
     def __call__(self, obj):
         key = obj.__class__
         if key in self._false_set:

--- a/openpathsampling/experimental/simstore/custom_json.py
+++ b/openpathsampling/experimental/simstore/custom_json.py
@@ -181,6 +181,19 @@ class JSONCodec(object):
             return obj
         return dct
 
+def iterable_to_dict(obj):
+    return {'as_list': list(obj)}
+
+def iterable_from_dict(dct, iterable_type):
+    return iterable_type(dct['as_list'])
+
+tuple_codec = JSONCodec(tuple, iterable_to_dict,
+                        functools.partial(iterable_from_dict,
+                                          iterable_type=tuple))
+set_codec = JSONCodec(set, iterable_to_dict,
+                        functools.partial(iterable_from_dict,
+                                          iterable_type=set))
+
 def bytes_to_dict(obj):
     return {'bytes': obj.decode('latin-1')}
 
@@ -221,4 +234,10 @@ uuid_object_codec = JSONCodec(cls=None,
                               is_my_obj=has_uuid,
                               is_my_dict=lambda x: False)
 
-# TODO: simtk.unit.Quantity  (in the OPS storage, though)
+DEFAULT_CODECS = [
+    uuid_object_codec,
+    bytes_codec,
+    tuple_codec,
+    set_codec,
+    numpy_codec,
+]

--- a/openpathsampling/experimental/simstore/proxy.py
+++ b/openpathsampling/experimental/simstore/proxy.py
@@ -1,0 +1,86 @@
+from .uuids import get_uuid, set_uuid
+
+import logging
+logger = logging.getLogger(__name__)
+
+def unproxy(uuid_mapping):
+    """This is a convenience for unproxying a lot of objects at once.
+    """
+    for uuid, obj in uuid_mapping.items():
+        if isinstance(obj, GenericLazyLoader):
+            uuid_mapping[uuid] = obj.load()
+
+def make_lazy_class(cls_):
+    # this is to mix-in inheritence
+    class LazyLoader(GenericLazyLoader, cls_):
+        pass
+    return LazyLoader
+
+class GenericLazyLoader(object):
+    def __init__(self, uuid, class_, storage):
+        set_uuid(self, uuid)
+        self.storage = storage
+        self.class_ = class_
+        self._loaded_object = None
+
+    def load(self):
+        if self._loaded_object is None:
+            self._loaded_object = \
+                    self.storage.load([get_uuid(self)], force=True)[0]
+        if self._loaded_object is None:
+            raise RuntimeError("UUID not found in storage: "
+                               + get_uuid(self))
+        return self._loaded_object
+
+    def __getattr__(self, attr):
+        # apparently IPython pretty-printing looks for a bunch of
+        # attributes; this means we auto-load if we try to autoprint the
+        # repr in IPython (TODO)
+        return getattr(self.load(), attr)
+
+    def __getitem__(self, item):
+        return self.load()[item]
+
+    def __iter__(self):
+        return self.load().__iter__()
+
+    def __len__(self):
+        return len(self.load())
+
+    def __str__(self):
+        if self._loaded_object:
+            return str(self._loaded_object)
+        else:
+            return repr(self)
+
+    def __repr__(self):
+        if self._loaded_object:
+            return repr(self._loaded_object)
+        else:
+            return ("<LazyLoader for " + str(self.class_.__name__)
+                    + " UUID " + str(self.__uuid__) + ">")
+
+
+class ProxyObjectFactory(object):
+    def __init__(self, storage, serialization_schema):
+        self.storage = storage
+        self.serialization_schema = serialization_schema
+        self.lazy_classes = {}
+
+    def make_lazy(self, cls, uuid):
+        if cls not in self.lazy_classes:
+            self.lazy_classes[cls] = make_lazy_class(cls)
+        return self.lazy_classes[cls](uuid=uuid,
+                                      class_=cls,
+                                      storage=self.storage)
+
+    def make_all_lazies(self, lazies):
+        # lazies is dict of {table_name: list_of_lazy_uuid_rows}
+        all_lazies = {}
+        for (table, lazy_uuid_rows) in lazies.items():
+            logger.debug("Making {} lazy proxies for objects in table '{}'"\
+                         .format(len(lazy_uuid_rows), table))
+            cls = self.serialization_schema.table_to_info[table].cls
+            for row in lazy_uuid_rows:
+                all_lazies[row.uuid] = self.make_lazy(cls, row.uuid)
+        return all_lazies

--- a/openpathsampling/experimental/simstore/serialization.py
+++ b/openpathsampling/experimental/simstore/serialization.py
@@ -17,84 +17,6 @@ def load_list_uuid(json_str, cache_list):
             for uuid in uuid_list]
 
 
-def make_lazy_class(cls_):
-    # this is to mix-in inheritence
-    class LazyLoader(GenericLazyLoader, cls_):
-        pass
-    return LazyLoader
-
-
-class GenericLazyLoader(object):
-    def __init__(self, uuid, class_, storage):
-        serialization.set_uuid(self, uuid)
-        self.storage = storage
-        self.class_ = class_
-        self._loaded_object = None
-
-    def load(self):
-        if self._loaded_object is None:
-            self._loaded_object = \
-                    self.storage.load([serialization.get_uuid(self)],
-                                      force=True)[0]
-        if self._loaded_object is None:
-            raise RuntimeError("UUID not found in storage: " +
-                               serialization.get_uuid(self))
-        return self._loaded_object
-
-    def __getattr__(self, attr):
-        # apparently IPython pretty-printing looks for a bunch of
-        # attributes; this means we auto-load if we try to autoprint the
-        # repr in IPython (TODO)
-        return getattr(self.load(), attr)
-
-    def __getitem__(self, item):
-        return self.load()[item]
-
-    def __iter__(self):
-        return self.load().__iter__()
-
-    def __len__(self):
-        return len(self.load())
-
-    def __str__(self):
-        if self._loaded_object:
-            return str(self._loaded_object)
-        else:
-            return repr(self)
-
-    def __repr__(self):
-        if self._loaded_object:
-            return repr(self._loaded_object)
-        else:
-            return ("<LazyLoader for " + str(self.class_.__name__)
-                    + " UUID " + str(self.__uuid__) + ">")
-
-
-class ProxyObjectFactory(object):
-    def __init__(self, storage, serialization_schema):
-        self.storage = storage
-        self.serialization_schema = serialization_schema
-        self.lazy_classes = {}
-
-    def make_lazy(self, cls, uuid):
-        if cls not in self.lazy_classes:
-            self.lazy_classes[cls] = make_lazy_class(cls)
-        return self.lazy_classes[cls](uuid=uuid,
-                                      class_=cls,
-                                      storage=self.storage)
-
-    def make_all_lazies(self, lazies):
-        # lazies is dict of {table_name: list_of_lazy_uuid_rows}
-        all_lazies = {}
-        for (table, lazy_uuid_rows) in lazies.items():
-            logger.debug("Making {} lazy proxies for objects in table '{}'"\
-                         .format(len(lazy_uuid_rows), table))
-            cls = self.serialization_schema.table_to_info[table].cls
-            for row in lazy_uuid_rows:
-                all_lazies[row.uuid] = self.make_lazy(cls, row.uuid)
-        return all_lazies
-
-
 
 class SchemaDeserializer(object):
     default_handlers = {
@@ -165,11 +87,8 @@ class ToDictSerializer(SchemaDeserializer):
         'list_uuid': serialization.to_bare_json
     }
 
-    # TODO: move this external; that will allow us to remove this class
-    # (use it as input to SchemaSerializer or a class factory for that)
-    # @staticmethod
-    # def make_numpy_handler(dtype, shape):
-        # return lambda arr: arr.astype(dtype=dtype, copy=False).tostring()
+    # TODO: I think this class can be basically remobed; need to transfer
+    # inherited func and attribs to SchemaSerializer
 
     def get_handler_from_factories(self, type_name):
         for factory in self.handler_factories:

--- a/openpathsampling/experimental/simstore/serialization_helpers.py
+++ b/openpathsampling/experimental/simstore/serialization_helpers.py
@@ -9,6 +9,11 @@ from .tools import flatten_all, nested_update, group_by_function
 from .tools import is_iterable, is_mappable, is_numpy_iterable
 from . import tools
 from .class_lookup import is_storage_iterable, is_storage_mappable
+from .proxy import GenericLazyLoader
+from .uuids import (
+    has_uuid, get_uuid, set_uuid, encode_uuid, decode_uuid, encoded_uuid_re,
+    is_uuid_string
+)
 
 # UUID recognition and encoding #####################################
 # Things in here might be modified for performance optimization. In
@@ -18,43 +23,6 @@ import sys
 if sys.version_info > (3, ):
     unicode = str
     long = int
-
-def has_uuid(obj):
-    return hasattr(obj, '__uuid__')
-
-
-def get_uuid(obj):
-    # TODO: I can come up with a better string encoding than this
-    try:
-        return str(obj.__uuid__)
-    except AttributeError as e:
-        if obj is None:
-            return obj
-        else:
-            raise e
-
-def set_uuid(obj, uuid):
-    obj.__uuid__ = long(uuid)
-
-
-def encode_uuid(uuid):
-    return "UUID(" + str(uuid) + ")"
-
-
-def decode_uuid(uuid_str):
-    return uuid_str[5:-1]
-
-
-# use the regular expression when looking through an entire JSON string; use
-# the is_uuid_string method for individual objects
-encoded_uuid_re = re.compile("UUID\((?P<uuid>[\-]?[0-9]+)\)")
-
-
-def is_uuid_string(obj):
-    return (
-        isinstance(obj, (str, unicode))
-        and obj[:5] == 'UUID(' and obj[-1] == ')'
-    )
 
 
 # Getting the list of UUIDs bsed on initial objets ###################
@@ -165,6 +133,10 @@ def get_all_uuids(initial_object, known_uuids=None, class_info=None):
         # found_objs += collections.Counter(o.__class__.__name__)
                                           # for o in objects)
         for obj in objects:
+            # TODO: this might be slow; check performance
+            if isinstance(obj, GenericLazyLoader):
+                obj = obj.load()
+
             # TODO: find a way to ensure that objects doesn't go over
             # duplicates here; see lprofile of default_find_uuids to see how
             # often abort due to being in cache in there, and whether we

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -101,6 +101,11 @@ class SQLStorageBackend(StorableNamedObject):
         self.debug = False
         self.max_query_size = 900
 
+        # maps a specific type name, to generic type info, e.g.
+        # 'ndarray.float32(1651,3)': 'ndarray'
+        # keys here are in the schema, values are (sql_type, size)
+        self.known_types = {k: (k, None) for k in sql_type}
+
         # override later if mode == 'r' or 'a'
         self.schema = {}
         self.table_to_number = {}
@@ -286,8 +291,10 @@ class SQLStorageBackend(StorableNamedObject):
 
         return results
 
-
     ### FROM HERE IS THE GENERIC PUBLIC API
+    def register_type(self, type_str, backend_type):
+        self.known_types[type_str] = backend_type
+
     def register_schema(self, schema, table_to_class,
                         sql_schema_metadata=None):
         """Register (part of) a schema (create necessary tables in DB)

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -28,6 +28,7 @@ sql_type = {
     'float': sql.Float,
     'function': sql.String,
     'ndarray': sql.LargeBinary,
+    'bool': sql.Boolean,
     #TODO add more
 }
 

--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -51,7 +51,12 @@ def _scalarize_singletons(values):
     all other data.
     """
     if isinstance(values, np.ndarray):
-        values.shape = tuple(n for n in values.shape if n != 1)
+        shape = tuple(n for n in values.shape if n != 1)
+        if shape == tuple():
+            values = values.__float__()
+        else:
+            values.shape = shape
+
         # shape = values.shape
         # if len(shape) > 1 and shape[1] == 1:
             # new_shape = tuple([shape[0]] + list(shape)[2:])

--- a/openpathsampling/experimental/simstore/storage.py
+++ b/openpathsampling/experimental/simstore/storage.py
@@ -153,6 +153,12 @@ class GeneralStorage(StorableNamedObject):
             # info.set_defaults(schema)
             # self.class_info.add_class_info(info)
 
+        schema_types = [type_str for attr_list in schema.values()
+                        for _, type_str in attr_list]
+        for type_str in schema_types:
+            backend_type = self.class_info.backend_type(type_str)
+            self.backend.register_type(type_str, backend_type)
+
         if not read_mode or self.backend.table_to_class == {}:
             table_to_class = {table: self.class_info[table].cls
                               for table in schema

--- a/openpathsampling/experimental/simstore/test_attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/test_attribute_handlers.py
@@ -1,0 +1,50 @@
+import pytest
+
+import numpy as np
+
+from .attribute_handlers import *
+
+class TestStandardHandler(object):
+    def setup(self):
+        self.obj = {'str': 'foo',
+                    'int': 42,
+                    'float': 3.14159,
+                    'function': lambda x: x}
+
+    @pytest.mark.parametrize('type_str, expected', [
+        ('str', 'str'), ('int', 'int'), ('float', 'float'),
+        ('function', 'function'), ('ndarray.float32(3,2)', None),
+    ])
+    def test_is_my_type(self, type_str, expected):
+        assert StandardHandler.is_my_type(type_str) == expected
+
+    @pytest.mark.parametrize('type_str', ['str', 'int', 'float', 'function'])
+    def test_serialization_cycle(self, type_str):
+        handler = StandardHandler(type_str)
+        data = self.obj[type_str]
+        ser = handler.serialize(data)
+        deser = handler.deserialize(ser)
+        reser = handler.serialize(deser)
+        assert data == deser
+        assert ser == reser
+
+
+class TestNDArrayHandler(object):
+    def setup(self):
+        self.data = np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+        self.ndarray_handler = NDArrayHandler(('float32', (2,3)))
+
+    @pytest.mark.parametrize('type_str,expected', [
+        ('str', None),
+        ('ndarray.float32(3, 2)', (np.float32, (3, 2))),
+        ('ndarray.float32(3,2)', (np.float32, (3, 2))),
+    ])
+    def test_is_my_type(self, type_str, expected):
+        assert NDArrayHandler.is_my_type(type_str) == expected
+
+    def test_serialization_cycle(self):
+        ser = self.ndarray_handler.serialize(self.data)
+        deser = self.ndarray_handler.deserialize(ser)
+        np.testing.assert_equal(deser, self.data)
+        reser = self.ndarray_handler.serialize(deser)
+        assert ser == reser

--- a/openpathsampling/experimental/simstore/test_class_info.py
+++ b/openpathsampling/experimental/simstore/test_class_info.py
@@ -7,6 +7,8 @@ from .test_utils import (
 
 from .serialization_helpers import default_find_uuids
 
+from .attribute_handlers import DEFAULT_HANDLERS
+
 class MockSpecialSerializationSchema(SerializationSchema):
     def is_special(self, item):
         return isinstance(item, ExtraMockDataObject)
@@ -30,7 +32,7 @@ class TestClassInfo(object):
             cls=MockUUIDObject
         )
         schema = {'mock': MockUUIDObject.schema}
-        class_info.set_defaults(schema)
+        class_info.set_defaults(schema, DEFAULT_HANDLERS)
         assert class_info.table == "mock"
         assert class_info.cls == MockUUIDObject
         assert isinstance(class_info.serializer, SchemaSerializer)

--- a/openpathsampling/experimental/simstore/test_serialization.py
+++ b/openpathsampling/experimental/simstore/test_serialization.py
@@ -7,6 +7,8 @@ from .test_utils import (LoadingStorageMock, all_objects, toy_uuid_maker,
 
 from . import class_info
 
+from .attribute_handlers import DEFAULT_HANDLERS
+
 
 class TestGenericLazyLoader(object):
     def setup(self):
@@ -123,7 +125,7 @@ class TestProxyObjectFactory(object):
                                         cls=MockSimulationObject,
                                         find_uuids=default_find_uuids)
         mock_info = class_info.ClassInfo(table='mock', cls=MockUUIDObject)
-        mock_info.set_defaults(schema)
+        mock_info.set_defaults(schema, DEFAULT_HANDLERS)
         serialization_schema = class_info.SerializationSchema(
             default_info=sim_info,
             schema=schema,

--- a/openpathsampling/experimental/simstore/test_serialization.py
+++ b/openpathsampling/experimental/simstore/test_serialization.py
@@ -1,4 +1,5 @@
 from .serialization import *
+from .proxy import *  # TODO: move this elsewhere
 import pytest
 
 from .serialization_helpers import get_uuid, default_find_uuids

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -56,6 +56,13 @@ def test_scalarize_singletons(array_input, expected):
         np.array(expected)
     )
 
+def test_scalarize_singletons_to_float():
+    arr = np.array([1.0])
+    arr.shape = tuple()
+    scalarized = scalarize_singletons(arr)
+    assert not isinstance(scalarized, np.ndarray)
+    assert isinstance(scalarized, float)
+
 def test_wrap_numpy():
     for inp in [1, [1, 2]]:
         assert isinstance(wrap_numpy(inp), np.ndarray)

--- a/openpathsampling/experimental/simstore/test_tags_table.py
+++ b/openpathsampling/experimental/simstore/test_tags_table.py
@@ -5,6 +5,8 @@ from .class_info import ClassInfo, SerializationSchema
 from .custom_json import JSONSerializerDeserializer, uuid_object_codec
 from .serialization_helpers import default_find_uuids
 
+from .attribute_handlers import DEFAULT_HANDLERS
+
 from openpathsampling.netcdfplus import StorableObject
 
 from .tags_table import *
@@ -39,7 +41,7 @@ class TestTagsTable(object):
             ]
         )
         for info in serialization_schema.class_info_list:
-            info.set_defaults(serialization_schema.schema)
+            info.set_defaults(serialization_schema.schema, DEFAULT_HANDLERS)
         backend = SQLStorageBackend(":memory:", mode='w')
         self.storage = GeneralStorage(backend, serialization_schema,
                                       serialization_schema.schema)

--- a/openpathsampling/experimental/simstore/uuids.py
+++ b/openpathsampling/experimental/simstore/uuids.py
@@ -1,0 +1,49 @@
+# UUID recognition and encoding #####################################
+# Things in here might be modified for performance optimization. In
+# particular, it might be worth using a string representation of the UUID
+# whenever possible (dicts with string keys have a special fast-path)
+
+import re
+import sys
+if sys.version_info > (3, ):
+    unicode = str
+    long = int
+
+def has_uuid(obj):
+    return hasattr(obj, '__uuid__')
+
+
+def get_uuid(obj):
+    # TODO: I can come up with a better string encoding than this
+    try:
+        return str(obj.__uuid__)
+    except AttributeError as e:
+        if obj is None:
+            return obj
+        else:
+            raise e
+
+def set_uuid(obj, uuid):
+    obj.__uuid__ = long(uuid)
+
+
+def encode_uuid(uuid):
+    return "UUID(" + str(uuid) + ")"
+
+
+def decode_uuid(uuid_str):
+    return uuid_str[5:-1]
+
+
+# use the regular expression when looking through an entire JSON string; use
+# the is_uuid_string method for individual objects
+encoded_uuid_re = re.compile("UUID\((?P<uuid>[\-]?[0-9]+)\)")
+
+
+def is_uuid_string(obj):
+    return (
+        isinstance(obj, (str, unicode))
+        and obj[:5] == 'UUID(' and obj[-1] == ')'
+    )
+
+

--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -50,8 +50,12 @@ def from_dict_attr_to_class(from_dict, attr_name):
 def monkey_patch_saving(paths):
     paths.netcdfplus.FunctionPseudoAttribute.to_dict = \
             function_pseudo_attribute_to_dict
-    paths.TPSNetwork.to_dict = \
-            tuple_keys_to_dict(paths.TPSNetwork.to_dict, 'transitions')
+    paths.TPSNetwork.to_dict = tuple_keys_to_dict(
+        paths.TPSNetwork.to_dict, 'transitions'
+    )
+    paths.MISTISNetwork.to_dict = tuple_keys_to_dict(
+        paths.MISTISNetwork.to_dict, 'input_transitions'
+    )
     return paths
 
 def monkey_patch_loading(paths):
@@ -62,9 +66,12 @@ def monkey_patch_loading(paths):
                 attr_name='key_class'
             ))
             # classmethod(function_pseudo_attribute_from_dict)
-    paths.TPSNetwork.from_dict = \
-            classmethod(tuple_keys_from_dict(paths.TPSNetwork.from_dict,
-                                             'transitions'))
+    paths.TPSNetwork.from_dict = classmethod(tuple_keys_from_dict(
+        paths.TPSNetwork.from_dict, 'transitions'
+    ))
+    paths.MISTISNetwork.from_dict = classmethod(tuple_keys_from_dict(
+        paths.MISTISNetwork.from_dict, 'input_transitions'
+    ))
     return paths
 
 def monkey_patch_all(paths):

--- a/openpathsampling/experimental/storage/ops_storage.py
+++ b/openpathsampling/experimental/storage/ops_storage.py
@@ -76,6 +76,11 @@ HANDLERS = DEFAULT_HANDLERS + [SimtkQuantityHandler]
 UNSAFE_CODECS = CODECS + [CallableCodec()]
 SAFE_CODECS = CODECS + [CallableCodec({'safemode': True})]
 
+DATA_CONTAINER_CLASSES = (
+    paths.engines.features.shared.KineticContainer,
+    paths.engines.features.shared.StaticContainer,
+)
+
 class MoveChangeDeserializer(SchemaDeserializer):
     # in general, I think it would be better to reorg MoveChange to only be
     # one class, but this is aimed at fixing problems with reloading
@@ -101,7 +106,6 @@ class MoveChangeDeserializer(SchemaDeserializer):
         obj.input_samples = dct['input_samples']
         set_uuid(obj, uuid)
         return obj
-
 
 
 class OPSSpecialLookup(object):
@@ -319,6 +323,8 @@ class Storage(storage.GeneralStorage):
         for table in table_names:
             logger.info("Attempting to register missing table {} ({})"\
                         .format(table, str(table_to_class[table])))
+            if issubclass(table_to_class[table], DATA_CONTAINER_CLASSES):
+                raise RuntimeError("TODO")
             if issubclass(table_to_class[table], paths.BaseSnapshot):
                 lookups.update(snapshots.snapshot_registration_from_db(
                     storage=self,

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -28,8 +28,7 @@ def unit_from_dict(dct):
     return unit
 
 def quantity_to_dict(obj):
-    return {
-            'value': obj.value,
+    return {'value': obj.value_in_unit(obj.unit),
             '__simtk_unit__': unit_to_dict(obj.unit)}
 
 def quantity_from_dict(dct):
@@ -41,7 +40,7 @@ if HAS_SIMTK:
     simtk_quantity_codec = JSONCodec(
         cls=simtk.unit.Quantity,
         to_dict=quantity_to_dict,
-        from_dict=quantity_to_dict,
+        from_dict=quantity_from_dict,
         is_my_dict=lambda x: '__simtk_unit__' in x
     )
 

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -88,7 +88,3 @@ class SimtkQuantityHandler(AttributeHandler):
     def deserialize(self, data, caches=None):
         unwrapped = self.inner_deserialize(data, caches)
         return self.unit * unwrapped
-
-
-
-

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -1,0 +1,95 @@
+from openpathsampling.experimental.simstore.custom_json import JSONCodec
+from openpathsampling.experimental.simstore.attribute_handlers import (
+    AttributeHandler, NDArrayHandler
+)
+import re
+
+try:
+    import simtk.unit
+except ImportError:
+    HAS_SIMTK = False
+else:
+    HAS_SIMTK = True
+    # note that we need to force simstore to not treat this as an iterable
+    from openpathsampling.experimental.simstore.class_lookup import \
+        is_storage_iterable
+    is_storage_iterable.force_false(simtk.unit.Quantity)
+
+### JSON SERIALIZATION ###################################################
+
+def unit_to_dict(obj):
+    return {p.name: int(power)
+            for p, power in obj.iter_base_or_scaled_units()}
+
+def unit_from_dict(dct):
+    unit = simtk.unit.Unit({})
+    for u_name, u_power in dct.items():
+        unit *= getattr(simtk.unit, u_name) ** u_power
+    return unit
+
+def quantity_to_dict(obj):
+    return {
+            'value': obj.value,
+            '__simtk_unit__': unit_to_dict(obj.unit)}
+
+def quantity_from_dict(dct):
+    unit = unit_from_dict(dct['__simtk_unit__'])
+    return dct['value'] * unit
+
+
+if HAS_SIMTK:
+    simtk_quantity_codec = JSONCodec(
+        cls=simtk.unit.Quantity,
+        to_dict=quantity_to_dict,
+        from_dict=quantity_to_dict,
+        is_my_dict=lambda x: '__simtk_unit__' in x
+    )
+
+### DIRECT SERIALIZATION #################################################
+_simtk_re = re.compile("simtk\((.*)\)\*((ndarray|float).*)")
+
+
+def simtk_unit_from_string(unit_str):
+    # TODO: add safety checks; parse the AST and ensure that all attributes
+    # are of `unit` and that all operations are mul/div/pow
+    from simtk import unit
+    return eval(unit_str, {'unit': unit})
+
+
+class SimtkQuantityHandler(AttributeHandler):
+    # NOTE: only supports ndarrays and floats for now
+    def __init__(self, type_info):
+        super().__init__(type_info)
+        self.unit_str, self.wrapped_type = type_info
+        self.unit = simtk_unit_from_string(self.unit_str)
+        if self.wrapped_type == 'float':
+            self.inner_serialize = lambda x: x
+            self.inner_deserialize = lambda x, _: x
+            self.backend_type = 'float'
+            self.type_size = None
+        else:
+            np_handler = NDArrayHandler.from_type_string(self.wrapped_type)
+            self.inner_serialize = np_handler.serialize
+            self.inner_deserialize = np_handler.deserialize
+            self.backend_type = np_handler.backend_type
+            self.type_size = np_handler.type_size
+
+    @staticmethod
+    def is_my_type(type_str):
+        m_simtk_quantity = _simtk_re.match(type_str)
+        if m_simtk_quantity:
+            unit = m_simtk_quantity.group(1)
+            wrapped_type = m_simtk_quantity.group(2)
+            return unit, wrapped_type
+
+    def serialize(self, obj):
+        unwrapped = obj.value_in_unit(self.unit)
+        return self.inner_serialize(unwrapped)
+
+    def deserialize(self, data, caches=None):
+        unwrapped = self.inner_deserialize(data, caches)
+        return self.unit * unwrapped
+
+
+
+

--- a/openpathsampling/experimental/storage/snapshots.py
+++ b/openpathsampling/experimental/storage/snapshots.py
@@ -96,7 +96,7 @@ def snapshot_registration_info(snapshot_instance, snapshot_number):
     attr_infos = []
     for table in [tbl for tbl in schema.keys() if tbl != 'snapshot']:
         obj = getattr(snapshot_instance, table)
-        attr_infos.append(ClassInfo(table=real_table,
+        attr_infos.append(ClassInfo(table=real_table[table],
                                     cls=obj.__class__,
                                     lookup_result=(engine_uuid,
                                                    obj.__class__)))

--- a/openpathsampling/experimental/storage/snapshots.py
+++ b/openpathsampling/experimental/storage/snapshots.py
@@ -1,7 +1,7 @@
 # NOTE: this is part of the OPS-specific stuff
 from ..simstore.class_info import ClassInfo
-
-from ..simstore.serialization_helpers import get_uuid
+from ..simstore.uuids import get_uuid
+from ..simstore.proxy import GenericLazyLoader
 
 def _nested_schema_entries(schema_entries, lazies):
     """Recursive algorithm to create all schema entries
@@ -96,6 +96,8 @@ def snapshot_registration_info(snapshot_instance, snapshot_number):
     attr_infos = []
     for table in [tbl for tbl in schema.keys() if tbl != 'snapshot']:
         obj = getattr(snapshot_instance, table)
+        if isinstance(obj, GenericLazyLoader):
+            obj = obj.load()
         attr_infos.append(ClassInfo(table=real_table[table],
                                     cls=obj.__class__,
                                     lookup_result=(engine_uuid,

--- a/openpathsampling/experimental/storage/snapshots.py
+++ b/openpathsampling/experimental/storage/snapshots.py
@@ -73,12 +73,12 @@ def snapshot_registration_from_db(storage, schema, class_info, table_name):
     lookup_result = (engine_uuid, cls)
     proposed_lookups = {table_name: lookup_result}
     attributes = schema[table_name]
-    for (attr, type_name) in attributes:
-        is_object = type_name in ['lazy', 'uuid', 'uuid_list']
-        is_table = attr in schema
-        if is_object and is_table:
-            cls = storage.backend.table_to_class[attr]
-            proposed_lookups[attr] = (engine_uuid, cls)
+    # for (attr, type_name) in attributes:
+        # is_object = type_name in ['lazy', 'uuid', 'uuid_list']
+        # is_table = attr in schema
+        # if is_object and is_table:
+            # cls = storage.backend.table_to_class[attr]
+            # proposed_lookups[attr] = (engine_uuid, cls)
     return proposed_lookups
 
 

--- a/openpathsampling/experimental/storage/test_snapshot_integrations.py
+++ b/openpathsampling/experimental/storage/test_snapshot_integrations.py
@@ -18,8 +18,8 @@ from openpathsampling.experimental.simstore import SQLStorageBackend
 class TestSnapshotIntegration(object):
     # TODO: no use of self anywhere in here; this might become bare test
     # functions
-
     def _make_storage(self, mode):
+        Storage._known_storages = {}
         backend = SQLStorageBackend("test.sql", mode=mode)
         storage = Storage.from_backend(
             backend=backend,
@@ -48,9 +48,19 @@ class TestSnapshotIntegration(object):
         )
         return snap
 
-    @pytest.mark.parametrize('integration', ['gromacs'])
+    def _make_openmm_snap(self):
+        mm = pytest.importorskip('simtk.openmm')
+        traj_file = data_filename('ala_small_traj.pdb')
+        traj = paths.engines.openmm.tools.ops_load_trajectory(traj_file)
+        snap = traj[0]
+        return snap
+
+    @pytest.mark.parametrize('integration', ['gromacs', 'openmm'])
     def test_integration(self, integration):
-        make_snap = {'gromacs': self._make_gromacs_snap}[integration]
+        make_snap = {
+            'gromacs': self._make_gromacs_snap,
+            'openmm': self._make_openmm_snap,
+        }[integration]
         snap = make_snap()
 
         storage = self._make_storage(mode='w')


### PR DESCRIPTION
This will make it possible to store OpenMM snapshots in SimStore.

Note:  this changes OpenMM snapshots so that the `KineticContainer` and `StaticContainer` objects, which are wrappers around the velocities and coordinates/box vectors, respectively, now also carry information about the engine of their associated snapshot. This *should* be fully backward compatible with the old storage. I've done some minor testing of that, but it would be nice if someone with older files (maybe @sroet, @arjunwadhawan, or @hejung?) could double-check that they can open/analyze older netcdfplus files when they check out this branch.

This also involves significant refactoring under the hood of SimStore, making it more flexible with regards to adding user-defined types.

I'm going to add some unit tests and docstrings before declaring it ready for review, but it's already at a point where I'm hoping to get some help with checking backward compatibility.