### PR TITLE
make test less flaky

### DIFF
--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -63,7 +63,7 @@ class TestGaussianBiasSelector(SelectorTest):
         ]
 
     def test_pick(self):
-        picks = [self.sel.pick(self.mytraj) for _ in range(100)]
+        picks = [self.sel.pick(self.mytraj) for _ in range(1000)]
         pick_counter = collections.Counter(picks)
         assert set(pick_counter.keys()) == set(range(len(self.mytraj)))
         # final test: 99.5 should happen more than 32.4


### PR DESCRIPTION
This week my CI failed with:
```python
=================================== FAILURES ===================================
______________________ TestGaussianBiasSelector.test_pick ______________________

self = <openpathsampling.tests.test_shooting.TestGaussianBiasSelector object at 0x7fac57d4fc10>

    def test_pick(self):
        picks = [self.sel.pick(self.mytraj) for _ in range(100)]
        pick_counter = collections.Counter(picks)
        assert set(pick_counter.keys()) == set(range(len(self.mytraj)))
        # final test: 99.5 should happen more than 32.4
>       assert pick_counter[2] > pick_counter[0]
E       assert 13 > 18

openpathsampling/tests/test_shooting.py:70: AssertionError
```
(first mentioned in #998) from the comments on #998, this test should just be made less flaky.

timing for this test file goes from `1.06 s` to `1.10 s` with this change 