### PR TITLE
Ignore more flaky PyEMMA on Python 2.7

### DIFF
--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -135,6 +135,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "def pyemma_generator(f):\n",
     "    f.add_inverse_distances(f.pairs(f.select_Backbone()))"
    ]
@@ -472,7 +473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Adds another ignore cell output (stderr) to the flaky PyEMMA notebook.

Honestly, it's probably best to just convert that notebook to proper unit tests. We need the unit tests anyway, and that's the main purpose of that notebook.

Such a minor change -- will merge on green.