### PR TITLE
Add codecov.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     name: "Tests"
     strategy:
+      # NOTE: when changing the test matrix, update the after_n_builds in
+      # codecov.yml to match the number of builds in the matrix
       matrix:
         CONDA_PY:
           #- 3.9

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+
+codecov:
+  notify:
+    wait_for_ci: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,4 @@ coverage:
 codecov:
   notify:
     wait_for_ci: true
+    after_n_builds: 3


### PR DESCRIPTION
Adding [config file](https://docs.codecov.io/docs/codecovyml-reference) for CodeCov. In particular, I'm hoping that I can get CodeCov to wait until the integration tests are done before adding its comment/status indicator. It's a little annoying to get the email (which, unlike the comment, doesn't update) saying CodeCov hates the PR after only the minimal test suite has come in. Also, I keep seeing the red X on a PR and checking to see where the tests went wrong, when it's really that the tests are still running and CodeCov has incomplete info.