### PR TITLE
Use a deque to keep track of more recent time estimates

### DIFF
--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -254,6 +254,10 @@ class PathSampling(PathSimulator):
             self.step += 1
             logger.info("Beginning MC cycle " + str(self.step))
             refresh = self.allow_refresh
+            now = time.time()
+            if nn > 0:
+                deq.append(now-time_start)
+
             if self.step % self.status_update_frequency == 0:
                 # do we visualize this step?
                 if self.live_visualizer is not None and mcstep is not None:
@@ -261,12 +265,10 @@ class PathSampling(PathSimulator):
                     self.live_visualizer.draw_ipynb(mcstep)
                     refresh = False
 
-                now = time.time()
                 elapsed = now - initial_time
 
                 if nn > 0:
-                    deq.append(now-time_start)
-                    time_per_step = elapsed / nn
+                    time_per_step = sum(deq) / len(deq)
                 else:
                     time_per_step = 1.0
 

--- a/openpathsampling/tests/test_tools.py
+++ b/openpathsampling/tests/test_tools.py
@@ -1,5 +1,4 @@
 import pytest
-from nose.tools import assert_equal
 from openpathsampling.tools import *
 
 import tempfile
@@ -16,48 +15,41 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 def test_pretty_print_seconds():
     # test the basics with full reporting
-    assert_equal(pretty_print_seconds(93784),
-                 "1 day 2 hours 3 minutes 4 seconds")
-    assert_equal(pretty_print_seconds(179990),
-                 "2 days 1 hour 59 minutes 50 seconds")
-    assert_equal(pretty_print_seconds(31),
-                 "31 seconds")
+    assert pretty_print_seconds(93784) == "1 day 2 hours 3 minutes 4 seconds"
+    assert (pretty_print_seconds(179990) ==
+            "2 days 1 hour 59 minutes 50 seconds")
+    assert pretty_print_seconds(31) == "31 seconds"
 
     # test positive n_labels (including testing rounding)
-    assert_equal(pretty_print_seconds(93784, n_labels=2),
-                 "1 day 2 hours")
-    assert_equal(pretty_print_seconds(179990, n_labels=2),
-                 "2 days 2 hours")
-    assert_equal(pretty_print_seconds(179990, n_labels=3),
-                 "2 days 2 hours 0 minutes")
-    assert_equal(pretty_print_seconds(31, n_labels=2),
-                 "31 seconds")
+    assert pretty_print_seconds(93784, n_labels=2) ==  "1 day 2 hours"
+    assert pretty_print_seconds(179990, n_labels=2) == "2 days 2 hours"
+    assert (pretty_print_seconds(179990, n_labels=3) ==
+            "2 days 2 hours 0 minutes")
+    assert pretty_print_seconds(31, n_labels=2) == "31 seconds"
 
     # test negative n_labels
-    assert_equal(pretty_print_seconds(93784, n_labels=-1),
-                 "1.09 days")
-    assert_equal(pretty_print_seconds(93784, n_labels=-2),
-                 "1 day 2.05 hours")
-    assert_equal(pretty_print_seconds(31, n_labels=-2),
-                 "31 seconds")
+    assert pretty_print_seconds(93784, n_labels=-1) == "1.09 days"
+    assert pretty_print_seconds(93784, n_labels=-2) == "1 day 2.05 hours"
+    assert pretty_print_seconds(31, n_labels=-2) == "31 seconds"
 
     # test separators
-    assert_equal(pretty_print_seconds(93784, separator=", "),
-                 "1 day, 2 hours, 3 minutes, 4 seconds")
+    assert (pretty_print_seconds(93784, separator=", ") ==
+            "1 day, 2 hours, 3 minutes, 4 seconds")
 
 
 def test_progress_string():
-    assert_equal(progress_string(0, 100, 10),
-                 "Starting simulation...\nWorking on first step\n")
-    assert_equal(progress_string(1, 11, 9378.4),
-                 "Running for 2 hours 36 minutes 18 seconds - "
-                 + "9378.40 seconds per step\n"
-                 + "Estimated time remaining: 1 day 2.05 hours\n")
+    assert (progress_string(0, 100, 10) ==
+            "Starting simulation...\nWorking on first step\n")
+    assert (progress_string(1, 11, 9378.4) ==
+            "Running for 2 hours 36 minutes 18 seconds - "
+            "9378.40 seconds per step\n"
+            "Estimated time remaining: 1 day 2.05 hours\n")
+
     # Override time_per_step
