### PR TITLE
Fix broken WHAMing if an InterfaceSet has more than 10 interfaces

### DIFF
--- a/openpathsampling/numerics/histogram.py
+++ b/openpathsampling/numerics/histogram.py
@@ -430,7 +430,7 @@ def histograms_to_pandas_dataframe(hists, fcn="histogram", fcn_args={}):
             if t != b:
                 raise Warning("Bins don't match up")
         if hist.name is None:
-            hist.name = str(hists.index(hist))
+            hist.name = int(hists.index(hist))
 
         hist_data = {
             "histogram" : hist,
@@ -447,7 +447,6 @@ def histograms_to_pandas_dataframe(hists, fcn="histogram", fcn_args={}):
             "cumulative" : "r"
         }[fcn]
         xvals = hist.xvals(bin_edge)
-
         frames.append(pd.DataFrame({hist.name : hist_data}, index=xvals))
     all_frames = pd.concat(frames, axis=1)
     return all_frames.fillna(0.0)

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -16,7 +16,8 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 import collections
 
 from openpathsampling.numerics import (Histogram, SparseHistogram,
-                                       HistogramPlotter2D)
+                                       HistogramPlotter2D,
+                                       histograms_to_pandas_dataframe)
 
 class MockAxes(object):
     def __init__(self, xticks, yticks):
@@ -25,6 +26,23 @@ class MockAxes(object):
 
     def get_xticks(self): return self.xticks
     def get_yticks(self): return self.yticks
+
+class TestFunctions(object):
+    def test_histograms_to_pandas_dataframe(self):
+        data = [1.0, 1.1, 1.2, 1.3, 2.0, 1.4, 2.3, 2.5, 3.1, 3.5]
+        # This length needs to be larger than 10 to see a difference between
+        # str ordering and int ordering
+        hists = [Histogram(n_bins=5) for i in range(11)]
+        for hist in hists:
+            _ = hist.histogram(data)
+        df = histograms_to_pandas_dataframe(hists)
+        # sort like is done in analysis
+        df = df.sort_index(axis=1)
+
+        # This breaks if the sorting is done based on strings as that will
+        # return [0, 1, 10 ...] instead of [0, 1, 2, ...]
+        for i, c in enumerate(df.columns):
+            assert str(c) == str(i)
 
 class TestHistogram(object):
     def setup(self):
@@ -166,6 +184,7 @@ class TestHistogram(object):
         histo = Histogram(bin_width=0.5, bin_range=(-1.0, 3.5))
         histo.histogram([3.5])
         assert histo.reverse_cumulative() != 0
+
 
 class TestSparseHistogram(object):
     def setup(self):

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -2,9 +2,6 @@ from __future__ import division
 from __future__ import absolute_import
 from past.utils import old_div
 from builtins import object
-from nose.tools import (assert_equal, assert_not_equal, raises,
-                        assert_almost_equal)
-from nose.plugins.skip import SkipTest
 from .test_helpers import assert_items_almost_equal, assert_items_equal
 import pytest
 import logging
@@ -19,6 +16,7 @@ from openpathsampling.numerics import (Histogram, SparseHistogram,
                                        HistogramPlotter2D,
                                        histograms_to_pandas_dataframe)
 
+
 class MockAxes(object):
     def __init__(self, xticks, yticks):
         self.xticks = xticks
@@ -26,6 +24,7 @@ class MockAxes(object):
 
     def get_xticks(self): return self.xticks
     def get_yticks(self): return self.yticks
+
 
 class TestFunctions(object):
     def test_histograms_to_pandas_dataframe(self):
@@ -44,11 +43,11 @@ class TestFunctions(object):
         for i, c in enumerate(df.columns):
             assert str(c) == str(i)
 
+
 class TestHistogram(object):
     def setup(self):
         self.data = [1.0, 1.1, 1.2, 1.3, 2.0, 1.4, 2.3, 2.5, 3.1, 3.5]
         self.nbins = 5
-        hist_counts = [5, 0, 2, 1, 1, 1]
         self.bins = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5]
         self.left_bin_edges = (1.0,)
         self.bin_widths = (0.5,)
