### PR TITLE
Remove things deprecated for 2.0

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -59,7 +59,7 @@ from .bias_function import (
 )
 
 from .collectivevariable import (
-    FunctionCV, MDTrajFunctionCV, MSMBFeaturizerCV,
+    FunctionCV, MDTrajFunctionCV,
     InVolumeCV, CollectiveVariable, CoordinateGeneratorCV,
     CoordinateFunctionCV, CallableCV, PyEMMAFeaturizerCV,
     GeneratorCV)
@@ -91,7 +91,7 @@ from .movechange import (
     RejectedMaxLengthSampleMoveChange
 )
 
-from .pathmover import Details, MoveDetails, SampleDetails
+from .pathmover import Details
 
 from .pathmover import (
     RandomChoiceMover, PathMover, ConditionalSequentialMover,

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -118,42 +118,6 @@ def version_tuple_to_string(version_tuple):
 
 # DEPRECATED THINGS SLATED FOR REMOVAL IN 2.0
 
-OPENMMTOOLS_VERSION = Deprecation(
-    problem="{OPS} {version} will require OpenMMTools 0.15 or later.",
-    remedy="Please update OpenMMTools.",
-    remove_version=(2, 0),
-    deprecated_in=(0, 9, 6)
-)
-
-SAMPLE_DETAILS = Deprecation(
-    problem="SampleDetails will be removed in {OPS} {version}.",
-    remedy="Use generic Details class instead.",
-    remove_version=(2, 0),
-    deprecated_in=(0, 9, 3)
-)
-
-MOVE_DETAILS = Deprecation(
-    problem="MoveDetails will be removed in {OPS} {version}.",
-    remedy="Use generic Details class instead.",
-    remove_version=(2, 0),
-    deprecated_in=(0, 9, 3)
-)
-
-SAVE_RELOAD_OLD_TPS_NETWORK = Deprecation(
-    problem="Old TPS networks will not be reloaded in {OPS} {version}.",
-    remedy="This file may not work with {OPS} {version}.",
-    remove_version=(2, 0),
-    deprecated_in=(0, 9 ,3)
-)
-
-MSMBUILDER = Deprecation(
-    problem=("MSMBuilder is no longer maintained. "
-             + "MSMBFeaturizer is no longer officially supported."),
-    remedy="Create a CoordinateFunctionCV based on MSMBuilderFeaturizers.",
-    remove_version=(2, 0),
-    deprecated_in=(1, 1, 0)
-)
-
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735
 def has_deprecations(cls):

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -30,18 +30,9 @@ def restore_custom_integrator_interface(integrator):
     except ImportError:  # pragma: no cover
         pass  # if openmmtools doesn't exist, can't restore interface
     else:
-        try:
-            # openmmtools 0.15 or later
-            from openmmtools.utils import RestorableOpenMMObject \
-                    as RestorableObject
-        except ImportError: # pragma: no cover
-            # DEPRECATED: remove in 2.0 (support for openmmtools < 0.15)
-            from openpathsampling.deprecations import OPENMMTOOLS_VERSION
-            OPENMMTOOLS_VERSION.warn()
-            from openmmtools.integrators import RestorableIntegrator \
-                    as RestorableObject
-
-        if RestorableObject.is_restorable(integrator):
+        # openmmtools 0.15 or later
+        from openmmtools.utils import RestorableOpenMMObject
+        if RestorableOpenMMObject.is_restorable(integrator):
             success = RestorableObject.restore_interface(integrator)
             logger.debug("Restored interface to integrator: " + str(success))
             # this return a bool based on success; we could error on fail,

--- a/openpathsampling/high_level/interface_set.py
+++ b/openpathsampling/high_level/interface_set.py
@@ -216,22 +216,13 @@ class GenericVolumeInterfaceSet(InterfaceSet):
                'intersect_with': self.intersect_with,
                'lambdas': self.lambdas,
                'direction': self.direction,
-               'volumes': self.volumes}
-        try:
-            dct.update({'cv_max': self.cv_max})
-        except AttributeError:  # pragma: no cover
-            # reverse compatibility; deprecated in 0.9.5, remove in 2.0
-            pass
-
+               'volumes': self.volumes,
+               'cv_max': self.cv_max}
         return dct
 
     def _load_from_dict(self, dct):
         self.cv = dct['cv']
-        try:
-            self.cv_max = dct['cv_max']
-        except KeyError:  # pragma: no cover
-            # reverse compatibility; deprecated in 0.9.4, remove in 2.0
-            pass
+        self.cv_max = dct['cv_max']
         self.minvals = dct['minvals']
         self.maxvals = dct['maxvals']
         self.intersect_with = dct['intersect_with']

