### PR TITLE
Fix SimStore NumPy deprecations

### DIFF
--- a/openpathsampling/experimental/simstore/attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/attribute_handlers.py
@@ -136,9 +136,9 @@ class NDArrayHandler(AttributeHandler):
         return parse_ndarray_type(type_str)
 
     def serialize(self, obj):
-        return obj.astype(dtype=self.dtype, copy=False).tostring()
+        return obj.astype(dtype=self.dtype, copy=False).tobytes()
 
     def deserialize(self, data, caches=None):
-        return np.fromstring(data, dtype=self.dtype).reshape(self.shape)
+        return np.frombuffer(data, dtype=self.dtype).reshape(self.shape)
 
 DEFAULT_HANDLERS = [NDArrayHandler, StandardHandler]

--- a/openpathsampling/experimental/simstore/custom_json.py
+++ b/openpathsampling/experimental/simstore/custom_json.py
@@ -207,7 +207,7 @@ import numpy as np
 def numpy_to_dict(obj):
     return {'shape': obj.shape,
             'dtype': str(obj.dtype),
-            'string': obj.tostring()}
+            'string': obj.tobytes()}
 
 def numpy_from_dict(dct):
     arr = np.frombuffer(dct['string'], dtype=np.dtype(dct['dtype']))


### PR DESCRIPTION
Removes some old `tostring()` calls that should be `tobytes()`.