### PR TITLE
SimStore: Simplify OPS Storage constructor

### DIFF
--- a/openpathsampling/experimental/storage/ops_storage.py
+++ b/openpathsampling/experimental/storage/ops_storage.py
@@ -243,11 +243,18 @@ ops_simulation_classes = {
 
 
 class Storage(storage.GeneralStorage):
-    def __init__(self, backend, schema, class_info, fallbacks=None,
-                 safemode=False):
+    def __init__(self, filename, mode='r', fallbacks=None, safemode=False):
         # TODO: this will change to match the current notation
-        super(Storage, self).__init__(backend, schema, class_info,
-                                      fallbacks, safemode)
+        backend = sql_backend.SQLStorageBackend(filename, mode=mode)
+        self.snapshots = None
+        super(Storage, self).__init__(
+            backend=backend,
+            schema=ops_schema,
+            class_info=ops_class_info,
+            simulation_classes=ops_simulation_classes,
+            fallbacks=fallbacks,
+            safemode=safemode
+        )
 
         self.n_snapshot_types = 0
         self.snapshots = SnapshotsTable(self)


### PR DESCRIPTION
Finally settling internally on the API: You can now set up an OPS storage with:

```python
storage = Storage(filename, mode)
```

No more of this `from_backend` stuff!