### PR TITLE
Add global random number generator; support in shooting pt selectors and pathmovers

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -118,6 +118,7 @@ from .pathsimulators import (
     ShootFromSnapshotsSimulation
 )
 
+from .random import default_rng
 from .sample import Sample, SampleSet
 
 from .shooting import (

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -4,7 +4,6 @@ Created on 19.07.2014
 @author: Jan-Hendrik Prinz
 @author: David W. H. Swenson
 """
-from __future__ import absolute_import
 import abc
 import logging
 import numpy as np

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -4,7 +4,7 @@ Created on 19.07.2014
 @author: Jan-Hendrik Prinz
 @author: David W. H. Swenson
 """
-
+from __future__ import absolute_import
 import abc
 import logging
 import numpy as np

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -7,12 +7,12 @@ Created on 19.07.2014
 
 import abc
 import logging
-import random
-
 import numpy as np
+
 import openpathsampling as paths
 from openpathsampling.netcdfplus import StorableNamedObject, StorableObject
 from openpathsampling.pathmover_inout import InOutSet, InOut
+from openpathsampling.random import default_rng, random
 from .ops_logging import initialization_logging
 from .treelogic import TreeMixin
 
@@ -132,7 +132,7 @@ class PathMover(with_metaclass(abc.ABCMeta, TreeMixin, StorableNamedObject)):
 
     def __init__(self):
         StorableNamedObject.__init__(self)
-
+        self._rng = default_rng()
         self._in_ensembles = None
         self._out_ensembles = None
         self._len = None
@@ -430,6 +430,8 @@ class PathMover(with_metaclass(abc.ABCMeta, TreeMixin, StorableNamedObject)):
                 "," + str(sample.trajectory) +
                 "," + repr(sample.ensemble) +
                 ")")
