### PR TITLE
SimStore: Make storable function modes customizable

### DIFF
--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -325,7 +325,7 @@ class StorableFunction(StorableNamedObject):
 
     @mode.setter
     def mode(self, value):
-        allowed_values = list(self._modes.keys())
+        allowed_values = list(self._modes)
         if value not in allowed_values:
             raise ValueError("Unknown mode: '%s'. Allowed options: %s" %
                              (value, allowed_values))
@@ -562,4 +562,3 @@ class StorageFunctionHandler(object):
         missing = uuids - set(uuid_map.keys())
         missing_map = {uuid: uuid_items[uuid] for uuid in missing}
         return uuid_map, missing_map
-

--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -274,6 +274,14 @@ class StorableFunction(StorableNamedObject):
         self._check_period(period_min, period_max)
         self.period_min = period_min
         self.period_max = period_max
+        self._modes = {  # tuples of (function, add_to_cache)
+            'analysis': [(self._get_cached, False),
+                         (self._get_storage, True),
+                         (self._eval, True)],
+            'production': [(self._get_cached, False),
+                           (self._eval, True)],
+            'no-caching': [(self._eval, False)]
+        }
         self.mode = 'analysis'
 
     @staticmethod
@@ -317,7 +325,7 @@ class StorableFunction(StorableNamedObject):
 
     @mode.setter
     def mode(self, value):
-        allowed_values = ['no-caching', 'analysis', 'production']
+        allowed_values = list(self._modes.keys())
         if value not in allowed_values:
             raise ValueError("Unknown mode: '%s'. Allowed options: %s" %
                              (value, allowed_values))
@@ -433,14 +441,7 @@ class StorableFunction(StorableNamedObject):
         uuid_items = {get_uuid(item): item for item in items}
         # TODO: add preprocessing here? if needed?
 
-        cache_mode_order = {  # tuples of (function, add_to_cache)
-            'analysis': [(self._get_cached, False),
-                         (self._get_storage, True),
-                         (self._eval, True)],
-            'production': [(self._get_cached, False),
-                           (self._eval, True)],
-            'no-caching': [(self._eval, False)]
-        }[self.mode]
+        cache_mode_order = self._modes[self.mode]
 
         missing = uuid_items
         result_dict = {}

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -275,8 +275,6 @@ class TestStorableFunction(object):
             pass
         else:
             func.local_cache.clear()
-        pytest.skip()
-        pass
 
     @staticmethod
     def _set_storage(func, mode, found_in, expected):
@@ -287,12 +285,13 @@ class TestStorableFunction(object):
                 found = {uuid: uuids[uuid] for uuid in uuids
                          if uuid in expected.keys()}
                 return {uuid: expected[uuid] for uuid in found}, missing
+
         else:
             def get_storage(cv_uuid, uuids):
                 return {}, dict(uuids)
 
         storage = mock.MagicMock(get_function_results=get_storage)
-        func._handler = storage
+        func._handlers.add(storage)
 
     @pytest.mark.parametrize('mode, found_in', [
         ('analysis', 'storage'), ('analysis', 'cache'),


### PR DESCRIPTION
The definition of modes for storable functions in SimStore (i.e., `'analysis'`, `'production'`, `'no-caching'`) was in a dictionary that was defined in the `__call__` method. This moves that dictionary to a private instance variable. This will allow (advanced) users to update that dictionary with custom modes.

This also removes an unnecessary skip that was shadowing the fact that some tests needed to be updated for changes in #985. The previously skipped tests now run and pass.