### PR TITLE
Shooting point selector with arbitrary bias

### DIFF
--- a/docs/shooting.rst
+++ b/docs/shooting.rst
@@ -11,3 +11,7 @@ ShootingPointSelectors
     ShootingPointSelector
     UniformSelector
     GaussianBiasSelector
+    BiasedSelector
+    InterfaceConstrainedSelector
+    FirstFrameSelector
+    FinalFrameSelector

--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -122,7 +122,8 @@ from .sample import Sample, SampleSet
 
 from .shooting import (
     ShootingPointSelector, UniformSelector, GaussianBiasSelector,
-    FirstFrameSelector, FinalFrameSelector, InterfaceConstrainedSelector
+    FirstFrameSelector, FinalFrameSelector, InterfaceConstrainedSelector,
+    BiasedSelector
 )
 
 from .snapshot_modifier import (

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -126,6 +126,25 @@ class GaussianBiasSelector(ShootingPointSelector):
         return math.exp(-self.alpha * (l_s - self.l_0) ** 2)
 
 
+class BiasedSelector(ShootingPointSelector):
+    """General biased shooting point selector
+
+    Takes any function (wrapped in an OPS CV) and uses that as the bias for
+    selecting the shooting point.
+
+    Parameters
+    ----------
+    func : :class:`.CollectiveVariable`
+        A function wrapped in an OPS CV which gives the relative bias.
+    """
+    def __init__(self, func):
+        super(BiasedSelector, self).__init__()
+        self.func = func
+
+    def f(self, snapshot, trajectory):
+        return self.func(snapshot)
+
+
 class UniformSelector(ShootingPointSelector):
     """
     Selects random frame in range `pad_start` to `len(trajectory-pad_end`.

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -10,6 +10,8 @@ from openpathsampling.ensemble import LengthEnsemble
 from openpathsampling.sample import Sample, SampleSet
 import openpathsampling as paths
 
+import numpy as np
+
 
 class SelectorTest(object):
     def setup(self):
@@ -81,6 +83,47 @@ class TestGaussianBiasSelector(SelectorTest):
         expected = pytest.approx(self.f[frame] / norm)
         assert self.sel.probability(traj[frame], traj) == expected
 
+class TestBiasedSelector(SelectorTest):
+    def setup(self):
+        super(TestBiasedSelector, self).setup()
+        self.f = {
+            'gaussian': [
+                0.32465246735834974,  # = exp(-2.0*(-0.5-0.25)**2)
+                0.9559974818331,      # = exp(-2.0*(0.1-0.25)**2)
+                0.9950124791926823,   # = exp(-2.0*(0.2-0.25)**2)
+                0.9950124791926823,   # = exp(-2.0*(0.3-0.25)**2)
+                0.8824969025845955,   # = exp(-2.0*(0.5-0.25)**2)
+            ],
+            'uniform': [1] * 5
+        }
+
+    @staticmethod
+    def _create_selector(func_name):
+        func = {
+            'gaussian': lambda s: np.exp(-2.0 * (s.xyz[0][0] - 0.25)**2),
+            'uniform': lambda s: 1
+        }[func_name]
+        cv = paths.FunctionCV('sel_cv', func)
+        selector = BiasedSelector(cv)
+        return selector
+
+    @pytest.mark.parametrize('func', ['gaussian', 'uniform'])
+    @pytest.mark.parametrize('frame', [0, 1, 2, 3, 4])
+    def test_f(self, func, frame):
+        sel = self._create_selector(func)
+        f = self.f[func]
+        traj = self.mytraj
+        assert sel.f(traj[frame], traj) == pytest.approx(f[frame])
+
+    @pytest.mark.parametrize('func', ['gaussian', 'uniform'])
+    @pytest.mark.parametrize('frame', [0, 1, 2, 3, 4])
+    def test_probability(self, func, frame):
+        sel = self._create_selector(func)
+        f = self.f[func]
+        norm = sum(f)
+        traj = self.mytraj
+        expected = pytest.approx(f[frame] / norm)
+        assert sel.probability(traj[frame], traj) == expected
 
 class TestFirstFrameSelector(SelectorTest):
     def test_pick(self):


### PR DESCRIPTION
For a very long time, OPS has had the ability to use a Gaussian bias in shooting point selection. That is, given a CV `f`, the  probability of selecting a shooting point `x` within a given trajectory is proportional to `np.exp(-a*(f(x)-x0)**2)`, where `a` and `x0` are parameters set by the user.

There is no reason for this to be restricted to Gaussians. This PR introduces a `BiasedSelector`, which allows one to use *any* function (wrapped in an OPS CV) as the bias function. The only reason this didn't exist before is because when we were writing shooting point selectors, I don't think we understood the flexibility that OPS CVs would have. 

Now, for example, the `GaussianBiasSelector` could be implemented as:

```python
def gaussian(snapshot, cv, a, x0):
    return np.exp(-a * (cv(snapshot)-x0)**2)

cv_gaussian = paths.FunctionCV('shooting_bias', gaussian, cv=my_cv, a=2.0, x0=0.25)
selector = paths.BiasedSelector(cv_gaussian)
```

But similarly, one could use any other function.