### PR TITLE
make rng private for selectors

### DIFF
--- a/openpathsampling/pathmovers/spring_shooting.py
+++ b/openpathsampling/pathmovers/spring_shooting.py
@@ -244,7 +244,7 @@ class SpringShootingSelector(paths.ShootingPointSelector):
         # Select the next index from the probability list and shift to range
         # from -delta_max to delta_max, 0 being the shooting index of the last
         # accepted trajectory
-        rand = self.rng.random() * self._total_bias
+        rand = self._rng.random() * self._total_bias
         dframe = 0
         prob = prob_list[0]
         while prob <= rand and dframe < len(prob_list):

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -13,7 +13,7 @@ init_log = logging.getLogger('openpathsampling.initialization')
 class ShootingPointSelector(StorableNamedObject):
     def __init__(self):
         # Assign rng, so it can be set to something else
-        self.rng = default_rng()
+        self._rng = default_rng()
         super(ShootingPointSelector, self).__init__()
 
     def f(self, snapshot, trajectory):
@@ -77,7 +77,7 @@ class ShootingPointSelector(StorableNamedObject):
         prob_list = self._biases(trajectory)
         sum_bias = sum(prob_list)
 
-        rand = self.rng.random() * sum_bias
+        rand = self._rng.random() * sum_bias
         idx = 0
         prob = prob_list[0]
         while prob <= rand and idx < len(prob_list):
@@ -151,7 +151,7 @@ class UniformSelector(ShootingPointSelector):
         return float(len(trajectory) - self.pad_start - self.pad_end)
 
     def pick(self, trajectory):
-        idx = self.rng.integers(self.pad_start,
+        idx = self._rng.integers(self.pad_start,
                                 len(trajectory) - self.pad_end)
         return idx
 


### PR DESCRIPTION
closes #1007 (partly)

The notebook from that issue now works. However, It is now uncertain is the state of the generators that is loaded. 
This depends whether OPS is re-imported between loading or not.

```python
# before simulation:
{'bit_generator': 'PCG64',
 'state': {'state': 336467696170254096309584224979479325155,
  'inc': 238122374084886836437703854582102603205},
 'has_uint32': 0,
 'uinteger': 0}
<numpy.random._pcg64.PCG64 at 0x7f0b819d9d10>
 
# after running:
 {'bit_generator': 'PCG64',
 'state': {'state': 195230481313007235580189205770362297672,
  'inc': 238122374084886836437703854582102603205},
 'has_uint32': 1,
 'uinteger': 2214207804}
 <numpy.random._pcg64.PCG64 at 0x7f0b819d9d10>
 
# loaded in the same kernel session
{'bit_generator': 'PCG64',
 'state': {'state': 195230481313007235580189205770362297672,
  'inc': 238122374084886836437703854582102603205},
 'has_uint32': 1,
 'uinteger': 2214207804}
<numpy.random._pcg64.PCG64 at 0x7f0b819d9d10>
 
# loaded in a restarted kernel session
 {'bit_generator': 'PCG64',
 'state': {'state': 316665816032858718566197330052104521012,
  'inc': 90421417105856406385200004491830534511},
 'has_uint32': 0,
 'uinteger': 0}
 <numpy.random._pcg64.PCG64 at 0x7f0ab8347d10>
```
This is a broader issue to be solved, as OPS does not have a way of storaging mutable objects (such as a rng state)
