### PR TITLE
ignore more flaky pyemma py 2.7

### DIFF
--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -245,7 +245,7 @@
    },
    "outputs": [],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n"
+    "# NBVAL_IGNORE_OUTPUT\n",
     "py_cv = storage.cvs['pyemma']"
    ]
   },

--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -245,6 +245,7 @@
    },
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n"
     "py_cv = storage.cvs['pyemma']"
    ]
   },


### PR DESCRIPTION
This failed for 2.7 with:
```
__________________ examples/tests/test_pyemma.ipynb::Cell 10 ___________________
Notebook cell execution failed
Cell 10: Cell outputs differ

Input:
py_cv = storage.cvs['pyemma']

Traceback:
Unexpected output fields from running code: set([u'stderr'])
```

Fixed in a similar fashion as #1009 

[edit]: [link to the failing test](https://github.com/sroet/openpathsampling/runs/2515098923)