### PR TITLE
Move n_dofs to engine; add engine.has_constraints()

### DIFF
--- a/openpathsampling/engines/openmm/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/openmm/features/instantaneous_temperature.py
@@ -10,19 +10,7 @@ def n_degrees_of_freedom(snapshot):
         number of degrees of freedom in this system (after accounting for
         constraints)
     """
-    # dof calculation taken from OpenMM's StateDataReporter
-    n_spatial = 3  # can we get this programmatically?
-    system = snapshot.engine.simulation.system
-    n_particles = system.getNumParticles()
-    dofs_particles = sum([n_spatial for i in range(n_particles)
-                               if system.getParticleMass(i) > 0*u.dalton])
-    dofs_constaints = system.getNumConstraints()
-    dofs_motion_removers = 0
-    if any(type(system.getForce(i)) == mm.CMMotionRemover
-           for i in range(system.getNumForces())):
-        dofs_motion_removers += 3
-    dofs = dofs_particles - dofs_constaints - dofs_motion_removers
-    return dofs
+    return self.engine.n_degrees_of_freedom()
 
 @property
 def instantaneous_temperature(snapshot):

--- a/openpathsampling/engines/openmm/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/openmm/features/instantaneous_temperature.py
@@ -10,7 +10,7 @@ def n_degrees_of_freedom(snapshot):
         number of degrees of freedom in this system (after accounting for
         constraints)
     """
