### PR TITLE
[WIP] Analysis Filters

### DIFF
--- a/examples/misc/analysis_filters.ipynb
+++ b/examples/misc/analysis_filters.ipynb
@@ -1,0 +1,341 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b8e87f34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openpathsampling as paths\n",
+    "from openpathsampling.experimental.storage import Storage, monkey_patch_all\n",
+    "paths = monkey_patch_all(paths)\n",
+    "\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "from openpathsampling.analysis.new_filters import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1af33fa8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storage = Storage(\"./oneway.db\", mode='r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96664904",
+   "metadata": {},
+   "source": [
+    "First, we can use these filters directly on steps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0127b9c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for step in RejectedSteps(storage.steps):\n",
+    "    ...  # here is where you might do something to analyze rejection reasons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a2f7bf35",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "559"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# we can use some basic Python to get a quick count of accepted steps\n",
+    "len(list(AcceptedSteps(storage.steps)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f5bc276",
+   "metadata": {},
+   "source": [
+    "We can also use the step filters in combination with sample filters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "516fe25e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "replica_0_filter = Replica(0)\n",
+    "for step in RejectedSteps(storage.steps):\n",
+    "    samples = step.change.canonical.trials\n",
+    "    for sample in replica_0_filter(samples):\n",
+    "        ... # do something with each sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46072e11",
+   "metadata": {},
+   "source": [
+    "However, since this is really common, we have a class `SampleFilter` that does that for you. Note that we have 3 primary stages: filtering based on the steps (`step_filter`), then selecting samples from those steps (`sample_selector`), then filtering based on the samples (`sample_filter`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3367156a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filt = SampleFilter(step_filter=RejectedSteps, \n",
+    "                    sample_selector=TrialSamples,\n",
+    "                    sample_filter=Replica(0))\n",
+    "\n",
+    "for sample in filt(steps, flatten=True):\n",
+    "    ... # just like above, but a little cleaner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73724652",
+   "metadata": {},
+   "source": [
+    "The `flatten` argument says to give each sample. The default behavior is for each step to return a list of samples (which may be an empty list for some steps)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c08b9e2b",
+   "metadata": {},
+   "source": [
+    "Finally, the part that's actually pretty neat -- we can use logical combinations of the filters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "9fd153b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1001"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filt = AcceptedSteps | RejectedSteps\n",
+    "len(list(filt(storage.steps)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "e41a79b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "153"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filt = RejectedSteps & CanonicalMover('ForwardShootMover')\n",
+    "len(list(filt(storage.steps)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7cf5506",
+   "metadata": {},
+   "source": [
+    "These can be arbitrarily complex (just remember to use parentheses correctly!):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "6332cfad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "337"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filt = (\n",
+    "    (RejectedSteps & CanonicalMover('ForwardShootMover'))\n",
+    "    | (AcceptedSteps & CanonicalMover('BackwardShootMover'))\n",
+    ")\n",
+    "len(list(filt(storage.steps)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "7f62f4ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# bad parens here give inherent contradiction\n",
+    "filt = (\n",
+    "    RejectedSteps \n",
+    "    & (CanonicalMover('ForwardShootMover') | AcceptedSteps)\n",
+    "    & CanonicalMover('BackwardShootMover')\n",
+    ")\n",
+    "len(list(filt(storage.steps)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e89dcf78",
+   "metadata": {},
+   "source": [
+    "So far, if you combine different stages, you'll get an error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "65928ae7",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Cannot combine filters <openpathsampling.analysis.new_filters.StepFilter object at 0x7fdd03b20410> and <openpathsampling.analysis.new_filters.SampleSelector object at 0x7fdd03b20250>",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-25-fcffa02b5cc4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mRejectedSteps\u001b[0m \u001b[0;34m&\u001b[0m \u001b[0mTrialSamples\u001b[0m \u001b[0;34m&\u001b[0m \u001b[0mReplica\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Dropbox/pysrc/openpathsampling/openpathsampling/analysis/new_filters.py\u001b[0m in \u001b[0;36m__and__\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m     15\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mcondition\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mNotImplementedError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     18\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__and__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mother\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m         \u001b[0;31m# need fancier logic here to combine multiple stages\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Dropbox/pysrc/openpathsampling/openpathsampling/analysis/new_filters.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, filter1, filter2)\u001b[0m\n\u001b[1;32m     46\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mSTAGE\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfilter1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSTAGE\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilter1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilter2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mfilter1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSTAGE\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mfilter2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSTAGE\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: Cannot combine filters <openpathsampling.analysis.new_filters.StepFilter object at 0x7fdd03b20410> and <openpathsampling.analysis.new_filters.SampleSelector object at 0x7fdd03b20250>"
+     ]
+    }
+   ],
+   "source": [
+    "RejectedSteps & TrialSamples & Replica(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "990348d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: need to add reprs to make that a little easier to read"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/openpathsampling/analysis/filters.py
+++ b/openpathsampling/analysis/filters.py
@@ -1,0 +1,195 @@
+import openpathsampling as paths
+import enum
+
+class Stages(enum.Enum):
+    UNKNOWN = 0
+    STEP_FILTER = 1
+    SAMPLE_SELECTOR = 2
+    SAMPLE_FILTER = 3
+    POSTPROCESSING = 4
+
+class _Filter(object):
+    """Abstract base class for filters.
+    """
+    STAGE = Stages.UNKNOWN
+    def condition(self, inp):
+        raise NotImplementedError()
+
+    def __and__(self, other):
+        # need fancier logic here to combine multiple stages
+        return AndFilterCombination(self, other)
+
+    def __or__(self, other):
+        return OrFilterCombination(self, other)
+
+    def __invert__(self):
+        return NegationFilter(self)
+
+    def __call__(self, inputs):
+        return filter(self.condition, inputs)
+
+
+class NegationFilter(_Filter):
+    @property
+    def STAGE(self):
+        return self.filter.STAGE
+
+    def __init__(self, filt):
+        self.filter = filt
+
+    def condition(self, inp):
+        return not self.filter(inp)
+
+
+class AndFilterCombination(_Filter):
+    @property
+    def STAGE(self):
+        return self.filter1.STAGE
+
+    def __init__(self, filter1, filter2):
+        if filter1.STAGE != filter2.STAGE:
+            raise TypeError(f"Cannot combine filters {filter1} and {filter2}")
+        self.filter1 = filter1
+        self.filter2 = filter2
+
+    def condition(self, inp):
+        return self.filter1.condition(inp) and self.filter2.condition(inp)
+
+
+class OrFilterCombination(_Filter):
+    @property
+    def STAGE(self):
+        return self.filter1.STAGE
+
+    def __init__(self, filter1, filter2):
+        if filter1.STAGE != filter2.STAGE:
+            raise TypeError(f"Cannot combine filters {filter1} and {filter2}")
+        self.filter1 = filter1
+        self.filter2 = filter2
+
+    def condition(self, inp):
+        return self.filter1.condition(inp) or self.filter2.condition(inp)
+
+
+class CanonicalMover(_Filter):
+    STAGE = Stages.STEP_FILTER
+    def __init__(self, mover):
+        if isinstance(mover, paths.PathMover):
+            self.mover = mover
+            self._condition = self.equality_check
+        elif isinstance(mover, str):
+            self.mover = getattr(paths, mover)
+            self._condition = self.isinstance_check
+        elif issubclass(mover, paths.PathMover):
+            self.mover = mover
+            self._condition = self.isinstance_check
+        else:
+            raise ValueError(f"{mover} does not appear to be a path mover")
+
+    def equality_check(self, mover):
+        return mover == self.mover
+
+    def isinstance_check(self, mover):
+        return isinstance(mover, self.mover)
+
+    def condition(self, step):
+        return self._condition(step.change.canonical.mover)
+
+    def __str__(self):
+        return f"(canonical mover is {self.mover}"
+
+
+class StepFilter(_Filter):
+    STAGE = Stages.STEP_FILTER
+    def __init__(self, condition):
+        self.condition = condition
+
+    def condition(self, step):
+        return self.condition(step)
+
+RejectedSteps = StepFilter(lambda step: not step.change.accepted)
+AcceptedSteps = StepFilter(lambda step: step.change.accepted)
+
+class SampleSelector(_Filter):
+    STAGE = Stages.SAMPLE_SELECTOR
+    def __init__(self, selector):
+        self.selector = selector
+
+    def condition(self, step):
+        return self.selector(step)
+
+    def __call__(self, step):
+        return self.selector(step)
+
+ActiveSamples = SampleSelector(lambda step: step.active.samples)
+TrialSamples = SampleSelector(lambda step: step.change.canonical.trials)
+
+
+class Ensemble(_Filter):
+    STAGE = Stages.SAMPLE_FILTER
+    def __init__(self, ensemble):
+        self.ensemble = ensemble
+
+    def condition(self, sample):
+        return sample.ensemble == self.ensemble
+
+
+class Replica(_Filter):
+    STAGE = Stages.SAMPLE_FILTER
+    def __init__(self, replica):
+        self.replica = replica
+
+    def condition(self, sample):
+        return sample.replica == self.replica
+
+class PostProcess(_Filter):
+    STAGE = Stages.POSTPROCESSING
+    def __init__(self, method):
+        self.method = method
+
+    def condition(self, samples):
+        for item in self.method(samples):
+            yield item
+
+def _flatten(samples):
+    for sample in samples:
+        yield sample
+
+def _list_per_step(samples):
+    return [list(samples)]
+
+Flatten = PostProcess(_flatten)
+ListPerStep = PostProcess(_list_per_step)
+
+class SampleFilter(object):
+    def __init__(self, step_filter=None, sample_selector=None,
+                 sample_filter=None, postprocess_filter=None):
+        self.step_filter = step_filter
+        self.sample_selector = sample_selector
+        self.sample_filter = sample_filter
+        if postprocess_filter is None:
+            postprocess_filter = ListPerStep
+        self.postprocess_filter = postprocess_filter
+
+    def __call__(self, steps, flatten=None):
+        postprocess = None
+        if flatten is True:
+            postprocess = Flatten
+        elif flatten is False:
+            postprocess = ListPerStep
+        elif flatten is None:
+            postprocess = self.postprocess_filter
+
+        if postprocess is None:
+            raise RuntimeError()
+
+        for step in self.step_filter(steps):
+            samples = self.sample_selector(step)
+            filtered = self.sample_filter(samples)
+            finalized = postprocess(filtered)
+            for result in finalized:
+                yield result
+
+# once we can mix stages:
+# TPSActiveSamples = ActiveSamples & Flatten
+# RejectedTrials = RejectedSteps & TrialSamples


### PR DESCRIPTION
This PR introduces analysis filters, an idea I've had for a while but just finally figured out how to implement correctly.

Basically, the idea is that a lot of OPS analysis code looks something like:

```python
for step in steps:
    mover = step.change.canonical.mover
    if not change.accepted and isinstance(mover, my_mover_type):
        trials = paths.SampleSet(step.change.canonical.trials)
        sample = trials[my_ensemble]
        # do something with that sample
```

Here the hypothetical user is checking rejected trials of a specific ensemble. It's some messy code already a couple levels of indent in, and with all that `step.change` stuff they need to remember. (And this is even using the hack that you can get a sample for a specific ensemble by converting the list of samples to a `SampleSet`.)

Here's how it works with the filters I'm introducing here:

```python
filt = SampleFilter(
    step_filter=RejectedSteps & CanonicalMover(my_mover_type),
    sample_selector=TrialSamples,
    sample_filter=Ensemble(my_ensemble),
)
for sample in filt(steps, flatten=True):
    # do something with that sample
```

I guess it doesn't save too much vertical space, but it does save some characters, and I think it will be much easier to learn/teach this approach.

More usage in the notebook added in this PR. For easy use cases, it's really nice (`for step in RejectedSteps(steps)`)

***

For discussion: does it make more sense stylistically to be:

```python
RejectedSteps & CanonicalMover(my_mover_type)
```

or 

```python
rejected_steps & canonical_mover(my_mover_type)
```

Formally, I think PEP8 would advise

```python
REJECTED_STEPS & CanonicalMover(my_mover_type)
```

since rejected states is actually a constant instance, while canonical mover really is a class. But consistency in user experience with filters is more important than foolish consistency with PEP8.
