### PR TITLE
Fix backward compatiblity for MDTrajTopology

### DIFF
--- a/openpathsampling/engines/openmm/__init__.py
+++ b/openpathsampling/engines/openmm/__init__.py
@@ -29,5 +29,6 @@ else:
     from . import features
 
     from .snapshot import Snapshot, MDSnapshot
+    from . import topology
 
 from openpathsampling.engines import NoEngine, SnapshotDescriptor


### PR DESCRIPTION
This fixes a backward compatibility problem introduced in #1012:

```python
import openpathsampling as paths
paths.engines.openmm.topology.MDTrajTopology
```

After #1012:

```pytb
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-95752f96565c> in <module>
----> 1 paths.engines.openmm.topology.MDTrajTopology

AttributeError: module 'openpathsampling.engines.openmm' has no attribute 'topology'
```

After this PR:

```
/Users/dwhs/miniconda3/envs/dev/bin/ipython:1: DeprecationWarning: openpathsampling.engines.openmm.topology.MDTrajTopology has been moved. Import MDTrajTopology from openpathsampling.engines instead.
  #!/Users/dwhs/miniconda3/envs/dev/bin/python
```