### PR TITLE
Fix MISTIS minus ensemble not forbidding other states

### DIFF
--- a/openpathsampling/high_level/network.py
+++ b/openpathsampling/high_level/network.py
@@ -918,6 +918,7 @@ class MISTISNetwork(TISNetwork):
 
     def _build_sampling_minus_ensembles(self):
         # combining the minus interfaces
+        all_states_set = set(self.initial_states + self.final_states)
         for initial in self.initial_states:
             innermosts = []
             # trans_from_initial: list of transition from initial
@@ -927,9 +928,12 @@ class MISTISNetwork(TISNetwork):
             ]
             for t1 in trans_from_initial:
                 innermosts.append(t1.interfaces[0])
+
+            forbidden = list(all_states_set - {initial})
             minus = paths.MinusInterfaceEnsemble(
                 state_vol=initial,
-                innermost_vols=innermosts
+                innermost_vols=innermosts,
+                forbidden=forbidden
             ).named(initial.name + " MIS minus")
             try:
                 self.special_ensembles['minus'][minus] = trans_from_initial

--- a/openpathsampling/tests/test_network.py
+++ b/openpathsampling/tests/test_network.py
@@ -382,7 +382,6 @@ class TestMISTISNetwork(TestMultipleStateTIS):
         assert_equal(ensBA(self.traj['AB']), False)
         assert_equal(ensBA(self.traj['AC']), False)
 
-
     def test_storage(self):
         import os
         fname = data_filename("mistis_storage_test.nc")

--- a/openpathsampling/tests/test_network.py
+++ b/openpathsampling/tests/test_network.py
@@ -291,6 +291,26 @@ class TestMISTISNetwork(TestMultipleStateTIS):
         for traj_label in ['CB', 'CA']:
             assert_equal(ms_outer_ens(self.traj[traj_label]), False)
 
+    def test_minus_ensembles(self):
+        good_traj_seq = [-0.51, -0.49, -0.40, -0.52, -0.48, -0.51]  # AXXAXA
+        bad_traj_seq = [-0.51, -0.49, -0.05, -0.52, -0.48, -0.51]  # AXBAXA
+
+        minus_dict = self.mistis.special_ensembles['minus']
+        minus_ensembles= [
+            ens for ens, trans in minus_dict.items()
+            if all(t.stateA == self.stateA for t in trans)
+        ]
+        assert len(minus_ensembles) == 1
+        minus_A = minus_ensembles[0]
+
+        good_minus_traj = make_1d_traj(good_traj_seq)
+        bad_minus_traj = make_1d_traj(bad_traj_seq)
+        assert minus_A(good_minus_traj)
+        assert not minus_A(bad_minus_traj)
+
+        ...
+
+
     def test_set_fluxes(self):
         flux_dict = {(self.stateA, self.ifacesA[0]): 2.0,  # same flux 2x
                      (self.stateB, self.ifacesB[0]): 4.0}
@@ -364,6 +384,7 @@ class TestMISTISNetwork(TestMultipleStateTIS):
         assert_equal(ensBA(self.traj['BC']), False)
         assert_equal(ensBA(self.traj['AB']), False)
         assert_equal(ensBA(self.traj['AC']), False)
+
 
     def test_storage(self):
         import os

--- a/openpathsampling/tests/test_network.py
+++ b/openpathsampling/tests/test_network.py
@@ -308,9 +308,6 @@ class TestMISTISNetwork(TestMultipleStateTIS):
         assert minus_A(good_minus_traj)
         assert not minus_A(bad_minus_traj)
 
-        ...
-
-
     def test_set_fluxes(self):
         flux_dict = {(self.stateA, self.ifacesA[0]): 2.0,  # same flux 2x
                      (self.stateB, self.ifacesB[0]): 4.0}


### PR DESCRIPTION
The minus interface as set up by the `MISTISNetwork` didn't forbid the trajectory from entering other states during the excursion from the state. This would occasionally manifest as a failure of the sanity check when saving, stating that the trajectory for some replica did not satisfy the ensemble (because the trajectory in the TIS ensemble after a replica exchange had frames in the other state). 

Typically, this meant that the minus trajectory had to cross to the other state and then *cross back*, so it was extremely rare, but I found it when working on a simple model that isn't actually rare enough to really need TIS to get the rate. @gyorgy-hantal: I think you encountered this problem once. This is the explanation.

This fixes it -- everything was in place to forbid other states (and used in MSTIS); just needed to add it to MISTIS. Also adds a test to prevent regression.