### PR TITLE
Fix so SimStore tests pass without simtk.unit

### DIFF
--- a/openpathsampling/experimental/simstore/test_custom_json.py
+++ b/openpathsampling/experimental/simstore/test_custom_json.py
@@ -4,7 +4,6 @@ import pytest
 
 import numpy as np
 from numpy import testing as npt
-from simtk import unit
 
 from . import test_utils
 

--- a/openpathsampling/experimental/storage/ops_storage.py
+++ b/openpathsampling/experimental/storage/ops_storage.py
@@ -40,7 +40,11 @@ from ..simstore import SQLStorageBackend  # TODO: generalize
 from . import snapshots
 from .snapshots_table import SnapshotsTable
 
-from .simtk_unit import simtk_quantity_codec, SimtkQuantityHandler
+try:
+    from .simtk_unit import simtk_quantity_codec, SimtkQuantityHandler
+except ImportError:
+    simtk_quantity_codec = None
+    SimtkQuantityHandler = None
 
 import logging
 logger = logging.getLogger(__name__)
@@ -71,8 +75,10 @@ ops_schema = {
 ops_schema_sql_metadata = {}
 
 # this defines the simulation object serializer for OPS
-CODECS = DEFAULT_CODECS + [simtk_quantity_codec]
-HANDLERS = DEFAULT_HANDLERS + [SimtkQuantityHandler]
+EXTRA_CODECS = [simtk_quantity_codec] if simtk_quantity_codec else []
+EXTRA_HANDLERS = [SimtkQuantityHandler] if SimtkQuantityHandler else []
+CODECS = DEFAULT_CODECS + EXTRA_CODECS
+HANDLERS = DEFAULT_HANDLERS + EXTRA_HANDLERS
 
 UNSAFE_CODECS = CODECS + [CallableCodec()]
 SAFE_CODECS = CODECS + [CallableCodec({'safemode': True})]

--- a/openpathsampling/experimental/storage/test_collective_variables.py
+++ b/openpathsampling/experimental/storage/test_collective_variables.py
@@ -119,6 +119,7 @@ class TestMDTrajFunctionCV(object):
     def setup(self):
         if not HAS_MDTRAJ:
             pytest.skip("Unable to import MDTraj")
+        pytest.importorskip('simtk.unit')
 
         self.mdt = md.load(data_filename("ala_small_traj.pdb"))
         top = ops_omm.topology.MDTrajTopology(self.mdt.topology)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,9 @@ test =
     pytest-cov
     coveralls
     ipynbtest
+simstore =
+    sqlalchemy
+    dill
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Without `simtk.unit` installed, SimStore wasn't working. We only test SimStore with full integrations (similar problem to #954).

This also adds an `extras` for SimStore, so (in future releases) `pip install openpathsampling[simstore]` will install the extra requirements for SimStore as well.