### PR TITLE
ignore cell 15 pyemma test

### DIFF
--- a/examples/tests/test_pyemma.ipynb
+++ b/examples/tests/test_pyemma.ipynb
@@ -329,6 +329,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "py_cv_idx = storage.idx(py_cv)\n",
     "print(py_cv_idx)\n",
     "py_emma_feat = storage.vars['attributes_json'][py_cv_idx]"


### PR DESCRIPTION
Similar to #1018 , I know the drill by now.

Today py2.7 failed with:
```
=================================== FAILURES ===================================
__________________ examples/tests/test_pyemma.ipynb::Cell 15 ___________________
Notebook cell execution failed
Cell 15: Cell outputs differ

Input:
py_cv_idx = storage.idx(py_cv)
print(py_cv_idx)
py_emma_feat = storage.vars['attributes_json'][py_cv_idx]

Traceback:
Unexpected output fields from running code: set([u'stderr'])
```
This also ignores that cell