@@ -59,93 +58,91 @@ class TestHistogram(object):
         self.hist_nbins = Histogram(n_bins=5)
         self.hist_nbins_binwidth = Histogram(n_bins=5, bin_width=1.0)
         self.hist_nbins_range = Histogram(n_bins=5, bin_range=(1.0, 3.5))
-        self.hist_binwidth_range = Histogram(bin_width=0.5, bin_range=(1.0, 3.5))
+        self.hist_binwidth_range = Histogram(bin_width=0.5,
+                                             bin_range=(1.0, 3.5))
 
     def test_initialization(self):
-        assert_equal(self.default_hist.bins, 20)
+        assert self.default_hist.bins == 20
 
-        assert_equal(self.hist_nbins.bins, 5)
-        assert_equal(self.hist_nbins.bin_width, None)
+        assert self.hist_nbins.bins == 5
+        assert self.hist_nbins.bin_width is None
 
-        assert_equal(self.hist_nbins_binwidth.bins, 5)
-        assert_equal(self.hist_nbins_binwidth.bin_width, None)
+        assert self.hist_nbins_binwidth.bins == 5
+        assert self.hist_nbins_binwidth.bin_width is None
 
-        assert_items_equal(self.hist_nbins_range.bins, self.bins)
-        assert_items_equal(self.hist_binwidth_range.bins, self.bins)
-
+        assert self.hist_nbins_range.bins == self.bins
+        assert self.hist_binwidth_range.bins == self.bins
 
     def test_build_from_data(self):
         hist = self.hist_nbins.histogram(self.data)
-        assert_equal(self.hist_nbins.count, 10)
-        assert_items_equal(hist, self.hist)
+        assert self.hist_nbins.count == 10
+        assert hist == self.hist
 
         hist2 = self.hist_binwidth_range.histogram(self.data)
-        assert_equal(self.hist_binwidth_range.count, 10)
-        assert_items_equal(hist2, self.hist)
+        assert self.hist_binwidth_range.count == 10
+        assert hist2 == self.hist
 
-    @raises(RuntimeError)
     def test_build_from_data_fail(self):
         histo = Histogram(n_bins=5)
-        histo.histogram()
+        with pytest.raises(RuntimeError, match="called without data"):
+            histo.histogram()
 
     def test_add_data_to_histogram(self):
         histogram = Histogram(n_bins=5, bin_range=(1.0, 3.5))
         hist = histogram.add_data_to_histogram(self.data)
-        assert_equal(histogram.count, 10)
-        assert_items_equal(hist, self.hist)
+        assert histogram.count == 10
+        assert hist == self.hist
 
         hist2 = histogram.add_data_to_histogram(self.data)
-        assert_items_equal(hist2, hist+hist)
-        assert_equal(histogram.count, 20)
+        assert hist2 == hist+hist
+        assert histogram.count == 20
 
     def test_compare_parameters(self):
