### PR TITLE
Potential fix for flaky PyEMMA tests in 2.7

### DIFF
--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -147,6 +147,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "cv = paths.collectivevariable.PyEMMAFeaturizerCV(\n",
     "    'pyemma', \n",
     "    pyemma_generator, \n",
@@ -339,6 +340,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "erg = py_emma_feat(storage.snapshots);"
    ]
   },

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -212,6 +212,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "cv(storage.trajectories[0]);"
    ]
   },
@@ -230,6 +231,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "cv(storage.snapshots.all());"
    ]
   },


### PR DESCRIPTION
I've been having problems with PyEMMA tests being flaky in Py2.7 ever since #987. It seems like there's something that sometimes shows up in stderr, which ipynbtest didn't check but apparently nbval does. The error I get is:

```
Notebook cell execution failed
Cell 8: Cell outputs differ

Input:
cv(storage.trajectories[0]);

Traceback:
Unexpected output fields from running code: set([u'stderr'])
```

This PR adds ignores to that cell and another near it that also may cause problems.