### PR TITLE
Test against OpenMM RCs

### DIFF
--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -1,0 +1,27 @@
+# Workflow to check for a recent OpenMM release candidate.
+#
+# If a recent RC is found, trigger a second workflow to test against it.
+# See also: test-openmm-rc.yml
+name: "Check for OpenMM RC"
+on:
+  schedule:
+    - cron: "0 9 * * */2"
+
+jobs:
+  check-rc:
+    runs-on: ubuntu-latest
+    name: "Check for OpenMM RC"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dwhswenson/conda-rc-check@main
+        id: checkrc
+        with:
+          channel: conda-forge
+          package: openmm
+          ndays: 30  # TODO: decrease to 7
+          labels: openmm_rc
+      - uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Test OpenMM Release Candidate
+          token: ${{ secrets.DISPATCH_TOKEN }}
+        if: ${{ steps.checkrc.outputs.hasrc == 'True' }}

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           channel: conda-forge
           package: openmm
-          ndays: 30  # TODO: decrease to 7
+          ndays: 30  # TODO: decrease to 3
           labels: openmm_rc
       - uses: benc-uk/workflow-dispatch@v1
         with:

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -4,6 +4,9 @@
 # See also: test-openmm-rc.yml
 name: "Check for OpenMM RC"
 on:
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: "0 9 * * */2"
 

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -4,9 +4,6 @@
 # See also: test-openmm-rc.yml
 name: "Check for OpenMM RC"
 on:
-  pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 9 * * */2"
 

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -1,0 +1,47 @@
+# Workflow to test against release candidate of OpenMM.
+# See also: check-openmm-rc.yml
+name: "Test OpenMM Release Candidate"
+on:
+  repository_dispatch:
+  # TODO: temporary -- for testing purposes
+  pull_request:
+    branch: master
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    name: "Tests"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-python@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with: 
+          auto-update-conda: true
+      - name: "Install requirements"
+        run: |
+          source devtools/conda_install_reqs.sh
+      - name: "Install OpenMM RC"
+        run: |
+          conda install -c conda-forge/label/openmm_rc -c conda-forge openmm
+      - name: "Install"
+        run: |
+          python -m pip install --no-deps -e .
+          python -c "import openpathsampling"
+      - name: "Versions"
+        run: conda list
+      - name: "Unit Tests"
+        env:
+          PY_COLORS: "1"
+        run: py.test -vv -s --cov --cov-report xml
+      - name: "Tests: Experimental"
+        if: matrix.MINIMAL == '' && matrix.CONDA_PY != '2.7'
+        run: py.test openpathsampling/experimental/ -vv -s
+      - name: "Notebook tests"
+        run: |
+          pushd examples/ && ./ipynbtests.sh || exit 1 && popd

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -26,8 +26,8 @@ jobs:
       - name: "Install requirements"
         run: |
           CONDA_PY=$(python -c "import sys; print('.'.join(str(s) for s in sys.version_info[:2]))")
-        echo "Python version: ${CONDA_PY}"
-        source devtools/conda_install_reqs.sh
+          echo "Python version: ${CONDA_PY}"
+          source devtools/conda_install_reqs.sh
       - name: "Install OpenMM RC"
         run: |
           conda install -c conda-forge/label/openmm_rc -c conda-forge openmm

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -3,9 +3,9 @@
 name: "Test OpenMM Release Candidate"
 on:
   repository_dispatch:
-  # TODO: temporary -- for testing purposes
-  pull_request:
-    branch: master
+  # use this for debugging
+  #pull_request:
+    #branch: master
 
 defaults:
   run:

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -25,7 +25,9 @@ jobs:
           auto-update-conda: true
       - name: "Install requirements"
         run: |
-          source devtools/conda_install_reqs.sh
+          CONDA_PY=$(python -c "import sys; print('.'.join(str(s) for s in sys.version_info[:2]))")
+        echo "Python version: ${CONDA_PY}"
+        source devtools/conda_install_reqs.sh
       - name: "Install OpenMM RC"
         run: |
           conda install -c conda-forge/label/openmm_rc -c conda-forge openmm


### PR DESCRIPTION
Every time I see an OpenMM release candidate announced, I think, "I should really try that out and run the OPS test suite against it." But I don't. And this time we got hit by a bug (https://github.com/openmm/openmm/issues/3098) that could have been fixed in prerelease had I run those tests.

So the other day I created a GitHub Action that checks for recent prereleases of a conda package. This PR is to implement use of it here. I think I'll need to merge this PR before I can actually check that everything works, because the workflow that gets triggered to run the tests won't exist until it has been merged to master. So this may require a follow-up PR to complete everything, although the basic idea seems to be working fine in https://github.com/dwhswenson/conda-rc-check/.

Overall approach I plan to take: Every other day we check to see if an RC has been released within the last 3 days. If so, we trigger a workflow that will test against that RC. This is a simplified version of our test suite, only testing against the current default Python version from miniconda, and using the OpenMM RC. (The 2 day/3 day difference is in case GitHub's scheduler doesn't run at exactly the same time, so this ensures some overlap in the time windows.)

For now I'm using the `main` branch of my Action, but I'll release a 1.0 of that once I've tried it out here.