### PR TITLE
Add threshold to codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ coverage:
     project:
       default:
         target: auto
+        threshold: 0.04%
 
 codecov:
   notify:


### PR DESCRIPTION
Some recent PRs that should have no effect on coverage (#990, #984) have been getting complaints from CodeCov because a single line in netcdfplus has become uncovered (not sure if this is flakiness or a change in something upstream).

This PR adds a threshold so CodeCov will pass if flakiness uncovers up to 0.4% of the currently covered code. That corresponds to about 5 Python statements.

This only affects the CodeCov "project" check: the "patch" check will keep its default behavior, which is that coverage for lines changed in the PR must be at least as much as the current total project coverage.