+        # TODO: This can't go through numpy.random as Samples unwrap to
+        # Snapshots when cast to arrays
         selected = random.choice(legal)
         logger.debug(
             "selected sample: (" + str(selected.replica) +
@@ -546,7 +548,7 @@ class SampleMover(PathMover):
             else:
                 probability *= sample.bias
 
-        rand = random.random()
+        rand = self._rng.random()
 
         if rand > probability:
             # rejected
@@ -1256,7 +1258,9 @@ class RandomSubtrajectorySelectMover(SubtrajectorySelectMover):
     """
 
     def _choose(self, trajectory_list):
-        return random.choice(trajectory_list), {}
+        # Needed to prevent ragged nested sequence DeprWarning in np 1.20
+        idx = self._rng.choice(len(trajectory_list))
+        return trajectory_list[idx], {}
 
 
 class FirstSubtrajectorySelectMover(SubtrajectorySelectMover):
@@ -1508,7 +1512,6 @@ class SelectionMover(PathMover):
         super(SelectionMover, self).__init__()
 
         self.movers = movers
-
         initialization_logging(init_log, self,
                                entries=['movers'])
 
@@ -1541,20 +1544,10 @@ class SelectionMover(PathMover):
         pass
 
     def select_mover(self, weights):
-        rand = np.random.random() * sum(weights)
-
-        idx = 0
-        prob = weights[0]
+        p = np.array(weights)
+        p /= sum(weights)
         logger.debug(self.name + " " + str(weights))
-        while prob <= rand and idx < len(weights):
-            idx += 1
-            try:
-                prob += weights[idx]
-            except IndexError as e:
-                msg = ("Attempted to get index " + str(idx) + " from " +
-                       str(repr(weights)) + ": ")
-                e.args = tuple([msg + e.args[0]] + list(e.args[1:]))
-                raise
+        idx = self._rng.choice(len(self.movers), p=p)
 
         logger_str = "{name} ({cls}) selecting {mtype} (index {idx})"
         logger.info(logger_str.format(

--- a/openpathsampling/pathmovers/spring_shooting.py
+++ b/openpathsampling/pathmovers/spring_shooting.py
@@ -244,7 +244,7 @@ class SpringShootingSelector(paths.ShootingPointSelector):
         # Select the next index from the probability list and shift to range
         # from -delta_max to delta_max, 0 being the shooting index of the last
         # accepted trajectory
-        rand = np.random.random() * self._total_bias
+        rand = self.rng.random() * self._total_bias
         dframe = 0
         prob = prob_list[0]
         while prob <= rand and dframe < len(prob_list):

--- a/openpathsampling/random.py
+++ b/openpathsampling/random.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+
+# Set one rng for all of OPS
+if np.version.version < '1.17':
+    # Legacy support, remove when numpy 1.16 support is dropped
+    class RandomState(np.random.RandomState):
+        def __init__(self, *args, **kwargs):
+            super(RandomState, self).__init__(*args, **kwargs)
+
+        # method overrides to mimic numpy.random.Generator
+        def random(self, *args, **kwargs):
+            return self.random_sample(*args, **kwargs)
+
+        def integers(self, *args, **kwargs):
+            return self.randint(*args, **kwargs)
+    rng = RandomState()
+else:
+    rng = np.random.default_rng()
+
+
+def default_rng():
+    return rng

--- a/openpathsampling/random.py
+++ b/openpathsampling/random.py
@@ -16,10 +16,10 @@ if np.version.version < '1.17':
 
         def integers(self, *args, **kwargs):
             return self.randint(*args, **kwargs)
-    rng = RandomState()
+    DEFAULT_RNG = RandomState()
 else:
-    rng = np.random.default_rng()
+    DEFAULT_RNG = np.random.default_rng()
 
 
 def default_rng():
-    return rng
+    return DEFAULT_RNG

--- a/openpathsampling/random.py
+++ b/openpathsampling/random.py
@@ -1,4 +1,5 @@
 import numpy as np
+import random
 
 
 # Set one rng for all of OPS

--- a/openpathsampling/random.py
+++ b/openpathsampling/random.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import numpy as np
 import random
 

--- a/openpathsampling/random.py
+++ b/openpathsampling/random.py
@@ -5,7 +5,7 @@ import random
 
 # Set one rng for all of OPS
 if np.version.version < '1.17':
-    # Legacy support, remove when numpy 1.16 support is dropped
+    # Legacy support, remove when numpy 1.16 support is dropped (Py2)
     class RandomState(np.random.RandomState):
         def __init__(self, *args, **kwargs):
             super(RandomState, self).__init__(*args, **kwargs)

--- a/openpathsampling/random.py
+++ b/openpathsampling/random.py
@@ -7,9 +7,6 @@ import random
 if np.version.version < '1.17':
     # Legacy support, remove when numpy 1.16 support is dropped (Py2)
     class RandomState(np.random.RandomState):
-        def __init__(self, *args, **kwargs):
-            super(RandomState, self).__init__(*args, **kwargs)
-
         # method overrides to mimic numpy.random.Generator
         def random(self, *args, **kwargs):
             return self.random_sample(*args, **kwargs)

--- a/openpathsampling/sample.py
+++ b/openpathsampling/sample.py
@@ -1,4 +1,4 @@
-import random
+from openpathsampling.random import random
 import logging
 
 import openpathsampling as paths

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -10,6 +10,11 @@ init_log = logging.getLogger('openpathsampling.initialization')
 
 
 class ShootingPointSelector(StorableNamedObject):
+    def __init__(self):
+        # Assign rng, so it can be set to something else
+        self.rng = np.random.default_rng()
+        super(ShootingPointSelector, self).__init__()
+
     def f(self, snapshot, trajectory):
         """
         Returns the unnormalized proposal probability of a snapshot
@@ -71,7 +76,7 @@ class ShootingPointSelector(StorableNamedObject):
         prob_list = self._biases(trajectory)
         sum_bias = sum(prob_list)
 
-        rand = np.random.random() * sum_bias
+        rand = self.rng.random() * sum_bias
         idx = 0
         prob = prob_list[0]
         while prob <= rand and idx < len(prob_list):
@@ -145,7 +150,7 @@ class UniformSelector(ShootingPointSelector):
         return float(len(trajectory) - self.pad_start - self.pad_end)
 
     def pick(self, trajectory):
-        idx = np.random.randint(self.pad_start,
+        idx = self.rng.integers(self.pad_start,
                                 len(trajectory) - self.pad_end)
         return idx
 
@@ -231,4 +236,3 @@ class FirstFrameSelector(ShootingPointSelector):
     def probability_ratio(self, snapshot, old_trajectory, new_trajectory):
         # must be matched by a first-frame selector somewhere
         return 1.0
-

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 
 from openpathsampling.netcdfplus import StorableNamedObject
+from openpathsampling import default_rng
 
 logger = logging.getLogger(__name__)
 init_log = logging.getLogger('openpathsampling.initialization')
@@ -12,7 +13,7 @@ init_log = logging.getLogger('openpathsampling.initialization')
 class ShootingPointSelector(StorableNamedObject):
     def __init__(self):
         # Assign rng, so it can be set to something else
-        self.rng = np.random.default_rng()
+        self.rng = default_rng()
         super(ShootingPointSelector, self).__init__()
 
     def f(self, snapshot, trajectory):

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -11,6 +11,7 @@ from builtins import object
 from nose.plugins.skip import SkipTest
 from nose.tools import (assert_equal, assert_not_equal, raises, assert_true,
                         assert_in, assert_not_in)
+import numpy as np
 from numpy.testing import assert_allclose
 
 from openpathsampling.collectivevariable import FunctionCV
@@ -622,7 +623,7 @@ class TestRandomChoiceMover(object):
         self.tps = A2BEnsemble(volA, volB)
         self.len3 = LengthEnsemble(3)
         self.init_samp = SampleSet([Sample(trajectory=traj,
-                                           ensemble=self.len3, 
+                                           ensemble=self.len3,
                                            replica=0)])
         self.hop_to_tis = EnsembleHopMover(
             ensemble=self.len3,
@@ -672,7 +673,7 @@ class TestRandomChoiceMover(object):
 
 class TestRandomAllowedChoiceMover(object):
     def setup(self):
-        self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7, 
+        self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7,
                                       -0.1, 0.2, 0.4, 0.6, 0.8,
                                      ])
         self.dyn.initialized = True
@@ -693,7 +694,7 @@ class TestRandomAllowedChoiceMover(object):
             coordinates=[-0.1, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7],
             velocities=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
         )
