### PR TITLE
SimStore: Periodic CVs

### DIFF
--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -282,10 +282,10 @@ class StorableFunction(StorableNamedObject):
         is_periodic = period_min is not None and period_max is not None
         is_error = not (is_periodic or is_not_periodic)
         if is_error:
-            raise RuntimeError("Periodic functions must have upper and "
-                               "lower bounds. This function has period_min "
-                               + str(period_min) + " and period_max "
-                               + str(period_max) + ".")
+            raise ValueError("Periodic functions must have upper and "
+                             "lower bounds. This function has period_min "
+                             + str(period_min) + " and period_max "
+                             + str(period_max) + ".")
         return is_periodic
 
     @property

--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -248,7 +248,8 @@ class StorableFunction(StorableNamedObject):
         (None) stores source for anything created in ``__main__`` that is
         not a lambda expression.
     """
-    def __init__(self, func, func_config=None, store_source=None, **kwargs):
+    def __init__(self, func, func_config=None, store_source=None,
+                 period_min=None, period_max=None,**kwargs):
         super(StorableFunction, self).__init__()
         self.func = func
         self.source = None
@@ -270,7 +271,27 @@ class StorableFunction(StorableNamedObject):
         self.local_cache = None  # set correctly by self.mode setter
         self._disk_cache = True
         self._handlers = set([])
+        self._check_period(period_min, period_max)
+        self.period_min = period_min
+        self.period_max = period_max
         self.mode = 'analysis'
+
+    @staticmethod
+    def _check_period(period_min, period_max):
+        is_not_periodic = period_min is None and period_max is None
+        is_periodic = period_min is not None and period_max is not None
+        is_error = not (is_periodic or is_not_periodic)
+        if is_error:
+            raise RuntimeError("Periodic functions must have upper and "
+                               "lower bounds. This function has period_min "
+                               + str(period_min) + " and period_max "
+                               + str(period_max) + ".")
+        return is_periodic
+
+    @property
+    def is_periodic(self):
+        return self._check_period(self.period_min, self.period_max)
+
 
     def add_handler(self, storage, override=False):
         self._handlers.add(storage)

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -230,7 +230,7 @@ class TestStorableFunction(object):
         expected = {2: False, 0: True, 1: 'error'}[n_nones]
         check_period = StorableFunction._check_period
         if expected == 'error':
-            with pytest.raises(RuntimeError, match='period'):
+            with pytest.raises(ValueError, match='period'):
                 check_period(period_min, period_max)
         else:
             assert check_period(period_min, period_max) == expected

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -223,6 +223,12 @@ class TestStorableFunction(object):
 
         self.func = StorableFunction(get_expected)
 
+    def test_check_periodic(self):
+        pytest.skip()
+
+    def test_is_periodic(self):
+        pytest.skip
+
     def test_gets_source(self):
         pytest.skip()
         pass

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     import mock
 
-from collections import defaultdict
+from collections import defaultdict, Counter
 import itertools
 
 import numpy as np
@@ -223,11 +223,23 @@ class TestStorableFunction(object):
 
         self.func = StorableFunction(get_expected)
 
-    def test_check_periodic(self):
-        pytest.skip()
+    @pytest.mark.parametrize('min_max', [(None, None), (None, 10), (0, 10)])
+    def test_check_periodic(self, min_max):
+        period_min, period_max = min_max
+        n_nones = Counter(min_max)[None]
+        expected = {2: False, 0: True, 1: 'error'}[n_nones]
+        check_period = StorableFunction._check_period
+        if expected == 'error':
+            with pytest.raises(RuntimeError):
+                check_period(period_min, period_max)
+        else:
+            assert check_period(period_min, period_max) == expected
 
     def test_is_periodic(self):
-        pytest.skip
+        assert not self.func.is_periodic
+        func = StorableFunction(lambda s: s.xyz[0][0], period_min=0.0,
+                                period_max=1.0)
+        assert func.is_periodic
 
     def test_gets_source(self):
         pytest.skip()

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -230,7 +230,7 @@ class TestStorableFunction(object):
         expected = {2: False, 0: True, 1: 'error'}[n_nones]
         check_period = StorableFunction._check_period
         if expected == 'error':
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError, match='period'):
                 check_period(period_min, period_max)
         else:
             assert check_period(period_min, period_max) == expected

--- a/openpathsampling/experimental/storage/collective_variables.py
+++ b/openpathsampling/experimental/storage/collective_variables.py
@@ -95,13 +95,19 @@ class MDTrajProcessor(Processor):
         return paths.Trajectory(values).to_mdtraj(topology=top)
 
 class MDTrajFunctionCV(CoordinateFunctionCV):
-    def __init__(self, func, topology, func_config=None,
-                 **kwargs):
+    def __init__(self, func, topology, func_config=None, period_min=None,
+                 period_max=None, **kwargs):
         if func_config is None:
             func_config = StorableFunctionConfig([
                 MDTrajProcessor(topology), wrap_numpy, scalarize_singletons,
             ])
-        super(MDTrajFunctionCV, self).__init__(func, func_config, **kwargs)
+        super(MDTrajFunctionCV, self).__init__(
+            func,
+            func_config=func_config,
+            period_min=period_min,
+            period_max=period_max,
+            **kwargs
+        )
         self.topology = topology
         self.mdtraj_topology = topology.mdtraj
 


### PR DESCRIPTION
This PR adds information about periodicity to SimStore CVs. It reserves the kwargs `period_min` and `period_max`.

This isn't currently used anywhere in the core of OPS, but might be used in the future to combine `PeriodicCVDefinedVolume` and `CVDefinedVolume` (probably a good option for OPS 2.0).

It will be used in the CLI for simulation setup.