### PR TITLE
Fix docstring MDTopology to MDTrajTopology

### DIFF
--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -539,7 +539,7 @@ class MDTrajFunctionCV(CoordinateFunctionCV):
         ----------
         name : str
         f
-        topology : :obj:`openpathsampling.engines.openmm.MDTopology`
+        topology : :obj:`openpathsampling.engines.openmm.MDTrajTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
             the featurizer in ``pyemma.coordinates.featurizer(topology)``
         cv_requires_lists
@@ -607,7 +607,7 @@ class MSMBFeaturizerCV(CoordinateGeneratorCV):
         name
         featurizer : msmbuilder.Featurizer, callable
             the featurizer used as a callable class
-        topology : :obj:`openpathsampling.engines.openmm.MDTopology`
+        topology : :obj:`openpathsampling.engines.openmm.MDTrajTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
             the featurizer in ``pyemma.coordinates.featurizer(topology)``
         **kwargs :
@@ -696,7 +696,7 @@ class PyEMMAFeaturizerCV(MSMBFeaturizerCV):
         name
         featurizer : :class:`pyemma.coordinates.featurizer`
             the pyemma featurizer used as a callable class
-        topology : :obj:`openpathsampling.engines.openmm.MDTopology`
+        topology : :obj:`openpathsampling.engines.openmm.MDTrajTopology`
             the mdtraj topology wrapper from OPS that is used to initialize
             the featurizer in ``pyemma.coordinates.featurizer(topology)``
         **kwargs : dict

--- a/openpathsampling/collectivevariables/plumed_wrapper.py
+++ b/openpathsampling/collectivevariables/plumed_wrapper.py
@@ -27,7 +27,7 @@ class PLUMEDCV(paths.CoordinateFunctionCV):
     https://doi.org/10.1016/j.cpc.2013.09.018
 
     Examples
-
+    --------
     >>> # To create a `CollectiveVariable` which calculates the dihedral psi
     >>> # formed by the atoms [7,9,15,17] in Ala dipeptide:
     >>> from openpathsampling import PLUMEDCV, PLUMEDInterface

--- a/openpathsampling/collectivevariables/plumed_wrapper.py
+++ b/openpathsampling/collectivevariables/plumed_wrapper.py
@@ -27,7 +27,7 @@ class PLUMEDCV(paths.CoordinateFunctionCV):
     https://doi.org/10.1016/j.cpc.2013.09.018
 
     Examples
-    --------
+
     >>> # To create a `CollectiveVariable` which calculates the dihedral psi
     >>> # formed by the atoms [7,9,15,17] in Ala dipeptide:
     >>> from openpathsampling import PLUMEDCV, PLUMEDInterface
@@ -224,7 +224,7 @@ class PLUMEDInterface(StorableNamedObject):
         """
         Parameters
         ----------
-        topology : :obj:`openpathsampling.engines.openmm.MDTopology`
+        topology : :obj:`openpathsampling.engines.openmm.MDTrajTopology`
         pathtoplumed : string
             path to the PLUMED installation
         timestep : double

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -83,7 +83,7 @@ class OpenMMEngine(DynamicsEngine):
         """
         Parameters
         ----------
-        topology : openpathsampling.engines.openmm.MDTopology
+        topology : openpathsampling.engines.openmm.MDTrajTopology
             a template snapshots which provides the topology object to be used
             to create the openmm engine
         system : simtk.openmm.app.System

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -1,5 +1,4 @@
 import logging
-import copy
 
 import simtk.openmm
 import simtk.openmm.app
@@ -11,6 +10,7 @@ from .snapshot import Snapshot
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
 
 def restore_custom_integrator_interface(integrator):
     """
@@ -35,12 +35,12 @@ def restore_custom_integrator_interface(integrator):
             # openmmtools 0.15 or later
             from openmmtools.utils import RestorableOpenMMObject \
                     as RestorableObject
-        except ImportError: # pragma: no cover
+        except ImportError:  # pragma: no cover
             # DEPRECATED: remove in 2.0 (support for openmmtools < 0.15)
             from openpathsampling.deprecations import OPENMMTOOLS_VERSION
             OPENMMTOOLS_VERSION.warn()
             from openmmtools.integrators import RestorableIntegrator \
-                    as RestorableObject
+                as RestorableObject
 
         if RestorableObject.is_restorable(integrator):
             success = RestorableObject.restore_interface(integrator)
@@ -346,6 +346,7 @@ class OpenMMEngine(DynamicsEngine):
             options=options,
             openmm_properties=properties
         )
+
     @property
     def mdtraj_topology(self):
         return self.topology.mdtraj
@@ -381,7 +382,6 @@ class OpenMMEngine(DynamicsEngine):
             # for i in range(iterator_length):
                 # new_item[i] = item[i].value_in_unit_system(u.md_unit_system)
             # return item
-
 
     def _build_current_snapshot(self):
         # TODO: Add caching for this and mark if changed
@@ -461,7 +461,6 @@ class OpenMMEngine(DynamicsEngine):
 
     def has_constraints(self):
         return tools.has_constraints_from_system(self.simulation.system)
-
 
     def apply_constraints(self, snapshot=None, position_tol=None,
                           velocity_tol=1e-5):


### PR DESCRIPTION
A student asked my help initializing the `OpenMMEngine` and I could not find the `openpathsampling.engines.openmm.MDTopology`. Looking at `openpathsampling/engines/openmm/topology.py` this is actually called: `MDTrajTopology`

This PR all the docstrings that mention `MDTopology`. 
it also fixes some of the trivial `pep8` complaints in openmm/engine.py