### PR TITLE
Pin OpenMM != 7.5.1

### DIFF
--- a/devtools/tested_integrations.txt
+++ b/devtools/tested_integrations.txt
@@ -1,5 +1,5 @@
 jupyter
-openmm
+openmm!=7.5.1
 openmmtools
 py-plumed
 pyemma


### PR DESCRIPTION
A change in OpenMM 7.5.1 is causing our tests to fail, and could cause problems for users if they trigger a NaN during dynamics with OpenMM. See https://github.com/openmm/openmm/issues/3098.