### PR TITLE
fix omt is None error in test suite

### DIFF
--- a/openpathsampling/tests/test_features.py
+++ b/openpathsampling/tests/test_features.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import
 from builtins import hex
 from builtins import object
-from nose.tools import (assert_equal, assert_not_equal,
-                        assert_almost_equal, raises, assert_in)
+from nose.tools import raises
 
-from nose.plugins.skip import Skip, SkipTest
-from .test_helpers import (true_func, assert_equal_array_array,
-                           make_1d_traj, assert_items_equal, u)
+from nose.plugins.skip import SkipTest
+from .test_helpers import u
 
 import logging
 
@@ -43,7 +41,7 @@ class TestFeatures(object):
         assert(toy_copy.velocities[1] == 1.0)
 
     def test_copy_with_replacement_openmm(self):
-        if not paths.integration_tools.HAS_OPENMM:
+        if not paths.integration_tools.HAS_OPENMM or omt is None:
             raise SkipTest
         # test an openmm snapshot
         sys = omt.testsystems.AlanineDipeptideVacuum()
@@ -71,4 +69,4 @@ class TestFeatures(object):
         init_vel = np.array([3.0, 4.0])
         toy_snap = toy_engine.Snapshot(
             coordinates=init_coord, velocities=init_vel)
-        toy_copy = toy_snap.copy_with_replacement(dummy=0)
+        toy_snap.copy_with_replacement(dummy=0)


### PR DESCRIPTION
If `OpenMM` is installed, but `OpenMMTools` isn't,  the test `TestFeatures.test_copy_with_replacement_openmm`
fails with:
```python
    def test_copy_with_replacement_openmm(self):
        if not paths.integration_tools.HAS_OPENMM:
            raise SkipTest
        # test an openmm snapshot
>       sys = omt.testsystems.AlanineDipeptideVacuum()
E       AttributeError: 'NoneType' object has no attribute 'testsystems'
```

This is due to the code-block at the start of that file:
```
try:                                                                            
    import openmmtools as omt                                                   
except ImportError:                                                             
    omt = None   
```

This alters the test such that it is also skipped if `omt is None`

Also cleans up some `pep8` complains in that file (mostly unused imports)