--- a/openpathsampling/high_level/network.py
+++ b/openpathsampling/high_level/network.py
@@ -203,15 +203,8 @@ class GeneralizedTPSNetwork(TransitionNetwork):
             'x_sampling_transitions': self._sampling_transitions,
             'special_ensembles': self.special_ensembles
         }
-        try:
-            ret_dict['initial_states'] = self.initial_states
-            ret_dict['final_states'] = self.final_states
-        except AttributeError:  # pragma: no cover
-            # DEPRECATED: remove for 2.0
-            from openpathsampling.deprecations import \
-                    SAVE_RELOAD_OLD_TPS_NETWORK
-            SAVE_RELOAD_OLD_TPS_NETWORK.warn()
-            pass  # backward compatibility
+        ret_dict['initial_states'] = self.initial_states
+        ret_dict['final_states'] = self.final_states
         return ret_dict
 
     @property
@@ -225,18 +218,9 @@ class GeneralizedTPSNetwork(TransitionNetwork):
         super(GeneralizedTPSNetwork, network).__init__()
         network._sampling_transitions = dct['x_sampling_transitions']
         network.transitions = dct['transitions']
-        try:
-            network.initial_states = dct['initial_states']
-            network.final_states = dct['final_states']
-        except KeyError:  # pragma: no cover
-            # DEPRECATED: remove for 2.0
-            pass  # backward compatibility
-        try:
-            network.special_ensembles = dct['special_ensembles']
-        except KeyError:  # pragma: no cover
-            # DEPRECATED: remove for 2.0
-            network.special_ensembles = {None: {}}
-            # default behavior for backward compatibility
+        network.initial_states = dct['initial_states']
+        network.final_states = dct['final_states']
+        network.special_ensembles = dct['special_ensembles']
         return network
 
     @classmethod
@@ -263,7 +247,10 @@ class GeneralizedTPSNetwork(TransitionNetwork):
 
         dict_result = {
             'x_sampling_transitions': sampling,
-            'transitions': transitions
+            'transitions': transitions,
+            'initial_states': initial_states,
+            'final_states': final_states,
+            'special_ensembles': {},
         }
         dict_result.update(kwargs)
         network = cls.from_dict(dict_result)

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -16,9 +16,6 @@ from openpathsampling.pathmover_inout import InOutSet, InOut
 from .ops_logging import initialization_logging
 from .treelogic import TreeMixin
 
-from openpathsampling.deprecations import deprecate, has_deprecations
-from openpathsampling.deprecations import SAMPLE_DETAILS, MOVE_DETAILS
-
 from future.utils import with_metaclass
 
 logger = logging.getLogger(__name__)
@@ -2630,28 +2627,3 @@ class Details(StorableObject):
             else:
                 mystr += str(key) + " = " + str(self.__dict__[key]) + '\n'
         return mystr
-
-
-@has_deprecations
-@deprecate(MOVE_DETAILS)
-class MoveDetails(Details):
-    """Details of the move as applied to a given replica
-
-    Specific move types may have add several other attributes for each
-    MoveDetails object. For example, shooting moves will also include
-    information about the shooting point selection, etc.
-    """
-
-    def __init__(self, **kwargs):
-        super(MoveDetails, self).__init__(**kwargs)
-
-
-# leave this for potential backwards compatibility
-@has_deprecations
-@deprecate(SAMPLE_DETAILS)
-class SampleDetails(Details):
-    """Details of a sample
-    """
-
-    def __init__(self, **kwargs):
-        super(SampleDetails, self).__init__(**kwargs)

--- a/openpathsampling/tests/test_api.py
+++ b/openpathsampling/tests/test_api.py
@@ -6,7 +6,7 @@ from .test_helpers import data_filename
 
 # select the file you want to use, or change to the file for your own API
 # (add more files to ensure that we support 1.0, 1.1, etc.)
-API_FILES = ["ops1x0_api.txt"]
+API_FILES = []  # we'll establish API 2.0 before release
 COMBO_ERROR = True
 
 @pytest.mark.parametrize('api_file', API_FILES)


### PR DESCRIPTION
**ANNOUNCING THE DEV-2.0 BRANCH!**

If you have changes that must change the API, please target the `dev-2.0` branch. I'm starting that off by removing all deprecated functionality (at least, what I could find).

For most improvements and new functionality, please continue to target the default branch. Changes there will be merged into `dev-2.0` regularly. I expect that there will be several more releases of OPS (at least up to 1.6) before 2.0 is finalized.