### PR TITLE
Cache AllOutX volume

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/setup-python@v2
       - uses: conda-incubator/setup-miniconda@v2
         with: 

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -2239,10 +2239,13 @@ class AllOutXEnsemble(AllInXEnsemble):
     """
     Ensemble of trajectories with all frames outside the given volume
     """
+    def __init__(self, volume, trusted=True):
+        super(AllOutXEnsemble, self).__init__(volume, trusted)
+        self._cached_volume = ~self.volume
 
     @property
     def _volume(self):
-        return ~self.volume
+        return self._cached_volume
 
     def _str(self):
         return 'x[t] in {0} for all t'.format(self._volume)


### PR DESCRIPTION
There is no reason to create a new volume every time we use `AllOutXEnsemble.can_append` etc.