### PR TITLE
Switch notebook tests to nbval

### DIFF
--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -8,18 +8,11 @@ echo "Running tests for Python version: $PYTHON_VERSION"
 
 dropbox_base_url="http://www.dropbox.com/s"
 
-# TODO: slowly build this up as I get tests working for various test
-# notebooks. Eventually, we get rid of the ipynbtests3 script and the
-# version checking in devtools/ci/ipythontests.sh
 case $PYTHON_VERSION in
     "2.7")
         mstis=$dropbox_base_url/1x4ny0c93gvu54n/toy_mstis_1k_OPS1.nc
         mistis=$dropbox_base_url/qaeczkugwxkrdfy/toy_mistis_1k_OPS1.nc
         ;;
-    #"3.5")
-        #mstis=$dropbox_base_url/1ulzssv5p4lr61f/toy_mstis_1k_OPS1_py36.nc
-        #mistis=$dropbox_base_url/8wldep8e26qignt/toy_mistis_1k_OPS1_py35.nc
-        #;;
     "3.6")
         mstis=$dropbox_base_url/1ulzssv5p4lr61f/toy_mstis_1k_OPS1_py36.nc
         mistis=$dropbox_base_url/76981cbgxm639m3/toy_mistis_1k_OPS1_py36.nc
@@ -41,37 +34,34 @@ cp `basename $mistis` toy_mistis_1k_OPS1.nc
 ls *nc
 cd toy_model_mstis/
 date
-ipynbtest.py "toy_mstis_1_setup.ipynb" || testfail=1
-date
-ipynbtest.py "toy_mstis_2_run.ipynb" || testfail=1
-date
-ipynbtest.py "toy_mstis_3_analysis.ipynb" || testfail=1
-date
-ipynbtest.py "toy_mstis_4_repex_analysis.ipynb" || testfail=1
-#date
-#ipynbtest.py "toy_mstis_5_srtis.ipynb" || testfail=1
+py.test --nbval-lax --current-env -v \
+    toy_mstis_1_setup.ipynb \
+    toy_mstis_2_run.ipynb \
+    toy_mstis_3_analysis.ipynb \
+    toy_mstis_4_repex_analysis.ipynb \
+    || testfail=1
+
 cd ../toy_model_mistis/
 date
-ipynbtest.py "toy_mistis_1_setup_run.ipynb" || testfail=1
-date
 # skip toy_mistis_2_flux: not needed
-ipynbtest.py "toy_mistis_3_analysis.ipynb" || testfail=1
-date
+py.test --nbval-lax --current-env -v \
+    toy_mistis_1_setup_run.ipynb \
+    toy_mistis_3_analysis.ipynb \
+    || testfail=1
+
 cd ../tests/
 cp ../toy_model_mstis/mstis.nc ./
-ipynbtest.py --strict --show-diff "test_openmm_integration.ipynb" || testfail=1
-date
-ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
-date
-ipynbtest.py --strict "test_netcdfplus.ipynb" || testfail=1
-date
-ipynbtest.py --strict "test_cv.ipynb" || testfail=1
-date
-ipynbtest.py --strict "test_pyemma.ipynb" || testfail=1
-date
+py.test --nbval --current-env \
+    test_openmm_integration.ipynb \
+    test_snapshot.ipynb \
+    test_netcdfplus.ipynb \
+    test_cv.ipynb \
+    test_pyemma.ipynb \
+    || testfail=1
+
 cd ../misc/
 cp ../toy_model_mstis/mstis.nc ./
-ipynbtest.py "tutorial_storage.ipynb" || testfail=1
+pytest --nbval-lax --current-env tutorial_storage.ipynb || testfail=1
 
 cd ..
 rm toy_mstis_1k_OPS1.nc

--- a/examples/tests/test_cv.ipynb
+++ b/examples/tests/test_cv.ipynb
@@ -120,7 +120,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "storage = paths.Storage('can_be_deleted.nc', mode='w')\n",
     "print(storage.snapshots.save(template))"
    ]
@@ -146,7 +146,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(storage.save([cv0, cv1, cv2, cv3]))"
    ]
   },
@@ -164,7 +164,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(storage.cvs.index)"
    ]
   },
@@ -293,6 +293,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "print(type(cv0([template, template])))\n",
     "print(type(cv0([template, template])[0]))\n",
     "print(type(cv1([template, template])))\n",
@@ -316,7 +317,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "print(storage.cvs.variables['json'][:])"
    ]
   },
@@ -378,7 +379,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(storage.save(t))"
    ]
   },
@@ -415,7 +416,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(storage.attributes.save(a))"
    ]
   },
@@ -595,6 +596,7 @@
     }
    ],
    "source": [
+    "# NBVAL_SKIP\n",
     "storage.attributes[4]"
    ]
   },
@@ -618,21 +620,63 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/examples/tests/test_netcdfplus.ipynb
+++ b/examples/tests/test_netcdfplus.ipynb
@@ -162,7 +162,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "# lazy because output checking fails in Py3k tests -- why is that?\n",
     "print(st.find_store(Node))"
    ]
@@ -375,6 +375,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(sorted(st.get_var_types()))"
    ]
   },
@@ -511,6 +512,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "for var_name, var in sorted(st.variables.items()):\n",
     "    print(var_name, var.dimensions)"
    ]
@@ -785,6 +787,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(st.vars['json'][0,1,1])"
    ]
   },
@@ -812,7 +815,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(st.variables['json'][0,1,:])"
    ]
   },
@@ -980,6 +983,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(st.variables['obj.nodes'][:])\n",
     "print(st.variables['nodes_json'][:])"
    ]
