### PR TITLE
Make more deterministic test

### DIFF
--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -1,11 +1,8 @@
 from builtins import object
 import collections
-from nose.tools import assert_equal, assert_almost_equal, raises
-from nose.plugins.skip import Skip, SkipTest
+from nose.tools import assert_equal, raises
 from openpathsampling.tests.test_helpers import (
-    assert_equal_array_array, assert_not_equal_array_array, make_1d_traj,
-    assert_items_equal, CalvinistDynamics
-)
+    make_1d_traj, assert_items_equal, CalvinistDynamics)
 import pytest
 
 from openpathsampling.shooting import *
@@ -34,6 +31,14 @@ class TestUniformSelector(SelectorTest):
         pick_idxs = [sel.pick(self.mytraj) for _ in range(100)]
         assert_equal(set(collections.Counter(pick_idxs).keys()), {1, 2, 3})
 
+    def test_0_probability(self):
+        # This test that we can, in fact, return 0.0 for illegal trajecotories
+        # Pad more than there are frames in the trajctory
+        uniform = UniformSelector(pad_start=3, pad_end=3)
+        for frame in self.mytraj:
+            assert uniform.probability(frame, self.mytraj) == 0.0
+
+
 
 class TestShootingPointSelector(SelectorTest):
     def test_probability(self):
@@ -44,6 +49,13 @@ class TestShootingPointSelector(SelectorTest):
         for frame in self.mytraj:
             assert sel.probability(frame, self.mytraj) == \
                     uniform.probability(frame, self.mytraj)
+
+    def test_0_probability(self):
+        # This test that we can, in fact, return 0.0 for illegal trajecotries
+        # Pad more than there are frames in the trajctory
+        uniform = UniformSelector(pad_start=3, pad_end=3)
+        assert uniform.probability(self.mytraj[0], self.mytraj) == 0.0
+
 
 class TestGaussianBiasSelector(SelectorTest):
     def setup(self):

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -1,6 +1,5 @@
 from builtins import object
 import collections
-from nose.tools import assert_equal, raises
 from openpathsampling.tests.test_helpers import (
     make_1d_traj, assert_items_equal, CalvinistDynamics)
 import pytest
@@ -29,7 +28,7 @@ class TestUniformSelector(SelectorTest):
     def test_pick(self):
         sel = UniformSelector()  # pad_start = pad_end = 1
         pick_idxs = [sel.pick(self.mytraj) for _ in range(100)]
-        assert_equal(set(collections.Counter(pick_idxs).keys()), {1, 2, 3})
+        assert set(collections.Counter(pick_idxs).keys()) == {1, 2, 3}
 
     def test_0_probability(self):
         # This test that we can, in fact, return 0.0 for illegal trajecotories
@@ -37,7 +36,6 @@ class TestUniformSelector(SelectorTest):
         uniform = UniformSelector(pad_start=3, pad_end=3)
         for frame in self.mytraj:
             assert uniform.probability(frame, self.mytraj) == 0.0
-
 
 
 class TestShootingPointSelector(SelectorTest):
@@ -94,9 +92,9 @@ class TestFirstFrameSelector(SelectorTest):
     def test_pick(self):
         sel = FirstFrameSelector()
         sp = sel.pick(self.mytraj)
-        assert_equal(sp, 0)
+        assert sp == 0
         snap = self.mytraj[sp]
-        assert_equal(snap.coordinates[0][0], -0.5)
+        assert snap.coordinates[0][0] == -0.5
 
     def test_shooting_move(self):
         self.shooter = ForwardShootMover(
@@ -106,12 +104,11 @@ class TestFirstFrameSelector(SelectorTest):
         )
         change = self.shooter.move(self.gs)
         samples = change.trials
-        assert_equal(len(samples), 1)
-        assert_equal(change.accepted, True)
-        assert_items_equal(
-            [-0.5, -0.4, -0.3, -0.2, -0.1],
-            [s.coordinates[0][0] for s in samples[0].trajectory]
-        )
+        assert len(samples) == 1
+        assert change.accepted is True
+        truth = [-0.5, -0.4, -0.3, -0.2, -0.1],
+
+        assert truth == [s.coordinates[0][0] for s in samples[0].trajectory]
 
     def test_f(self):
         sel = FirstFrameSelector()
@@ -124,9 +121,9 @@ class TestFinalFrameSelector(SelectorTest):
     def test_pick(self):
         sel = FinalFrameSelector()
         sp = sel.pick(self.mytraj)
