### PR TITLE
Fix error in testing OpenMM RCs

### DIFF
--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -2,7 +2,7 @@
 # See also: check-openmm-rc.yml
 name: "Test OpenMM Release Candidate"
 on:
-  repository_dispatch:
+  workflow_dispatch:
   # use this for debugging
   #pull_request:
     #branch: master


### PR DESCRIPTION
I used the wrong trigger name in #1019. (I had also looked at using the `repository_dispatch` mechanism, but decided to use `workflow_dispatch` instead.)

I'm merge this as soon as tests pass.