-        self.samp1 = Sample(trajectory=init_traj1, replica=0, 
+        self.samp1 = Sample(trajectory=init_traj1, replica=0,
                             ensemble=self.ens1)
         self.samp2 = Sample(trajectory=init_traj2, replica=1,
                             ensemble=self.ens2)
@@ -1134,10 +1135,10 @@ class TestMinusMover(object):
         self.dyn = CalvinistDynamics([
             # successful move: (backward extension then forward)
             -0.13, 0.13, 0.33, -0.11, -0.12, 0.12, 0.32, -0.131,
-            # never leaves state: 
+            # never leaves state:
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
-            -0.25, 
+            -0.25,
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
             # goes to other state:
@@ -1152,7 +1153,7 @@ class TestMinusMover(object):
             innermost_ensembles=self.innermost,
             engine=self.dyn
         )
-        self.first_segment = [-0.1, 0.1, 0.3, 0.1, -0.15] 
+        self.first_segment = [-0.1, 0.1, 0.3, 0.1, -0.15]
         self.list_innermost = [-0.11, 0.11, 0.31, 0.11, -0.12]
         self.second_segment = [-0.25, 0.2, 0.4, 0.2, -0.2]
         init_minus = make_1d_traj(
@@ -1191,7 +1192,7 @@ class TestMinusMover(object):
         assert_equal(samples[0].ensemble(samples[0].trajectory), True)
         assert_equal(samples[0].ensemble, self.minus._segment_ensemble)
         assert_equal(self.mover.engine, self.dyn)
-        
+
 
     def test_successful_move(self):
         init_innermost = make_1d_traj(self.list_innermost, [1.0]*5)
@@ -1371,10 +1372,10 @@ class TestSingleReplicaMinusMover(object):
         self.dyn = CalvinistDynamics([
             # successful move: (backward extension then forward)
             -0.13, 0.13, 0.33, -0.11, -0.12, 0.12, 0.32, -0.131,
-            # never leaves state: 
+            # never leaves state:
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
-            -0.25, 
+            -0.25,
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
             -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15,
             # goes to other state:
@@ -1389,7 +1390,7 @@ class TestSingleReplicaMinusMover(object):
             innermost_ensembles=self.innermost,
             engine=self.dyn
         )
-        self.first_segment = [-0.1, 0.1, 0.3, 0.1, -0.15] 
+        self.first_segment = [-0.1, 0.1, 0.3, 0.1, -0.15]
         self.list_innermost = [-0.11, 0.11, 0.31, 0.11, -0.12]
         self.second_segment = [-0.25, 0.2, 0.4, 0.2, -0.2]
         init_minus = make_1d_traj(

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -11,7 +11,6 @@ from builtins import object
 from nose.plugins.skip import SkipTest
 from nose.tools import (assert_equal, assert_not_equal, raises, assert_true,
                         assert_in, assert_not_in)
-import numpy as np
 from numpy.testing import assert_allclose
 
 from openpathsampling.collectivevariable import FunctionCV

--- a/openpathsampling/tests/test_random.py
+++ b/openpathsampling/tests/test_random.py
@@ -1,0 +1,15 @@
+from builtins import object
+from openpathsampling.random import *
+
+class TestRandom(object):
+    def test_default_rng(self):
+        rng = default_rng()
+        #test if we can grab an integer (and rng excludes endpoint)
+        i = rng.integers(1)
+        assert i == 0
+
+    def test_identities(self):
+        rng1 = default_rng()
+        rng2 = default_rng()
+        # These should be te same object
+        assert rng1 is rng2

--- a/openpathsampling/tests/test_random.py
+++ b/openpathsampling/tests/test_random.py
@@ -1,10 +1,11 @@
 from builtins import object
 from openpathsampling.random import *
 
+
 class TestRandom(object):
     def test_default_rng(self):
         rng = default_rng()
-        #test if we can grab an integer (and rng excludes endpoint)
+        # Test if we can grab an integer (and rng excludes endpoint)
         i = rng.integers(1)
         assert i == 0
 

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -3,7 +3,6 @@ import collections
 from openpathsampling.tests.test_helpers import (
     make_1d_traj, assert_items_equal, CalvinistDynamics)
 import pytest
-import numpy as np
 
 from openpathsampling.shooting import *
 from openpathsampling.pathmover import ForwardShootMover, BackwardShootMover
@@ -62,8 +61,6 @@ class TestGaussianBiasSelector(SelectorTest):
             0.9950124791926823,   # = exp(-2.0*(0.3-0.25)**2)
             0.8824969025845955,   # = exp(-2.0*(0.5-0.25)**2)
         ]
-        # Seed rng to prevent flaky test_pick
-        self.sel.rng = np.random.default_rng(42)
 
     def test_pick(self):
         picks = [self.sel.pick(self.mytraj) for _ in range(100)]

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -3,6 +3,7 @@ import collections
 from openpathsampling.tests.test_helpers import (
     make_1d_traj, assert_items_equal, CalvinistDynamics)
 import pytest
+import numpy as np
 
 from openpathsampling.shooting import *
 from openpathsampling.pathmover import ForwardShootMover, BackwardShootMover
@@ -61,6 +62,8 @@ class TestGaussianBiasSelector(SelectorTest):
             0.9950124791926823,   # = exp(-2.0*(0.3-0.25)**2)
             0.8824969025845955,   # = exp(-2.0*(0.5-0.25)**2)
         ]
+        # Seed rng to prevent flaky test_pick
+        self.sel.rng = np.random.default_rng(42)
 
     def test_pick(self):
         picks = [self.sel.pick(self.mytraj) for _ in range(100)]


### PR DESCRIPTION
This week my CI failed with:
```python
=================================== FAILURES ===================================
______________________ TestGaussianBiasSelector.test_pick ______________________

self = <openpathsampling.tests.test_shooting.TestGaussianBiasSelector object at 0x7fac57d4fc10>

    def test_pick(self):
        picks = [self.sel.pick(self.mytraj) for _ in range(100)]
        pick_counter = collections.Counter(picks)
        assert set(pick_counter.keys()) == set(range(len(self.mytraj)))
        # final test: 99.5 should happen more than 32.4
>       assert pick_counter[2] > pick_counter[0]
E       assert 13 > 18

openpathsampling/tests/test_shooting.py:70: AssertionError
```

This PR attaches a random number generator to the selectors that can be seeded during tests to prevent these flaky tests.

The current implementation requires `numpy>=1.17` (that is when numpy swapped from `RandomState` to [`Generator`](https://numpy.org/doc/stable/reference/random/index.html)) @dwhswenson please let me know if that is too strict of a requirement and if I should write some code to support the Legacy `RandomState`