### PR TITLE
Update ujson pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     svgwrite
     networkx
     matplotlib
-    ujson<2
+    ujson !=2.*, !=3.*, !=4.0.0, !=4.0.1
     mdtraj
 # mdtraj is not technically required, but we co-package it because it is
 # required for many integrations with other packages

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     svgwrite
     networkx
     matplotlib
-    ujson !=2.*, !=3.*, !=4.0.0, !=4.0.1
+    ujson!=2.*,!=3.*,!=4.0.0,!=4.0.1
     mdtraj
 # mdtraj is not technically required, but we co-package it because it is
 # required for many integrations with other packages


### PR DESCRIPTION
With the [release of ujson 4.0.2](https://github.com/ultrajson/ultrajson/releases/tag/4.0.2), we should be able to relax the pin of ujson without regressing on #922. Since that release is very new, I'm not going to assume that it is in all distribution channels yet, so the pin is kind of complicated (still allowing ujson <2 while also allowing >=4.0.2).

By the next release, I hope we'll be able to just pin `ujson >=4.0.2`.