-    return self.engine.n_degrees_of_freedom()
+    return snapshot.engine.n_degrees_of_freedom()
 
 @property
 def instantaneous_temperature(snapshot):

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -6,6 +6,7 @@ from openpathsampling.integration_tools import (
 try:
     import simtk.openmm
     import simtk.openmm.app
+    from simtk import unit as u
     from simtk.openmm.app.internal.unitcell import reducePeriodicBoxVectors
 except ImportError:
     # this happens when we directly import tools (e.g., for
@@ -454,3 +455,47 @@ def load_trr(trr_file, top, velocities=True):
 
     traj = trajectory_from_mdtraj(mdt, velocities=vel)
     return reduce_trajectory_box_vectors(traj)
+
+def n_dofs_from_system(system):
+    """Get the number of degrees of freedom from an Openmm System
+
+    Parameters
+    ----------
+    system : :class:`simtk.openmm.System`
+        object describing the system
+
+    Returns
+    -------
+    int :
+        number of degrees of freedom
+    """
+    # dof calculation based on OpenMM's StateDataReporter
+    n_spatial = 3
+    n_particles = system.getNumParticles()
+    dofs_particles = sum([n_spatial for i in range(n_particles)
+                          if system.getParticleMass(i) > 0*u.dalton])
+    dofs_constaints = system.getNumConstraints()
+    dofs_motion_removers = 0
+    has_cm_motion_remover = any(
+        type(system.getForce(i)) == simtk.openmm.CMMotionRemover
+        for i in range(system.getNumForces())
+    )
+    if has_cm_motion_remover:
+        dofs_motion_removers += 3
+    dofs = dofs_particles - dofs_constaints - dofs_motion_removers
+    return dofs
+
+def has_constraints_from_system(system):
+    """Get the number of degrees of freedom from an Openmm System
+
+    Parameters
+    ----------
+    system : :class:`simtk.openmm.System`
+        object describing the system
+
+    Returns
+    -------
+    bool :
+        whether there are constraints
+    """
+    return system.getNumConstraints() > 0

--- a/openpathsampling/engines/toy/engine.py
+++ b/openpathsampling/engines/toy/engine.py
@@ -134,3 +134,10 @@ class ToyEngine(DynamicsEngine):
         for i in range(self.n_steps_per_frame):
             self.integ.step(sys=self)
         return self.current_snapshot
+
+    def n_degrees_of_freedom(self):
+        topol = self.topology
+        return topol.n_atoms * topol.n_spatial
+
+    def has_constraints(self):
+        return False

--- a/openpathsampling/engines/toy/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/toy/features/instantaneous_temperature.py
@@ -9,8 +9,7 @@ def n_degrees_of_freedom(snapshot):
         number of degrees of freedom in this system (after accounting for
         constraints)
     """
-    topol = snapshot.engine.topology
-    return topol.n_atoms * topol.n_spatial
+    return snapshot.engine.n_degrees_of_freedom()
 
 @property
 def instantaneous_temperature(snapshot):

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -266,6 +266,15 @@ class GeneralizedDirectionModifier(SnapshotModifier):
             input snapshot to check for validity
         """
         try:
+            has_constraints = engine.has_constraints()
+        except AttributeError:
+            pass
+        else:
+            if has_constraints:
+                raise RuntimeError("Cannot use this snapshot modifier with "
+                                   "an engine that has constraints.")
+
+        try:
             box_vectors = snapshot.box_vectors
         except AttributeError:
             box_vectors = None

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -247,10 +247,11 @@ class GeneralizedDirectionModifier(SnapshotModifier):
     SingleAtomVelocityDirectionModifier
     """
     def __init__(self, delta_v, subset_mask=None,
-                 remove_linear_momentum=True):
+                 remove_linear_momentum=True, engine=None):
         super(GeneralizedDirectionModifier, self).__init__(subset_mask)
         self.delta_v = delta_v
         self.remove_linear_momentum = remove_linear_momentum
+        self.engine = engine
 
     def _verify_snapshot(self, snapshot):
         """
@@ -266,7 +267,7 @@ class GeneralizedDirectionModifier(SnapshotModifier):
             input snapshot to check for validity
         """
         try:
-            has_constraints = engine.has_constraints()
+            has_constraints = self.engine.has_constraints()
         except AttributeError:
             pass
         else:

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -4,6 +4,7 @@
 from __future__ import division
 from __future__ import absolute_import
 
+import pytest
 from builtins import range
 from builtins import object
 from past.utils import old_div
@@ -263,3 +264,18 @@ class TestOpenMMEngine(object):
 
         # make sure there is no change!
         assert_equal(init_samp[0].trajectory, init_traj)
+
+    @pytest.mark.parametrize('has_constraints', [True, False])
+    def test_has_constraints(self, has_constraints):
+        omt = pytest.importorskip('openmmtools')
+        constraints = app.HBonds if has_constraints else None
+        system = omt.testsystems.AlanineDipeptideVacuum(
+            constraints=constraints
+        )
+        template = peng.snapshot_from_testsystem(system)
+        engine = peng.Engine(
+            topology=template.topology,
+            system=system.system,
+            integrator=omt.integrators.VVVRIntegrator()
+        )
+        assert engine.has_constraints() == has_constraints

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -317,6 +317,26 @@ class TestGeneralizedDirectionModifier(object):
         )
         self.openmm_modifier._verify_snapshot(constr_snap)
 
+    def test_verify_engine_constraints(self):
+        ad_vacuum_constr = omt.testsystems.AlanineDipeptideVacuum()
+        constrained_engine = omm_engine.Engine(
+            topology=self.test_snap.topology,
+            system=ad_vacuum_constr.system,
+            integrator=omt.integrators.VVVRIntegrator()
+        )
+        modifier = GeneralizedDirectionModifier(
+            1.2 * u.nanometer / u.picosecond,
+            engine=constrained_engine
+        )
+        # this is a hack because ndofs not defined in TestsystemEngine
+        self.openmm_engine.current_snapshot = self.test_snap
+        snap = self.openmm_engine.current_snapshot
+        # when it checks based on the engine, it should be fine
+        self.openmm_modifier._verify_snapshot(snap)
+        # when modifier overrides snap.engine, it errors
+        with pytest.raises(RuntimeError):
+            modifier._verify_snapshot(snap)
+
     def test_verify_snapshot_box_vectors(self):
         ad_explicit = omt.testsystems.AlanineDipeptideExplicit(
             constraints=None,

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -334,7 +334,7 @@ class TestGeneralizedDirectionModifier(object):
         # when it checks based on the engine, it should be fine
         self.openmm_modifier._verify_snapshot(snap)
         # when modifier overrides snap.engine, it errors
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="constraints"):
             modifier._verify_snapshot(snap)
 
     def test_verify_snapshot_box_vectors(self):

--- a/openpathsampling/tests/test_toy_dynamics.py
+++ b/openpathsampling/tests/test_toy_dynamics.py
@@ -239,6 +239,9 @@ class TestToyEngine(object):
         self.sim.start(snapshot=snap)
         self.sim.stop([snap])
 
+    def test_has_constraints(self):
+        assert not self.sim.has_constraints()
+
 
 # === TESTS FOR TOY INTEGRATORS ===========================================
 


### PR DESCRIPTION
This moves the calculation of the number of degrees of freedom to the engine. This is expected to be a constant for an engine -- at least, the engines we have so far don't allow number of particles to change -- so it makes sense to cache it (for OpenMM), instead of calculating it over and over with the `snapshot.n_degrees_of_freedom` feature.

This also adds an `engine.has_constraints()` method. This gives a cleaner way to abort if an engine with constraints tries to use one of the `DirectionModifier` snapshot modifiers.