@@ -1050,7 +1054,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "proxy = st.vars['lazyobj.nodes'][0,0,0]\n",
     "print('Type:   ', type(proxy))\n",
     "print('Class:  ', proxy.__class__)\n",
@@ -1449,6 +1453,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(st.nodesnamed.name_idx)"
    ]
   },
@@ -1527,6 +1532,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(st.nodesunique.name_idx)"
    ]
   },
@@ -1806,6 +1812,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print('[', ', '.join(st.dict.variables['json'][:]), ']')"
    ]
   },
@@ -2076,6 +2083,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(hex(st_fb.nodes.save(st_fb.fallback.nodes[0])))"
    ]
   },
@@ -2114,21 +2122,63 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/examples/tests/test_openmm_integration.ipynb
+++ b/examples/tests/test_openmm_integration.ipynb
@@ -77,7 +77,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "{ key: type(value) for key, value in testsystem.__dict__.items()}"
    ]
   },
@@ -253,7 +253,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "print(traj[5].coordinates)"
    ]
   },
@@ -272,6 +272,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# covers mdtraj warning\n",
     "psi = md.compute_psi(traj.to_mdtraj())"
    ]
   },
@@ -296,7 +298,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "psi[1][3:8]"
    ]
   },
@@ -347,7 +349,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "st.variables['engines_json'][0][0:256] + '...'"
    ]
   },
@@ -506,7 +508,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -29,7 +29,7 @@
    },
    "outputs": [],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "import pyemma.coordinates as coor"
    ]
   },
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "ref_storage = paths.Storage('engine_store_test.nc', mode='r')"
    ]
   },
@@ -108,7 +108,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "storage = paths.Storage('delete.nc', 'w')\n",
     "storage.trajectories.save(ref_storage.trajectories[0])"
    ]
@@ -193,7 +193,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(storage.save(cv))"
    ]
   },
@@ -306,7 +306,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(storage.variables['attributes_json'][:])"
    ]
   },
@@ -363,7 +363,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(erg[:,2:4])"
    ]
   },
@@ -397,7 +397,7 @@
     }
    ],
    "source": [
-    "#! lazy\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "storage = paths.Storage('delete.nc', 'r')"
    ]
   },

--- a/examples/tests/test_snapshot.ipynb
+++ b/examples/tests/test_snapshot.ipynb
@@ -219,7 +219,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "Markdown(code_to_md(A))"
    ]
   },
@@ -281,7 +281,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "Markdown(code_to_md(EmptySnap))"
    ]
   },
@@ -381,7 +381,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "Markdown(code_to_md(SuperSnap))"
    ]
   },
@@ -489,7 +489,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "Markdown(code_to_md(MegaSnap))"
    ]
   },
@@ -655,7 +655,7 @@
     }
    ],
    "source": [
-    "#! ignore\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "Markdown(code_to_md(paths.engines.openmm.MDSnapshot))"
    ]
   },

--- a/examples/toy_model_mistis/toy_mistis_1_setup_run.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_1_setup_run.ipynb
@@ -381,7 +381,7 @@
    },
    "outputs": [],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "# tests should not run this, users should. Undoes the previous cell\n",
     "sset = better_initial_conditions"
    ]
@@ -447,7 +447,7 @@
    },
    "outputs": [],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "# skip this during testing; leave for full calculation\n",
     "mistis_calc.run_until(100000)"
    ]

--- a/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
+++ b/examples/toy_model_mistis/toy_mistis_3_analysis.ipynb
@@ -471,7 +471,7 @@
    },
    "outputs": [],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "n_blocks = 5 # for real examples"
    ]
   },

--- a/examples/toy_model_mstis/toy_mstis_2_run.ipynb
+++ b/examples/toy_model_mstis/toy_mstis_2_run.ipynb
@@ -387,7 +387,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "# don't run this during testing\n",
     "equilibration.run_until_decorrelated()"
    ]
@@ -494,7 +494,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "# skip this during testing, but leave it for demo purposes\n",
     "# we use the %run magic because this isn't in a package\n",
     "%run ../resources/toy_plot_helpers.py\n",
@@ -596,7 +596,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "# don't run all those steps in testing!\n",
     "mstis_calc.live_visualizer = None   # turn off the live visualization\n",
     "mstis_calc.run_until(n_steps)"
@@ -701,7 +701,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "custom_equil.run_until_decorrelated()"
    ]
   }

--- a/examples/toy_model_mstis/toy_mstis_3_analysis.ipynb
+++ b/examples/toy_model_mstis/toy_mstis_3_analysis.ipynb
@@ -1758,7 +1758,7 @@
     }
    ],
    "source": [
-    "#! skip\n",
+    "# NBVAL_SKIP\n",
     "# The skip directive tells our test runner not to run this cell\n",
     "import time\n",
     "max_step = 10\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,7 @@ test =
     pytest
     pytest-cov
     coveralls
-    ipynbtest
-    jupyter_client<6.1.11
+    nbval
 simstore =
     sqlalchemy
     dill


### PR DESCRIPTION
We currently run several notebooks as tests -- mostly system-scale smoke tests, though also some more unit-level testing. These tests are run using a tool that @jhprinz wrote, [ipynbtest](https://github.com/jhprinz/ipynb-test).

Unfortunately, ipynbtest hasn't been maintained for a quite a while. Additionally, after @jhprinz developed ipynbtest, another tool, [nbval](https://github.com/computationalmodelling/nbval), became a widely used pytest plugin for using Jupyter notebooks in testing.

With no one to maintain ipynbtest, I think we need to switch to nbval. This PR does that. I'm sad about this, because I think ipynbtest is a nicer tool to use (I like the way it reports Markdown headings as a progress indicator while running.) However, this is now the only thing blocking us from testing on Python 3.8 and 3.9, so the time has come.