### PR TITLE
Prevent netcdfplus from trying to load netcdfplus CVs as SimStore CVs

### DIFF
--- a/openpathsampling/netcdfplus/base.py
+++ b/openpathsampling/netcdfplus/base.py
@@ -242,8 +242,10 @@ class StorableObject(object):
             The name points to the class
         """
         subclasses = StorableObject.descendants()
-
-        return {subclass.__name__: subclass for subclass in subclasses}
+        return {subclass.__name__: subclass for subclass in subclasses
+                if not subclass.__module__.startswith(
+                    'openpathsampling.experimental.storage'
+                )}
 
     @classmethod
     def args(cls):


### PR DESCRIPTION
As of #995, it appears that netcdfplus tries to load CVs as SimStore CVs. This is apparently because netcdfplus maps a class name (not fully qualified; just the class name) to a class. And once SimStore CVs were found in the chain of subclasses, netcdfplus replaced the old CVs with the new ones. This would lead to errors when loading old CVs (which do not have the same storage dict as new CVs).

The solution is to exclude classes in the `openpathsampling.experimental.storage` subpackage from being listed as classes that netcdfplus can load.