### PR TITLE
Pin sqlalchemy!=1.4.0

### DIFF
--- a/devtools/experimental_reqs.txt
+++ b/devtools/experimental_reqs.txt
@@ -1,1 +1,2 @@
-sqlalchemy
+sqlalchemy!=1.4.0
+dill

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ test =
     coveralls
     nbval
 simstore =
-    sqlalchemy
+    sqlalchemy!=1.4.0
     dill
 
 [bdist_wheel]


### PR DESCRIPTION
Tests stopped working this morning (had to be the day of my APS March Meeting talk!) SQLAlchemy accidentally made changes in their 1.4.0 release that broke SimStore. See https://github.com/sqlalchemy/sqlalchemy/issues/6074. Looks like they're already preparing a fix, so I'm pinning to `!=1.4.0` as opposed to `<1.4`.