### PR TITLE
OpenMM RC testing: Switch ndays to 3

### DIFF
--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           channel: conda-forge
           package: openmm
-          ndays: 30  # TODO: decrease to 3
+          ndays: 3
           labels: openmm_rc
       - uses: benc-uk/workflow-dispatch@v1
         with:


### PR DESCRIPTION
I got the expected failure with `ndays` set to 30, so this PR is just to reduce that down to 3. See #1019 for overall test design.

I'll merge this immediate on passing tests; all needed review was done in discussion of #1019. 