-        assert_equal(sp, 4)
+        assert sp == 4
         snap = self.mytraj[sp]
-        assert_equal(snap.coordinates[0][0], 0.5)
+        assert snap.coordinates[0][0] == 0.5
 
     def test_shooting_move(self):
         self.shooter = BackwardShootMover(
@@ -136,7 +133,7 @@ class TestFinalFrameSelector(SelectorTest):
         )
         change = self.shooter.move(self.gs)
         samples = change.trials
-        assert_equal(change.accepted, True)
+        assert change.accepted is True
         assert_items_equal(
             [0.1, 0.2, 0.3, 0.4, 0.5],
             [s.coordinates[0][0] for s in samples[0].trajectory]
@@ -158,17 +155,18 @@ class TestConstrainedSelector(SelectorTest):
     def test_pick(self):
         mytraj = make_1d_traj(coordinates=[-0.5, -0.4, -0.3, -0.1,
                                            0.1, 0.2, 0.3, 0.5])
-        assert_equal(self.sel.pick(mytraj), 4)
+        assert self.sel.pick(mytraj) == 4
 
-    @raises(RuntimeError)
     def test_all_in_interface(self):
         mytraj = make_1d_traj(coordinates=[-0.5, -0.4, -0.3, -0.1,
                                            -0.1, -0.2, -0.3])
-        self.sel.pick(mytraj)
+        # Assert that the right runtime error pops up
+        with pytest.raises(RuntimeError, match="Interface constrained"):
+            self.sel.pick(mytraj)
 
     def test_sum_bias(self):
         mytraj = make_1d_traj(coordinates=[-0.5, 0.1, 0.2, 0.3, 0.5])
-        assert_equal(self.sel.sum_bias(mytraj), 1.0)
+        assert self.sel.sum_bias(mytraj) == 1.0
 
     def test_f(self):
         mytraj = make_1d_traj(coordinates=[-0.5, -0.4, -0.3, -0.1,
@@ -176,7 +174,7 @@ class TestConstrainedSelector(SelectorTest):
         expected_idx = 4
         idx = self.sel.pick(mytraj)
         frame = mytraj[idx]
-        assert_equal(self.sel.f(frame, mytraj), 1.0)
+        assert self.sel.f(frame, mytraj) == 1.0
         for idx1, frame in enumerate(mytraj):
             if (idx1 != expected_idx):
-                assert_equal(self.sel.f(frame, mytraj), 0.0)
+                assert self.sel.f(frame, mytraj) == 0.0

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -48,12 +48,6 @@ class TestShootingPointSelector(SelectorTest):
             assert sel.probability(frame, self.mytraj) == \
                     uniform.probability(frame, self.mytraj)
 
-    def test_0_probability(self):
-        # This test that we can, in fact, return 0.0 for illegal trajecotries
-        # Pad more than there are frames in the trajctory
-        uniform = UniformSelector(pad_start=3, pad_end=3)
-        assert uniform.probability(self.mytraj[0], self.mytraj) == 0.0
-
 
 class TestGaussianBiasSelector(SelectorTest):
     def setup(self):

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -100,8 +100,7 @@ class TestFirstFrameSelector(SelectorTest):
         samples = change.trials
         assert len(samples) == 1
         assert change.accepted is True
-        truth = [-0.5, -0.4, -0.3, -0.2, -0.1],
-
+        truth = [-0.5, -0.4, -0.3, -0.2, -0.1]
         assert truth == [s.coordinates[0][0] for s in samples[0].trajectory]
 
     def test_f(self):


### PR DESCRIPTION
In the doc update #963, I saw from codecov that the following line was not reliably hit in `shooting.py`:
![Screenshot from 2021-01-22 09-18-41](https://user-images.githubusercontent.com/19587267/105466885-3096be00-5c95-11eb-9a8d-e294b74941ee.png)
 
This adds a test to force that code path in the first commit: https://github.com/openpathsampling/openpathsampling/commit/1842ed9fd04bda947cba7c01f7d7016aaf9a5269

The second commit (https://github.com/openpathsampling/openpathsampling/commit/31e11bf38db860cdcec4f74561dc90ec4b614e60) drops `nose` in the `test_shooting.py` and uses `pytest` instead as an incremental update towards #756 

Edit: (https://github.com/openpathsampling/openpathsampling/pull/964/commits/dc6e428b22e106707e6fdc528fdc30e62e5ac83d) removes the duplicate of the test added in the first commit (I had copied it to a different spot around in the first commit, but forgot to remove the original one :facepalm: )