### PR TITLE
fix numpy 1.20 DeprecationWarnings

### DIFF
--- a/openpathsampling/netcdfplus/netcdfplus.py
+++ b/openpathsampling/netcdfplus/netcdfplus.py
@@ -877,7 +877,7 @@ class NetCDFPlus(netCDF4.Dataset):
             setter = lambda v: np.array(v)
 
         elif var_type == 'bool':
-            getter = lambda v: v.astype(np.bool).tolist()
+            getter = lambda v: v.astype(bool).tolist()
             setter = lambda v: np.array(v, dtype=np.int8)
 
         elif var_type == 'index':


### PR DESCRIPTION
With the release of `numpy` `1.20` came a couple `DeprecationWarning`s, mainly about `np.float` or `np.bool` just being an alias for the python internal. The one Warning that is left (in my test setup) comes from `openmmtools` and is handled in https://github.com/choderalab/openmmtools/pull/497