### PR TITLE
Update README.md CI badge to GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/openpathsampling/openpathsampling.svg?branch=master)](https://travis-ci.org/openpathsampling/openpathsampling)
+![Tests](https://github.com/openpathsampling/openpathsampling/workflows/Tests/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/openpathsampling/openpathsampling/badge.svg?branch=master)](https://coveralls.io/github/openpathsampling/openpathsampling?branch=master)
 
 # OpenPathSampling

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Tests](https://github.com/openpathsampling/openpathsampling/workflows/Tests/badge.svg?branch=master)
+[![Tests](https://github.com/openpathsampling/openpathsampling/workflows/Tests/badge.svg?branch=master)](https://github.com/openpathsampling/openpathsampling/actions?query=workflow%3ATests)
 [![Coverage Status](https://coveralls.io/repos/github/openpathsampling/openpathsampling/badge.svg?branch=master)](https://coveralls.io/github/openpathsampling/openpathsampling?branch=master)
 
 # OpenPathSampling


### PR DESCRIPTION
Conda started trowing exceptions this morning and I wanted to see if any other builds were failing. I thought the ones here had passed (from the travis badge), but that badge has not been running for 21 days.

This PR swaps that badge to the GA one