### PR TITLE
Ensure that SimStore always saves movescheme

### DIFF
--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -46,6 +46,16 @@ def from_dict_attr_to_class(from_dict, attr_name):
         return from_dict(dct)
     return inner
 
+_PREPATCH = {
+    cls: {'to': getattr(cls, 'to_dict'),
+          'from': getattr(cls, 'from_dict')}
+    for cls in [
+        paths.netcdfplus.FunctionPseudoAttribute,
+        paths.TPSNetwork,
+        paths.MISTISNetwork,
+        paths.CallableCV,
+    ]
+}
 
 def monkey_patch_saving(paths):
     paths.netcdfplus.FunctionPseudoAttribute.to_dict = \
@@ -77,4 +87,10 @@ def monkey_patch_loading(paths):
 def monkey_patch_all(paths):
     paths = monkey_patch_saving(paths)
     paths = monkey_patch_loading(paths)
+    return paths
+
+def unpatch(paths):
+    for cls, old in _PREPATCH.items():
+        cls.to_dict = old['to']
+        cls.from_dict = old['from']
     return paths

--- a/openpathsampling/experimental/storage/test_pathsampling.py
+++ b/openpathsampling/experimental/storage/test_pathsampling.py
@@ -1,0 +1,24 @@
+# extra tests for PathSampling when running SimStore
+from openpathsampling.tests import test_pathsimulator
+from openpathsampling.experimental.storage import Storage, monkey_patch_all
+from openpathsampling.experimental.storage.monkey_patches import unpatch
+import openpathsampling as paths
+
+def setup_module():
+    import openpathsampling as paths
+    paths = monkey_patch_all(paths)
+
+def teardown_module():
+    import openpathsampling as paths
+    paths = unpatch(paths)
+
+class TestPathSampling(test_pathsimulator.TestPathSampling):
+    def test_save_scheme(self, tmpdir):
+        filename = tmpdir.join("temp.db")
+        storage = Storage(filename, mode='w')
+        assert len(storage.schemes) == 0
+        sim = paths.PathSampling(storage=storage,
+                                 move_scheme=self.scheme,
+                                 sample_set=self.init_cond)
+        assert len(storage.schemes) == 1
+

--- a/openpathsampling/pathsimulators/path_sampling.py
+++ b/openpathsampling/pathsimulators/path_sampling.py
@@ -51,6 +51,7 @@ class PathSampling(PathSimulator):
         self.status_update_frequency = 1
 
         if initialize:
+            # NOTE: why aren't we using save_initial_step here?
             samples = []
             if sample_set is not None:
                 for sample in sample_set:
@@ -76,6 +77,8 @@ class PathSampling(PathSimulator):
         if self.storage is not None:
             template_trajectory = self.sample_set.samples[0].trajectory
             self.storage.save(template_trajectory)
+            self.storage.save([self.move_scheme, self.root_mover,
+                               self._mover])
             self.save_current_step()
 
     def to_dict(self):

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -828,7 +828,7 @@ class TestPathSampling(object):
     def test_save_initial_scheme(self, tmpdir):
         # check that we actually save scheme when we save this
         filename = tmpdir.join("temp.nc")
-        storage = paths.Storage(filename, mode='w')
+        storage = paths.Storage(str(filename), mode='w')
         assert len(storage.schemes) == 0
         sim = paths.PathSampling(storage=storage,
                                  move_scheme=self.scheme,

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -808,6 +808,8 @@ class TestPathSampling(object):
             paths.strategies.OrganizeByMoveGroupStrategy()
         ])
         init_cond = scheme.initial_conditions_from_trajectories(init_traj)
+        self.scheme = scheme
+        self.init_cond = init_cond
         self.sim = PathSampling(storage=None, move_scheme=scheme,
                                 sample_set=init_cond)
 
@@ -822,3 +824,13 @@ class TestPathSampling(object):
         init_xyz = set(s.xyz.tobytes() for s in initial_snaps)
         final_xyz = set(s.xyz.tobytes() for s in final_snaps)
         assert init_xyz & final_xyz == set([])
+
+    def test_save_initial_scheme(self, tmpdir):
+        # check that we actually save scheme when we save this
+        filename = tmpdir.join("temp.nc")
+        storage = paths.Storage(filename, mode='w')
+        assert len(storage.schemes) == 0
+        sim = paths.PathSampling(storage=storage,
+                                 move_scheme=self.scheme,
+                                 sample_set=self.init_cond)
+        assert len(storage.schemes) == 1


### PR DESCRIPTION
Based on an email report from @gyorgy-hantal. It seems that SimStore was not saving the move scheme in the rare case that all steps fail due to maximum length/NaN. This seems to be because of a difference in SimStore allowing you to stash several steps for saving, whereas netcdfplus immediately saves after each step.

This PR also introduces a (not well-tested) `unpatch` method to undo the SimStore monkey patches. This will mainly be useful in testing.