### PR TITLE
MAX_SQL_ITEMS as class variable

### DIFF
--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -288,7 +288,7 @@ class SQLStorageBackend(StorableNamedObject):
         table = self.metadata.tables[table_name]
         results = []
         with self.engine.connect() as conn:
-            for block in grouper(idx_list, 1000):
+            for block in grouper(idx_list, 900):
                 or_stmt = sql.or_(*(table.c.idx == idx for idx in block))
                 sel = table.select(or_stmt)
                 results.extend(list(conn.execute(sel)))

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -96,6 +96,7 @@ class SQLStorageBackend(StorableNamedObject):
 
     More info: https://docs.sqlalchemy.org/en/latest/core/engines.html
     """
+    MAX_SQL_ITEMS = 900
     def __init__(self, filename, mode='r', sql_dialect='sqlite', **kwargs):
         super().__init__()
         self.filename = filename
@@ -103,7 +104,6 @@ class SQLStorageBackend(StorableNamedObject):
         self.mode = mode
         self.kwargs = kwargs
         self.debug = False
-        self.max_query_size = 900
 
         # maps a specific type name, to generic type info, e.g.
         # 'ndarray.float32(1651,3)': 'ndarray'
@@ -288,7 +288,7 @@ class SQLStorageBackend(StorableNamedObject):
         table = self.metadata.tables[table_name]
         results = []
         with self.engine.connect() as conn:
-            for block in grouper(idx_list, 900):
+            for block in grouper(idx_list, self.MAX_SQL_ITEMS):
                 or_stmt = sql.or_(*(table.c.idx == idx for idx in block))
                 sel = table.select(or_stmt)
                 results.extend(list(conn.execute(sel)))
@@ -412,7 +412,7 @@ class SQLStorageBackend(StorableNamedObject):
         """
         table = self.metadata.tables[table_name]
         results = []
-        for uuid_block in tools.block(uuids, self.max_query_size):
+        for uuid_block in tools.block(uuids, self.MAX_SQL_ITEMS):
             # uuid_sel = table.select(
                 # sql.exists().where(table.c.uuid.in_(uuid_block))
             # )
@@ -460,7 +460,7 @@ class SQLStorageBackend(StorableNamedObject):
 
         res = []
         uuids = [obj['uuid'] for obj in objects]
-        for uuid_block in tools.block(uuids, self.max_query_size):
+        for uuid_block in tools.block(uuids, self.MAX_SQL_ITEMS):
             sel_uuids_idx = sql.select([table.c.uuid, table.c.idx]).\
                     where(table.c.uuid.in_(uuid_block))
             with self.engine.connect() as conn:
@@ -501,7 +501,7 @@ class SQLStorageBackend(StorableNamedObject):
         uuid_table = self.metadata.tables['uuid']
         logger.debug("Looking for {} UUIDs".format(len(uuids)))
         results = []
-        for uuid_block in tools.block(uuids, self.max_query_size):
+        for uuid_block in tools.block(uuids, self.MAX_SQL_ITEMS):
             logger.debug("New block of {} UUIDs".format(len(uuid_block)))
             uuid_sel = uuid_table.select().\
                     where(uuid_table.c.uuid.in_(uuid_block))

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -179,6 +179,24 @@ class TestSQLStorageBackend(object):
         assert len(loaded_table) == 3
         pytest.skip()
 
+    def test_load_save_large_numbers(self):
+        # mainly a smoke test to ensure that we reload everything correctly
+        n_objs = 1001
+        snapshot_schema = {'snapshot0': self.schema['snapshot0']}
+        self.database.register_schema(snapshot_schema, self.table_to_class)
+        assert self.database.table_len('snapshot0') == 0
+        snap_dicts = [
+            {'filename': 'foo.trr', 'index': idx, 'uuid': 'uuid' + str(idx)}
+            for idx in range(n_objs)
+        ]
+        self.database.add_to_table('snapshot0', snap_dicts)
+        assert self.database.table_len('snapshot0') == n_objs
+        uuids = [dct['uuid'] for dct in snap_dicts]
+        uuid_table_rows = self.database.load_uuids_table(uuids)
+        assert len(uuid_table_rows) == n_objs
+        reloaded = self.database.load_table_data(uuid_table_rows)
+        assert len(reloaded) == n_objs
+
     def test_load_table_data_missing(self):
         pytest.skip()
 


### PR DESCRIPTION
This converts the `max_query_size` that @sroet had introduced as an instance variable in `SQLStorageBackend` to a class variable, and adds its use in a corner case that @gyorgy-hantal came across.

It makes more sense to have this as a class variable because it is determined by the way the SQL backend (usually SQLite) was compiled on the local machine, and therefore will be constant throughout a session (for however many files the user opens). Of course, it can still be overridden on an instance-by-instance basis.

Currently WIP because I'm hoping that I can get a regression test, but I may mark it as ready to merge without such a test if it is too annoying to create. @gyorgy-hantal has confirmed that this fixed his issue.