-    assert_equal(progress_string(1, 11, 9378.4, 10),
-                 "Running for 2 hours 36 minutes 18 seconds - "
-                 + "10.00 seconds per step\n"
-                 + "Estimated time remaining: 1 minute 40 seconds\n")
+    assert (progress_string(1, 11, 9378.4, 10) ==
+            "Running for 2 hours 36 minutes 18 seconds - "
+            "10.00 seconds per step\n"
+            "Estimated time remaining: 1 minute 40 seconds\n")
 
 
 def test_ensure_file_dne():

--- a/openpathsampling/tests/test_tools.py
+++ b/openpathsampling/tests/test_tools.py
@@ -13,6 +13,7 @@ logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
+
 def test_pretty_print_seconds():
     # test the basics with full reporting
     assert_equal(pretty_print_seconds(93784),
@@ -44,6 +45,7 @@ def test_pretty_print_seconds():
     assert_equal(pretty_print_seconds(93784, separator=", "),
                  "1 day, 2 hours, 3 minutes, 4 seconds")
 
+
 def test_progress_string():
     assert_equal(progress_string(0, 100, 10),
                  "Starting simulation...\nWorking on first step\n")
@@ -51,6 +53,11 @@ def test_progress_string():
                  "Running for 2 hours 36 minutes 18 seconds - "
                  + "9378.40 seconds per step\n"
                  + "Estimated time remaining: 1 day 2.05 hours\n")
+    # Override time_per_step
+    assert_equal(progress_string(1, 11, 9378.4, 10),
+                 "Running for 2 hours 36 minutes 18 seconds - "
+                 + "10.00 seconds per step\n"
+                 + "Estimated time remaining: 1 minute 40 seconds\n")
 
 
 def test_ensure_file_dne():

--- a/openpathsampling/tools.py
+++ b/openpathsampling/tools.py
@@ -181,7 +181,8 @@ def pretty_print_seconds(seconds, n_labels=0, separator=" "):
     return output_str
 
 
-def progress_string(n_steps_completed, n_steps_total, time_elapsed):
+def progress_string(n_steps_completed, n_steps_total, time_elapsed,
+                    time_per_step=None):
     """
     String to report on simulation progress.
 
@@ -199,6 +200,8 @@ def progress_string(n_steps_completed, n_steps_total, time_elapsed):
         total number of (Monte Carlo/trajectory-level) step in simulation
     time_elapsed : float-like
         time elapsed in the simulation, in seconds
+    time_per_step : float-like, optional
+        overrides the default estimate of time_elapsed/n_steps_total
 
     Returns
     -------
@@ -206,10 +209,10 @@ def progress_string(n_steps_completed, n_steps_total, time_elapsed):
         string to output describing simulation progress, including estimated
         time remaining
     """
-    try:
-        time_per_step = time_elapsed / n_steps_completed
-    except ZeroDivisionError:
+    if n_steps_completed == 0:
         return "Starting simulation...\nWorking on first step\n"
+    if time_per_step is None:
+        time_per_step = time_elapsed / n_steps_completed
     time_to_finish = (n_steps_total - n_steps_completed) * time_per_step
     output_str = (
         "Running for " + pretty_print_seconds(time_elapsed) + " - "


### PR DESCRIPTION
Today, I got annoyed by the fact that OPS's `Estimated time remaining` becomes worse, the longer you run (see for example, the table in [this comment](https://github.com/openpathsampling/openpathsampling/pull/928#issuecomment-709249488) )

This fixes that (slightly) by using a `deque` with a default length of `10_000` MC steps. So that it just uses the average of the last `10_000` steps to estimate the average step time and the time remaining. 

The changes in this PR are:
- use `deque` to get a slightly better estimate of the time-left (47f76d4 and babd276)
- add a `time_per_step` override for `progress_string` to override the `time_per_step` calculation and adds a test for this behavior (47f76d4)
- removes `nose` from `test_tools.py`, partial progress towards #756 (6a8485c)