### PR TITLE
Fix bug with SimStore CVs storing NumPy arrays

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -56,11 +56,10 @@ class Deprecation(object):
             result = result.format(**self.str_replace)
         return result
 
-    def warn(self, stacklevel=2):
+    def warn(self, stacklevel=2, category=DeprecationWarning):
         """Emit a warning for this deprecation."""
         if not (self.has_warned and self.warn_once):
-            warnings.warn(self.message, DeprecationWarning,
-                          stacklevel=stacklevel)
+            warnings.warn(self.message, category, stacklevel=stacklevel)
             self.has_warned = True
 
     def docstring_message(self, style='numpydoc'):
@@ -117,6 +116,13 @@ def version_tuple_to_string(version_tuple):
 
 
 # DEPRECATED THINGS SLATED FOR REMOVAL IN 2.0
+SIMSTORE_NO_SFR_TYPES = Deprecation(
+    problem=("This file is missing stored result types, and will not be "
+             "supported in {OPS} {version}."),
+    remedy=("Add result types to the file. See ???"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 5, 1)
+)
 
 OPENMMTOOLS_VERSION = Deprecation(
     problem="{OPS} {version} will require OpenMMTools 0.15 or later.",

--- a/openpathsampling/experimental/simstore/class_info.py
+++ b/openpathsampling/experimental/simstore/class_info.py
@@ -173,6 +173,12 @@ class SerializationSchema(object):
         # current default is to return the input; may change
         return type_name, None
 
+    def handler_for(self, type_name):
+        for handler in self.attribute_handlers:
+            handler_obj = handler.from_type_string(type_name)
+            if handler_obj is not None:
+                return handler_obj
+
     def register_info(self, class_info_list, schema=None):
         schema = tools.none_to_default(schema, {})
         self.schema.update(schema)

--- a/openpathsampling/experimental/simstore/memory_backend.py
+++ b/openpathsampling/experimental/simstore/memory_backend.py
@@ -79,6 +79,10 @@ class MemoryStorageBackend(object):
         self.uuid_table = {}  # maps UUID to table name
         self._table_to_class = {}
 
+        # at least these, possible more, move to superclass?
+        self.sfr_result_types = {}
+        self.serialization = {}
+
     @property
     def identifier(self):
         return hex(id(self))
@@ -103,6 +107,7 @@ class MemoryStorageBackend(object):
 
     def register_storable_function(self, table_name, result_type):
         self.data[table_name] = {}
+        self.sfr_result_types[table_name] = result_type
 
     def add_storable_function_results(self, table_name, result_dict):
         # TODO: safety checks that we don't overwrite existing

--- a/openpathsampling/experimental/simstore/regressions/README.md
+++ b/openpathsampling/experimental/simstore/regressions/README.md
@@ -1,0 +1,7 @@
+The `regressions` directory includes tests that are more complex and either:
+
+1. involve too many parts to be clear exactly which unit test module they belong to;
+2. would add too much complication to the unit tests in a module, and therefore are better kept separate.
+
+
+In general, these will be tests that were discovered by users exposing bugs. Test modules in here may only contain a single (or very few) tests, and will often be in response to a single issue.

--- a/openpathsampling/experimental/simstore/regressions/test_numpy_sfrs.py
+++ b/openpathsampling/experimental/simstore/regressions/test_numpy_sfrs.py
@@ -1,0 +1,93 @@
+# This test checks a regression related to  storing results from storable
+# functions that are of not basic types that SQLAlchemy knows. In
+# particular, functions that returns NumPy arrays were storing the results
+# without complaint, but could not re-load them as the correct type.
+import pytest
+import numpy as np
+
+from openpathsampling.experimental.simstore import (
+    StorableFunction, StorableFunctionResults, storable_function_find_uuids
+)
+from openpathsampling.experimental.simstore import SQLStorageBackend
+from openpathsampling.experimental.simstore import GeneralStorage
+from openpathsampling.experimental.simstore.class_info import (
+    SerializationSchema, ClassInfo
+)
+from openpathsampling.netcdfplus import StorableObject
+from openpathsampling.experimental.storage.ops_storage import (
+    unsafe_ops_codecs, safe_ops_codecs
+)
+from openpathsampling.experimental.simstore.serialization_helpers import (
+    default_find_uuids
+)
+
+from openpathsampling.experimental.simstore.test_utils import MockUUIDObject
+
+
+@pytest.fixture
+def minimal_sfr_serialization():
+    schema = {
+        'foo': [('normal_attr', 'int')],
+        'storable_functions': [('json', 'json_obj')],
+        'simulation_objects': [('json', 'json_obj')],
+    }
+    serialization = SerializationSchema(
+        default_info=ClassInfo(
+            table='simulation_objects',
+            cls=StorableObject,
+            serializer=unsafe_ops_codecs.simobj_serializer,
+            deserializer=unsafe_ops_codecs.simobj_deserializer,
+            safe_deserializer=safe_ops_codecs.simobj_serializer,
+            find_uuids=default_find_uuids
+        ),
+        sfr_info=ClassInfo(
+            table="function_results",
+            cls=StorableFunctionResults,
+            serializer=StorableFunctionResults.to_dict,
+            deserializer=lambda x: x,  # deserializer not used
+            find_uuids=default_find_uuids
+        ),
+        schema=schema,
+        class_info_list=[
+            ClassInfo(table='foo', cls=MockUUIDObject),
+            ClassInfo(table='storable_functions',
+                      cls=StorableFunction,
+                      find_uuids=storable_function_find_uuids,
+                      serializer=unsafe_ops_codecs.simobj_serializer,
+                      deserializer=unsafe_ops_codecs.simobj_deserializer),
+        ]
+    )
+    return schema, serialization
+
+def stupid_func(inp):
+    import numpy as np
+    return np.array([1.0, 2.0, 3.0])
+
+def test_numpy_sfrs(minimal_sfr_serialization, tmpdir):
+    schema, serialization = minimal_sfr_serialization
+    # create and save
+    backend = SQLStorageBackend(tmpdir / 'tmp.db', mode='w')
+    storage = GeneralStorage(backend, serialization, schema)
+
+    inp = MockUUIDObject('foo', 1)
+    func = StorableFunction(stupid_func).named('stupid')
+    eval_result = func(inp)
+
+    storage.save([func, inp])
+    storage.close()
+
+    # reload
+    storage._known_storages = {}
+    backend = SQLStorageBackend(tmpdir / 'tmp.db', mode='r')
+    storage = GeneralStorage(backend, serialization, schema)
+
+    sfs = list(storage.backend.table_iterator('storable_functions'))
+    func = storage.load([sfs[0].uuid])[0]
+
+    store_result = func(inp)
+
+    assert store_result is not eval_result  # not same in memory
+    assert isinstance(store_result, eval_result.__class__)
+    np.testing.assert_array_equal(store_result, eval_result)
+
+

--- a/openpathsampling/experimental/simstore/serialization.py
+++ b/openpathsampling/experimental/simstore/serialization.py
@@ -90,6 +90,9 @@ class ToDictSerializer(SchemaDeserializer):
     # TODO: I think this class can be basically remobed; need to transfer
     # inherited func and attribs to SchemaSerializer
 
+    # TODO: this seems odd here. I think this should be part of the
+    # SerializationSchema object (which knows the attribute handler
+    # factories).
     def get_handler_from_factories(self, type_name):
         for factory in self.handler_factories:
             handler = factory.from_type_string(type_name)

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -399,7 +399,6 @@ class SQLStorageBackend(StorableNamedObject):
         result_dict : Mapping[Str, Any]
             mapping from UUID to result
         """
-        # breakpoint()
         # anything in the cache doesn't need to be saved
         known_uuids = self.known_uuids[table_name]
         set_uuids = set(result_dict.keys())

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -116,6 +116,7 @@ class SQLStorageBackend(StorableNamedObject):
 
         # currently this is only used by the storable functions, but in
         # principle, it might be good for everything to move into this
+        # maps result type (str) to attribute handler to serialize that
         self.serialization = {}
 
         # override later if mode == 'r' or 'a'

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 import collections
 from collections import abc
 import sqlalchemy as sql
@@ -12,9 +13,10 @@ from .backend import extract_backend_metadata
 from .my_types import backend_registration_type
 from .serialization_helpers import import_class
 
-
 import logging
 logger = logging.getLogger(__name__)
+
+from openpathsampling.deprecations import SIMSTORE_NO_SFR_TYPES
 
 # dict to convert from OPS type descriptors to SQL types
 sql_type = {
@@ -34,7 +36,8 @@ sql_type = {
 
 universal_sql_meta = {
     'uuid': {'uuid': {'primary_key': True}},
-    'tables': {'name': {'primary_key': True}}
+    'tables': {'name': {'primary_key': True}},
+    'sfr_result_types': {'uuid': {'primary_key': True}},
 }
 
 def make_columns(table_name, schema, sql_schema_metadata, backend_types):
@@ -109,6 +112,11 @@ class SQLStorageBackend(StorableNamedObject):
         # 'ndarray.float32(1651,3)': 'ndarray'
         # keys here are in the schema, values are (sql_type, size)
         self.known_types = {k: (k, None) for k in sql_type}
+        self.sfr_result_types = {}
+
+        # currently this is only used by the storable functions, but in
+        # principle, it might be good for everything to move into this
+        self.serialization = {}
 
         # override later if mode == 'r' or 'a'
         self.schema = {}
@@ -201,6 +209,21 @@ class SQLStorageBackend(StorableNamedObject):
             self.schema = self.database_schema()
             self.table_to_number, self.number_to_table = \
                     self.internal_tables_from_db()
+
+            self.sfr_result_types.update(self._load_sfr_types())
+
+    def _load_sfr_types(self):
+        try:
+            table = self.metadata.tables['sfr_result_types']
+        except KeyError:
+            SIMSTORE_NO_SFR_TYPES.warn()
+            sfr_types = {}
+        else:
+            with self.engine.connect() as conn:
+                sfr_type_entries = list(conn.execute(table.select()))
+            sfr_types = {e.uuid: e.result_type for e in sfr_type_entries}
+
+        return sfr_types
 
     @classmethod
     def from_engine(cls, engine, connection_uri=None, **kwargs):
@@ -360,7 +383,11 @@ class SQLStorageBackend(StorableNamedObject):
                             "may already have tables of the same names.")
 
         self.metadata.create_all(self.engine)
-        # TODO : do we need to do anything else for this?
+        sfr_result_types = self.metadata.tables['sfr_result_types']
+        with self.engine.connect() as conn:
+            conn.execute(sfr_result_types.insert(),
+                         {'uuid': table_name, 'result_type': result_type})
+        self.sfr_result_types[table_name] = result_type
 
     def add_storable_function_results(self, table_name, result_dict):
         """
@@ -371,6 +398,7 @@ class SQLStorageBackend(StorableNamedObject):
         result_dict : Mapping[Str, Any]
             mapping from UUID to result
         """
+        # breakpoint()
         # anything in the cache doesn't need to be saved
         known_uuids = self.known_uuids[table_name]
         set_uuids = set(result_dict.keys())
@@ -385,7 +413,9 @@ class SQLStorageBackend(StorableNamedObject):
         unknown_uuids -= set(found_results.keys())
 
         # only store the results that haven't been stored
-        results = [{'uuid': uuid, 'value': result_dict[uuid]}
+        result_type = self.sfr_result_types[table_name]
+        serialize = self.serialization[result_type].serialize
+        results = [{'uuid': uuid, 'value': serialize(result_dict[uuid])}
                    for uuid in unknown_uuids]
         table = self.metadata.tables[table_name]
         if results:
@@ -412,6 +442,8 @@ class SQLStorageBackend(StorableNamedObject):
         """
         table = self.metadata.tables[table_name]
         results = []
+        result_type = self.sfr_result_types[table_name]
+        deserialize = self.serialization[result_type].deserialize
         for uuid_block in tools.block(uuids, self.MAX_SQL_ITEMS):
             # uuid_sel = table.select(
                 # sql.exists().where(table.c.uuid.in_(uuid_block))
@@ -423,7 +455,7 @@ class SQLStorageBackend(StorableNamedObject):
             results += res
 
         logger.debug("Found {} UUIDs".format(len(results)))
-        result_dict = {uuid: value for uuid, value in results}
+        result_dict = {uuid: deserialize(value) for uuid, value in results}
         return result_dict
 
     def load_storable_function_table(self, table_name):

--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -563,8 +563,9 @@ class StorageFunctionHandler(object):
             self.canonical_functions[func_uuid] = func
 
         # get the type from storage
-        if has_table:
-            result_type = self.storage.backend.sfr_result_types[func_uuid]
+        result_type = self.storage.backend.sfr_result_types.get(func_uuid,
+                                                                None)
+        if result_type is not None:
             serializer = self.storage.class_info.handler_for(result_type)
             if serializer is None:
                 raise RuntimeError("Unable to serialize objects of type '"

--- a/openpathsampling/experimental/simstore/storage.py
+++ b/openpathsampling/experimental/simstore/storage.py
@@ -43,7 +43,8 @@ universal_schema = {
     'uuid': [('uuid', 'uuid'), ('table', 'int'), ('row', 'int')],
     'tables': [('name', 'str'), ('idx', 'int'), ('module', 'str'),
                ('class_name', 'str')],
-    'tags': [('name', 'str'), ('content', 'uuid')]
+    'sfr_result_types': [('uuid', 'str'), ('result_type', 'str')],
+    'tags': [('name', 'str'), ('content', 'uuid')],
 }
 
 

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -17,7 +17,7 @@ class TestSQLStorageBackend(object):
                                'snapshot0': tuple,
                                'snapshot1': tuple}
         self.default_table_names = {'uuid', 'tables', 'schema', 'metadata',
-                                    'tags'}
+                                    'tags', 'sfr_result_types'}
 
     def _sample_data_dict(self):
         sample_list = [(0, 'ens1', 'traj1'),

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -345,6 +345,34 @@ class TestStorableFunction(object):
 
         assert func(['uuid', 'other']) == [found_in_1, found_in_2]
 
+    @pytest.mark.parametrize('error_if_missing', [True, False])
+    def test_validate_missing(self, error_if_missing):
+        get_expected = lambda x: 'result'
+        func = StorableFunction(get_expected)
+        self._set_storage(func, 'analysis', 'eval',
+                          {'input': 'result'})
+        pytest_context = {
+            True: pytest.raises(Exception),  # KeyError is test-specific
+            False: pytest.warns(UserWarning)
+        }[error_if_missing]
+        with pytest_context:
+            func.validate(['input'], error_if_missing)
+
+    @pytest.mark.parametrize('is_valid', [True, False])
+    def test_validate(self, is_valid):
+        get_expected = lambda x: 'result'
+        func = StorableFunction(get_expected)
+        stored_value = 'result' if is_valid else 'foo'
+        self._set_storage(func, 'analysis', 'storage',
+                          {'input': stored_value})
+        try:
+            func.validate('input')
+        except StorableFunctionResultError:
+            if is_valid:
+                raise
+            # else pass
+
+
     def test_to_dict_from_dict_cycle(self):
         pytest.skip()
         pass

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -21,6 +21,8 @@ class MockBackend(object):
         self.storable_function_tables = defaultdict(dict)
         self.called_register = defaultdict(int)
         self.called_load = defaultdict(int)
+        self.sfr_result_types = {}
+        self.serialization = {}
 
     def has_table(self, table_name):
         return table_name in self.storable_function_tables
@@ -28,6 +30,7 @@ class MockBackend(object):
     def register_storable_function(self, table_name, result_type):
         self.storable_function_tables[table_name] = {}
         self.called_register[table_name] += 1
+        self.sfr_result_types[table_name] = result_type
 
     def load_storable_function_results(self, func_uuid, uuids):
         table = self.storable_function_tables[func_uuid]
@@ -383,6 +386,7 @@ class TestStorageFunctionHandler(object):
         uuid = get_uuid(self.func)
         if has_table:
             self.storage.backend.storable_function_tables[uuid] = {}
+            self.storage.backend.sfr_result_types[uuid] = 'float'
 
         example = 1.0 if with_result else None
         unable_to_register = example is None and not has_table


### PR DESCRIPTION
There was a bug when storing results from SimStore CVs that were not types known to SQL (mainly, if the result of a CV was a NumPy array). Essentially, the result type of CVs were not being stored to the file.

This PR fixes it. This does make some changes to the interface for backends (they must define `serialization` and `sfr_result_types` dictionaries, and the entry in `sfr_result_types` for a given storable function must be set during the `register_storable_function` method). It's unlikely that anyone is writing custom backends, but this would affect such users.

---

For any users affected by this bug: Your data is still intact, you just need to tell SimStore how to load it. I've saved a [notebook to a gist](https://gist.github.com/dwhswenson/88d672a7258e646de192dd4af5810869) ([alternate render for current version](https://nbviewer.jupyter.org/urls/gist.githubusercontent.com/dwhswenson/88d672a7258e646de192dd4af5810869/raw/7d4ccc61565154c8479f614278f46a04b401d30c/simstore_numpy_fix.ipynb)) with details on how to do that.