-        assert_equal(self.hist_nbins.compare_parameters(None), False)
-        assert_equal(
-            self.hist_nbins_range.compare_parameters(self.hist_binwidth_range),
-            True
+        assert self.hist_nbins.compare_parameters(None) is False
+        assert (
+            self.hist_nbins_range.compare_parameters(self.hist_binwidth_range)
+            is True
         )
-        assert_equal(
-            self.hist_binwidth_range.compare_parameters(self.hist_nbins_range),
-            True
+        assert (
+            self.hist_binwidth_range.compare_parameters(self.hist_nbins_range)
+            is True
         )
         histo = Histogram(n_bins=5)
-        assert_equal(self.hist_nbins_range.compare_parameters(histo), False)
+        assert self.hist_nbins_range.compare_parameters(histo) is False
         histo.histogram(self.data)
-        assert_equal(self.hist_nbins_range.compare_parameters(histo), False)
-        assert_equal(
-            self.hist_nbins_range.compare_parameters(self.hist_nbins),
-            False
+        assert self.hist_nbins_range.compare_parameters(histo) is False
+        assert (
+            self.hist_nbins_range.compare_parameters(self.hist_nbins)
+            is False
         )
-        assert_equal(histo.compare_parameters(self.hist_nbins), False)
-        assert_equal(self.hist_nbins.compare_parameters(histo), False)
+        assert histo.compare_parameters(self.hist_nbins) is False
+        assert self.hist_nbins.compare_parameters(histo) is False
 
     def test_xvals(self):
         histo = Histogram(n_bins=5)
-        hist = histo.histogram(self.data) # need this to set the bins
-        assert_equal(histo.left_bin_edges, self.left_bin_edges)
-        assert_equal(histo.bin_widths, self.bin_widths)
-        assert_items_equal(histo.xvals("l"), [1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
-        assert_items_equal(histo.xvals("r"), [1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
-        assert_items_equal(histo.xvals("m"),
-                           [1.25, 1.75, 2.25, 2.75, 3.25, 3.75])
-
+        _ = histo.histogram(self.data)  # need this to set the bins
+        assert histo.left_bin_edges == self.left_bin_edges
+        assert histo.bin_widths == self.bin_widths
+        assert all(histo.xvals("l") == [1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
+        assert all(histo.xvals("r") == [1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
+        assert all(histo.xvals("m") == [1.25, 1.75, 2.25, 2.75, 3.25, 3.75])
 
     def test_normalization(self):
         histo = Histogram(n_bins=5)
-        hist = histo.histogram(self.data)
-        assert_equal(histo._normalization(), 5.0)
+        _ = histo.histogram(self.data)
+        assert histo._normalization() == 5.0
 
     def test_normalized(self):
         histo = Histogram(n_bins=5)
-        hist = histo.histogram(self.data)
-        assert_items_equal(list(histo.normalized().values()),
-                           [1.0, 0.0, 0.4, 0.2, 0.2, 0.2])
-        assert_items_equal(list(histo.normalized(raw_probability=True).values()),
-                           [0.5, 0.0, 0.2, 0.1, 0.1, 0.1])
+        _ = histo.histogram(self.data)
+        assert (list(histo.normalized().values()) ==
+                [1.0, 0.0, 0.4, 0.2, 0.2, 0.2])
+        assert (list(histo.normalized(raw_probability=True).values()) ==
+                [0.5, 0.0, 0.2, 0.1, 0.1, 0.1])
 
     def test_cumulative(self):
         histo = Histogram(n_bins=5)
-        hist = histo.histogram(self.data)
+        _ = histo.histogram(self.data)
         cumulative = list(histo.cumulative(None).values())
         assert_items_almost_equal(cumulative, [5.0, 5.0, 7.0, 8.0, 9.0, 10.0])
         assert_items_almost_equal(histo.cumulative(maximum=1.0),
@@ -195,30 +192,30 @@ class TestSparseHistogram(object):
 
     def test_correct(self):
         correct_results = collections.Counter({
-            (0, 0) : 1,
-            (0, 2) : 2,
-            (1, 3) : 1
+            (0, 0): 1,
+            (0, 2): 2,
+            (1, 3): 1
         })
-        assert_equal(self.histo._histogram, correct_results)
+        assert self.histo._histogram == correct_results
 
     def test_call(self):
         histo_fcn = self.histo()
         # voxels we have filled
-        assert_equal(histo_fcn((0.25, 0.65)), 2)
-        assert_equal(histo_fcn((0.01, 0.09)), 1)
-        assert_equal(histo_fcn((0.61, 0.89)), 1)
+        assert histo_fcn((0.25, 0.65)) == 2
+        assert histo_fcn((0.01, 0.09)) == 1
+        assert histo_fcn((0.61, 0.89)) == 1
         # empty voxel gives 0
-        assert_equal(histo_fcn((2.00, 2.00)), 0)
+        assert histo_fcn((2.00, 2.00)) == 0
 
     def test_normalized(self):
         raw_prob_normed = self.histo.normalized(raw_probability=True)
-        assert_almost_equal(raw_prob_normed((0.25, 0.65)), 0.5)
-        assert_almost_equal(raw_prob_normed((0.01, 0.09)), 0.25)
-        assert_almost_equal(raw_prob_normed((0.61, 0.89)), 0.25)
+        assert pytest.approx(raw_prob_normed((0.25, 0.65))) == 0.5
+        assert pytest.approx(raw_prob_normed((0.01, 0.09))) == 0.25
+        assert pytest.approx(raw_prob_normed((0.61, 0.89))) == 0.25
         normed_fcn = self.histo.normalized()
-        assert_almost_equal(normed_fcn((0.25, 0.65)), old_div(0.5,0.15))
-        assert_almost_equal(normed_fcn((0.01, 0.09)), old_div(0.25,0.15))
-        assert_almost_equal(normed_fcn((0.61, 0.89)), old_div(0.25,0.15))
+        assert pytest.approx(normed_fcn((0.25, 0.65))) == old_div(0.5, 0.15)
+        assert pytest.approx(normed_fcn((0.01, 0.09))) == old_div(0.25, 0.15)
+        assert pytest.approx(normed_fcn((0.61, 0.89))) == old_div(0.25, 0.15)
 
 
 class TestHistogramPlotter2D(object):
@@ -234,15 +231,17 @@ class TestHistogramPlotter2D(object):
         xbins = self.plotter.to_bins(vals, 0)
         assert_items_almost_equal(xbins, [-0.2, 1.0, 1.6])
         ybins = self.plotter.to_bins(vals, 1)
-        assert_items_almost_equal(ybins, [0.0, 2.0, 3.0])
-        assert_equal(self.plotter.to_bins(None, 0), None)
+        truth = [0.0, 2.0, 3.0]
+        for y, t in zip(ybins, truth):
+            assert pytest.approx(y) == t
+        assert self.plotter.to_bins(None, 0) is None
 
     def test_axis_input(self):
         xt, xr, xl = self.plotter.axis_input(hist=[-1.0, 1.0, 2.0],
                                              ticklabels=None,
                                              lims=None,
                                              dof=0)
-        assert_equal(xt, None)
+        assert xt is None
         assert_items_equal(xr, (-1.0, 2.0))
         assert_items_equal(xl, (0, 3))
 
@@ -284,4 +283,3 @@ class TestHistogramPlotter2D(object):
         assert_items_equal(ylabels, ["-1.90", "-0.10", "1.70"])
 
         self.plotter.label_format = old_format
-


### PR DESCRIPTION
This fixes an error that took a long time to track down and manifests itself with the same error as #920 (or with a wrong answer in more extreme cases).

**TLDR:** WHAMing  with more than 10 interfaces in an interfaceset was horribly broken, should now work 


https://github.com/openpathsampling/openpathsampling/commit/14bcc2f5ef927167994f737bdb31b18bd542fc88 fixes the issue and adds a regression test
https://github.com/openpathsampling/openpathsampling/commit/bf8241c3e6651d49163771152ede98131f6875e1 updates the test file to use `pytest` instead (incremental update for #756) 

How this PR came to be:

This manifested itself as the same error as #920 (partial stacktrace):
```python
IndexError                                Traceback (most recent call last)
...

~/github_files/openpathsampling/openpathsampling/analysis/tis/crossing_probability.py in from_ensemble_histograms(self, hists)
    128         print(df.index)
    129         # TODO: remove WHAM-specific name here
--> 130         tcp = self.combiner.wham_bam_histogram(df).to_dict()
    131         return LookupFunction(tcp.keys(), tcp.values())

~/github_files/openpathsampling/openpathsampling/numerics/wham.py in wham_bam_histogram(self, input_df)
    503         """
    504         cleaned = self.prep_reverse_cumulative(input_df)
--> 505         self.check_cleaned_overlaps(cleaned)
    506         guess = self.guess_lnZ_crossing_probability(cleaned)
    507         sum_k_Hk_Q = self.sum_k_Hk_Q(cleaned)

~/github_files/openpathsampling/openpathsampling/numerics/wham.py in check_cleaned_overlaps(self, cleaned_df)
    477             prev_data = cleaned_df[prev_col]
    478 
--> 479             first_nonzero = col_data[col_data != 0.0].index[0]
    480             if not prev_data[first_nonzero] > 0.0:
    481                 # use not and > to account for NaNs

~/miniconda3/envs/tstis/lib/python3.7/site-packages/pandas/core/indexes/base.py in __getitem__(self, key)
   4099         if is_scalar(key):
   4100             key = com.cast_scalar_indexer(key, warn_float=True)
-> 4101             return getitem(key)
   4102 
   4103         if isinstance(key, slice):

IndexError: index 0 is out of bounds for axis 0 with size 0
```
From that issue we know that that happens if everything before the interface is set to `0` and everything after that interface is also `0`. So the first thing I did was setting cutoff to `0` to circumvent the same issue as in #920. 

This did not solve the error so I decided to add print functions to the `prep_reverse_cumulative` function of `numerics.wham.py` (sidenote: [`%autoreload` is great](https://switowski.com/blog/ipython-autoreload) and makes it so that I can debug this without waiting an hour to reload my data).

This is is the first block of  print(`df`), before any cleaning, notice anything peculiar about the column ordering?
 ```
            0         1        10       11        12        13        14  \
-2.6  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-2.5  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-2.4  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-2.3  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-2.2  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-2.1  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-2.0  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.9  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.8  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.7  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.6  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.5  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.4  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.3  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.2  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.1  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-1.0  1.000000  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.9  0.739261  1.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.8  0.548452  0.826174  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.7  0.221778  0.286713  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.6  0.038961  0.022977  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.5  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.4  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.3  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.2  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
-0.1  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.0  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.1  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.2  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.3  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.4  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.5  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.6  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.7  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.8  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 0.9  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.0  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.1  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.2  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.3  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.4  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.5  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.6  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.7  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.8  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 1.9  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.0  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.1  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.2  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.3  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.4  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.5  0.000000  0.000000  1.000000  1.00000  1.000000  1.000000  1.000000   
 2.6  0.000000  0.000000  0.325674  0.52048  0.340659  0.416583  0.643357   
```
Now here is where things go horribly wrong: line `137-142` of `wham.py` are:
```python
          if self.interfaces is not None:                                         
              # use the interfaces values to set anything before that value to    
              # zero                                                              
              if type(self.interfaces) is not pd.Series:                          
                  self.interfaces = pd.Series(data=self.interfaces,                  
                                              index=df.columns)  
```
Because this is how `self.interfaces` looks before converting it to a series:
```python
[-1.0, -0.9, -0.8, -0.7000000000000001, -0.6000000000000001, -0.5000000000000001, -0.40000000000000013, -0.30000000000000016, -0.20000000000000018, -0.1000000000000002, -2.220446049250313e-16, 0.09999999999999964, 0.19999999999999973, 0.2999999999999998, 0.3999999999999997, 0.49999999999999956, 0.5999999999999996, 0.6999999999999997, 0.7999999999999996, 0.8999999999999995, 0.9999999999999996]
```
and this is after
```python
0    -1.000000e+00
1    -9.000000e-01
10   -8.000000e-01
11   -7.000000e-01
12   -6.000000e-01
13   -5.000000e-01
14   -4.000000e-01
15   -3.000000e-01
16   -2.000000e-01
17   -1.000000e-01
18   -2.220446e-16
19    1.000000e-01
2     2.000000e-01
20    3.000000e-01
3     4.000000e-01
4     5.000000e-01
5     6.000000e-01
6     7.000000e-01
7     8.000000e-01
8     9.000000e-01
9     1.000000e+00
``` 

So this now maps the 3rd interface to the data of the 10th, but even worse is the 13th interface is mapped to the data of the second! The data from my 2nd interface does not have any data that is past the 13th, so this results in a column of `0`s after cleaning (everything up to the 13th interface is set to 0).

Now, this PR does not actually alter `wham.py` because the real issue is the sorting of the columns of the dataframe.
This is done at line `124-127` of `openpathsampling/analysis/tis/crossing_probability.py`
```python
        df = paths.numerics.histograms_to_pandas_dataframe(                     
            input_hists,                                                        
            fcn="reverse_cumulative"                                               
        ).sort_index(axis=1)  
```
So this sorts axis=1, and what we see is that th columns are sorted, but as if they are `str`s, as those are sorted character by character, which is how you end up with `0, 1, 10, 11, ..., 19, 2, 20, 3, ...` . Now where do these strings come from? 

That is what is actually fixed in this PR
If we look at the called function (`histograms_to_pandas_dataframe`) on line 432-433 the follwing code exists:
```python
      if hist.name is None:                                                   
              hist.name = str(hists.index(hist))     
```
and these `str` indices end up in the dataframe. Hence this PR to convert them to an `int` instead.