### PR TITLE
Remove some Py2-specific code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           #- 3.9
           #- 3.8
           - 3.7
-          - 2.7
+          #- 2.7
         MINIMAL: [""]
         include:
           - CONDA_PY: 3.7

--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -3,12 +3,7 @@ import pandas as pd
 import numpy as np
 
 from openpathsampling.progress import SimpleProgress
-
-try:
-    from collections import abc
-except ImportError:
-    import collections as abc
-
+from collections import abc
 
 # based on http://stackoverflow.com/a/3387975
 class TransformedDict(abc.MutableMapping):

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -8,11 +8,7 @@ from openpathsampling.netcdfplus import WeakKeyCache, \
 from openpathsampling.deprecations import (has_deprecations, deprecate,
                                            MSMBUILDER)
 
-import sys
-if sys.version_info > (3, ):
-    get_code = lambda func: func.__code__
-else:
-    get_code = lambda func: func.func_code
+get_code = lambda func: func.__code__
 
 
 # ==============================================================================

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -160,12 +160,7 @@ def has_deprecations(cls):
     """Decorator to ensure that docstrings get updated for wrapped class"""
     for obj in [cls] + list(vars(cls).values()):
         if callable(obj) and hasattr(obj, '__new_docstring'):
-            try:
-                obj.__doc__ = obj.__new_docstring
-            except AttributeError:
-                # probably Python 2; we can't update docstring in Py2
-                # see https://github.com/Chilipp/docrep/pull/9 and related
-                pass
+            obj.__doc__ = obj.__new_docstring
             del obj.__new_docstring
     return cls
 

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -18,9 +18,6 @@ from .delayedinterrupt import DelayedInterrupt
 
 logger = logging.getLogger(__name__)
 
-if sys.version_info > (3, ):
-    basestring = str
-
 # =============================================================================
 # SOURCE CONTROL
 # =============================================================================
@@ -250,9 +247,6 @@ class DynamicsEngine(StorableNamedObject):
                         else:
                             okay_options[variable] = my_options[variable]
                     elif isinstance(my_options[variable], type(default_value)):
-                        okay_options[variable] = my_options[variable]
-                    elif isinstance(my_options[variable], basestring) \
-                            and isinstance(default_value, basestring):
                         okay_options[variable] = my_options[variable]
                     elif default_value is None:
                         okay_options[variable] = my_options[variable]

--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -169,17 +169,9 @@ class Trajectory(list, StorableObject):
         )
         raise AttributeError(msg)
 
-
     # ==========================================================================
     # LIST INHERITANCE FUNCTIONS
     # ==========================================================================
-
-    def __getslice__(self, *args, **kwargs):
-        ret = list.__getslice__(self, *args, **kwargs)
-        if type(ret) is list:
-            ret = Trajectory(ret)
-
-        return ret
 
     # this is intuitive. hash(Trajectory(traj)) == hash(traj)
     # but hash(LoaderProxy(..., traj.__uuid__)) != hash(traj)

--- a/openpathsampling/sample.py
+++ b/openpathsampling/sample.py
@@ -9,11 +9,7 @@ from openpathsampling.tools import refresh_output
 
 from collections import Counter
 
-import sys
-if sys.version_info > (3, ):
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
+from collections.abc import Mapping
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
#977 dropped Python 2 from the OPS 2.0 test matrix. In the process, some code lost coverage. Here I remove the Py2-specific code for most of that (except netcdfplus, which I'm not worrying about since it will also be dropped in 2.0).

There's one line where I don't immediately understand how it lost coverage:

https://github.com/openpathsampling/openpathsampling/blob/6ff2cbbf615928c031896e1d719217d2087fa940/openpathsampling/engines/dynamics_engine.py#L256

This is in an instance test against `basestring`, but `basestring` is `str` for Py3+ (we set it at the top of the file). Any idea why that's not getting covered? (particularly @sroet)

Note that this PR is not intended to drop all Py2-related code -- there's more to do on that. This is just catching the things that lost coverage when Py2 left the test matrix.