### PR TITLE
Prevent excessive trajectory slicing

### DIFF
--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1715,6 +1715,7 @@ class SequentialEnsemble(Ensemble):
 
         traj_final = len(trajectory)
         final_ens = len(self.ensembles) - 1
+        ltraj = list(trajectory)
         # print traj_final, final_ens
         # logging startup
         if cache.debug_enabled:  # pragma: no cover
@@ -1767,7 +1768,7 @@ class SequentialEnsemble(Ensemble):
                     "(" + str(subtraj_first) + "," + str(subtraj_final) + ")"
                 )
             if subtraj_final - subtraj_first > 0:
-                subtraj = trajectory[slice(subtraj_first, subtraj_final)]
+                subtraj = ltraj[slice(subtraj_first, subtraj_final)]
                 if ens_num == final_ens:
                     if subtraj_final == traj_final:
                         # we're in the last ensemble and the whole
@@ -1816,7 +1817,7 @@ class SequentialEnsemble(Ensemble):
                     # next frame might satisfy next ensemble
                     if self._use_cache:
                         prev_slice = cache.contents['assignments'][ens_num - 1]
-                        prev_subtraj = trajectory[prev_slice]
+                        prev_subtraj = ltraj[prev_slice]
                         prev_ens = self.ensembles[ens_num - 1]
                         if prev_ens.can_append(prev_subtraj, trusted=True):
                             logger.debug(
@@ -1883,6 +1884,7 @@ class SequentialEnsemble(Ensemble):
         subtraj_final = len(trajectory)
         ens_final = len(self.ensembles) - 1
         ens_num = ens_final
+        ltraj = list(trajectory)
 
         if self._use_cache:
             _ = cache.check(trajectory)
@@ -1945,7 +1947,7 @@ class SequentialEnsemble(Ensemble):
                 "(" + str(subtraj_first) + "," + str(subtraj_final) + ")"
             )
             if subtraj_final - subtraj_first > 0:
-                subtraj = trajectory[slice(subtraj_first, subtraj_final)]
+                subtraj = ltraj[slice(subtraj_first, subtraj_final)]
                 if ens_num == first_ens:
                     if subtraj_first == traj_first:
                         logger.debug("Returning can_prepend")
@@ -1987,7 +1989,7 @@ class SequentialEnsemble(Ensemble):
                     if self._use_cache:
                         prev_slice = cache.contents['assignments'][ens_num + 1]
                         logger.debug("prev_slice " + str(prev_slice))
-                        prev_subtraj = trajectory[prev_slice]
+                        prev_subtraj = ltraj[prev_slice]
                         logger.debug("prev_subtraj " + str(prev_subtraj))
                         logger.debug("traj " + str(trajectory))
                         prev_ens = self.ensembles[ens_num + 1]

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1481,6 +1481,7 @@ class SequentialEnsemble(Ensemble):
         self._cache_can_prepend = EnsembleCache(-1)
         self._cache_strict_can_prepend = EnsembleCache(-1)
         self._cache_check_reverse = EnsembleCache(-1)
+        self._zero_traj = paths.Trajectory([])
 
         # sanity checks
         if len(self.min_overlap) != len(self.max_overlap):
@@ -1573,7 +1574,7 @@ class SequentialEnsemble(Ensemble):
                     subtraj_first = subtraj_final
             else:
                 if ens_num <= final_ens and \
-                        self.ensembles[ens_num](paths.Trajectory([])):
+                        self.ensembles[ens_num](self._zero_traj):
                     ens_num += 1
                     transitions.append(subtraj_final)
                     subtraj_first = subtraj_final
@@ -1831,7 +1832,7 @@ class SequentialEnsemble(Ensemble):
                         "returning True")
                     return True
 
-                elif self.ensembles[ens_num](paths.Trajectory([])):
+                elif self.ensembles[ens_num](self._zero_traj):
                     logger.debug(
                         "Moving on because of allowed zero-length ensemble")
                     ens_num += 1
@@ -2005,7 +2006,7 @@ class SequentialEnsemble(Ensemble):
                         "All frames assigned, more ensembles to go: "
                         "returning True")
                     return True
-                elif self.ensembles[ens_num](paths.Trajectory([])):
+                elif self.ensembles[ens_num](self._zero_traj):
                     logger.debug(
                         "Moving on because of allowed zero-length ensemble")
                     ens_num -= 1


### PR DESCRIPTION
Some more UUID optimization coming from #892.

So while running the test uuid system from #892, I noticed **a lot** of `Trajectory` objects getting generated. Looking at the code, **every time you slice a Trajectory, you generate a new Trajectory**.

To test how many and were I added the following code to trajectory.py (and where) 
```diff
+++ b/openpathsampling/engines/trajectory.py
@@ -23,6 +23,7 @@ class Trajectory(list, StorableObject):
     """
 
     engine = None
+    kill_count = 1000000
 
     def __init__(self, trajectory=None):
         """
@@ -45,6 +46,10 @@ class Trajectory(list, StorableObject):
             else:
                 self.extend(trajectory)
 
+        Trajectory.kill_count -= 1
+        if Trajectory.kill_count < 0:
+            raise RuntimeError("KILLED")
+
```

and ran the following script:
```python
sset = testscheme.initial_conditions_from_trajectories([eng_trj, eng_trj2,
                                                        eng_trj3],
                                                        strategies=[
                                                            'split',
                                                            'extend-complex',
                                                            'extend-minimal'])
# Error out early
sset.sanity_check()
testscheme.assert_initial_conditions(sset)

#Equilibrate
equilibration = paths.PathSampling(
    storage=None,
    sample_set=sset,
    move_scheme=testscheme
)
initial = 100000
paths.Trajectory.kill_count=initial
equilibration.run(10)
print("trajs_generated = "+str(initial-paths.Trajectory.kill_count))
```
(important part here is that I only look at the number of trajectories created after initialization)

Here is a table of number of trajectories created from running this 6 times on `master` and 6 times on this branch
|  | main| this PR |
| --- | --- | --- | 
||77857|20728|
||64553|22852|
||73042|14508|
||76004|18205|
||75349|27016|
||82440|33964|
|*mean*| 74874 | 22879 |

This PR saves **70%** of all Trajectory objects generated (during sampling). `23_000` still an insane amount in my opinion for just `10` mc steps, but this is at least a decent step into (hopefully) not running into #892 as often.

In the long term; sliced trajectories should probably return read_only views (without an uuid)  and not new Trajectories