### PR TITLE
[WIP] OpenMMToolsMCEngine

### DIFF
--- a/examples/misc/mc_engine.ipynb
+++ b/examples/misc/mc_engine.ipynb
@@ -1,0 +1,353 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1ede3493",
+   "metadata": {},
+   "source": [
+    "# The OpenMMTools Monte Carlo Engine\n",
+    "\n",
+    "While it is very common to use molecular dynamics to generate the paths used in path sampling, a path can be any ordered sequence of snapshots. For example, one could generate a sequence of Markov Chain Monte Carlo steps connecting two states, and do path sampling on that.\n",
+    "\n",
+    "For those interested in doing this (within the domain of force-field based simulation), the OpenMMTools project has a subpackage for Markov Chain Monte Carlo, and OpenPathSampling has an engine that uses that subpackage.\n",
+    "\n",
+    "As usual, you set up the engine just as you would for a normal simulation with it. Then we wrap things from the underlying tool in the OPS engine wrapper."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7f7e696",
+   "metadata": {},
+   "source": [
+    "## Creating an MCMC sampler with OpenMMTools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83c6a60e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from simtk import unit\n",
+    "import openmmtools\n",
+    "from openmmtools import testsystems, cache, mcmc\n",
+    "from openmmtools.states import ThermodynamicState, SamplerState"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3fd3cd16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testsystem = testsystems.AlanineDipeptideVacuum()\n",
+    "thermodynamic_state = ThermodynamicState(system=testsystem.system, \n",
+    "                                         temperature=298*unit.kelvin)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd413a09",
+   "metadata": {},
+   "source": [
+    "In the OpenMMTools MCMC package, each move applies to all the atoms in its `atom_subset`. So to create a move that randomly selects a single atom and randomly displaces that atom, you need to create a displacement move for each atom, then join them in a `WeightedMove`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1ea14e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "moves = [\n",
+    "    mcmc.MCDisplacementMove(displacement_sigma=0.05*unit.angstrom,\n",
+    "                            atom_subset=[i])\n",
+    "    for i in range(testsystem.mdtraj_topology.n_atoms)\n",
+    "]\n",
+    "move = mcmc.WeightedMove([(m, 1/len(moves)) for m in moves])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2baf56b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use OpenMMTools to get good initial conditions\n",
+    "sampler_state = SamplerState(positions=testsystem.positions)\n",
+    "sampler = mcmc.MCMCSampler(thermodynamic_state, sampler_state, move)\n",
+    "sampler.minimize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac95925b",
+   "metadata": {},
+   "source": [
+    "## Setting up path sampling with OpenPathSampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffb97ab8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openpathsampling as paths\n",
+    "from openpathsampling.engines.openmm.mcengine import OpenMMToolsMCEngine, snapshot_from_sampler_state\n",
+    "\n",
+    "# we'll use the new storage, because it is faster\n",
+    "from openpathsampling.experimental.storage import monkey_patch_all, Storage\n",
+    "from openpathsampling.experimental.storage.collective_variables import MDTrajFunctionCV\n",
+    "paths = monkey_patch_all(paths)\n",
+    "\n",
+    "import mdtraj as md\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "403871a9",
+   "metadata": {},
+   "source": [
+    "### Creating the OPS engine\n",
+    "\n",
+    "The next two cells are the only ones specific to integrating this new engine type with OPS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab50fe7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdtraj_topology = testsystem.mdtraj_topology\n",
+    "ops_topology = paths.engines.MDTrajTopology(mdtraj_topology)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "683a7c36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = OpenMMToolsMCEngine(thermodynamic_state, move,\n",
+    "                             {'n_steps_per_frame': 10,\n",
+    "                              'n_frames_max': 1000},\n",
+    "                             topology=mdtraj_topology)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10bda885",
+   "metadata": {},
+   "source": [
+    "### Defining CVs and stable states"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de025fc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# just to verify that we have the right atoms\n",
+    "[mdtraj_topology.atom(i) for i in [4, 6, 8, 14, 16]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6dc7342",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# CVs\n",
+    "phi = MDTrajFunctionCV(md.compute_dihedrals, topology=ops_topology, \n",
+    "                       period_min=-np.pi, period_max=np.pi,\n",
+    "                       indices=[[4, 6, 8, 14]]).named(\"phi\")\n",
+    "psi = MDTrajFunctionCV(md.compute_dihedrals, topology=ops_topology, \n",
+    "                       period_min=-np.pi, period_max=np.pi,\n",
+    "                       indices=[[6, 8, 14, 16]]).named(\"psi\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8f499c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: check these values for Amber ff96\n",
+    "# estimates based on eyeballing https://doi.org/10.1098/rspa.2019.0036\n",
+    "# Mediocre state defs won't mess up the sampling, but aren't as helpful in teaching\n",
+    "C7eq = (\n",
+    "    paths.PeriodicCVDefinedVolume(phi, lambda_min=-np.pi, lambda_max=-0.8,\n",
+    "                                  period_min=-np.pi, period_max=np.pi)\n",
+    "    & paths.PeriodicCVDefinedVolume(psi, lambda_min=0.5, lambda_max=3.5,\n",
+    "                                    period_min=-np.pi, period_max=np.pi)\n",
+    ").named(\"C7eq\")\n",
+    "C7ax = (\n",
+    "    paths.PeriodicCVDefinedVolume(phi, lambda_min=0.5, lambda_max=1.5,\n",
+    "                                  period_min=-np.pi, period_max=np.pi)\n",
+    "    & paths.PeriodicCVDefinedVolume(psi, lambda_min=-2.0, lambda_max=-0.5,\n",
+    "                                    period_min=-np.pi, period_max=np.pi)\n",
+    ").named(\"C7ax\")\n",
+    "# period information in CVDefinedVolumes won't be required in OPS 2.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a404464",
+   "metadata": {},
+   "source": [
+    "### Creating sampling network and move scheme\n",
+    "\n",
+    "For TPS, these are very easy. They get more complicated for TIS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6db89880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "network = paths.TPSNetwork(C7eq, C7ax).named(\"tps-network\")\n",
+    "scheme = paths.OneWayShootingMoveScheme(network, engine=engine).named('one-way TPS')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d856514",
+   "metadata": {},
+   "source": [
+    "### Getting an initial transition trajectory\n",
+    "\n",
+    "This is always one of the hardest parts of setting up a TPS simulation. In this example we will use a high temperature version of the engine to generate a transition from a long trajectory. This is not always the best way to generate an initial trajectory, but it works well enough for simple systems like this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e239dab5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use the same move, different thermodynamic state, and allow more steps\n",
+    "hi_temp = engine = OpenMMToolsMCEngine(\n",
+    "    thermodynamic_state=ThermodynamicState(system=testsystem.system, \n",
+    "                                           temperature=700*unit.kelvin),\n",
+    "    move=move,\n",
+    "#    options={'n_steps_per_frame': 10, 'n_frames_max': 10000},\n",
+    "    options={'n_steps_per_frame': 10, 'n_frames_max': 1000},\n",
+    "    topology=mdtraj_topology\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac7b19c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make a snapshot from the minimized sampler state\n",
+    "snapshot = snapshot_from_sampler_state(sampler.sampler_state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d92d442",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visit_all = paths.VisitAllStatesEnsemble([C7ax, C7eq])\n",
+    "traj = hi_temp.generate(snapshot, visit_all.can_append)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fe8dcb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# extract only the transition using scheme.initial_conditions_from_trajectories\n",
+    "init_conds = scheme.initial_conditions_from_trajectories(traj)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f0dca9a",
+   "metadata": {},
+   "source": [
+    "### Putting together the path sampling simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1be8dec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storage = Storage(\"mc_tps.db\", mode='w')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae09c265",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tps = paths.PathSamplingling(\n",
+    "    storage=storage,\n",
+    "    movescheme=scheme,\n",
+    "    initial_conditions=init_conds\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a04a0fb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tps.run(100)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/misc/mc_engine.ipynb
+++ b/examples/misc/mc_engine.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "moves = [\n",
-    "    mcmc.MCDisplacementMove(displacement_sigma=0.05*unit.angstrom,\n",
+    "    mcmc.MCDisplacementMove(displacement_sigma=0.1*unit.angstrom,\n",
     "                            atom_subset=[i])\n",
     "    for i in range(testsystem.mdtraj_topology.n_atoms)\n",
     "]\n",
@@ -139,7 +139,7 @@
    "outputs": [],
    "source": [
     "engine = OpenMMToolsMCEngine(thermodynamic_state, move,\n",
-    "                             {'n_steps_per_frame': 10,\n",
+    "                             {'n_steps_per_frame': 100,\n",
     "                              'n_frames_max': 1000},\n",
     "                             topology=ops_topology).named(\"engine\")"
    ]
@@ -232,25 +232,26 @@
    "source": [
     "### Getting an initial transition trajectory\n",
     "\n",
-    "This is always one of the hardest parts of setting up a TPS simulation. In this example we will use a high temperature version of the engine to generate a transition from a long trajectory. This is not always the best way to generate an initial trajectory, but it works well enough for simple systems like this."
+    "This is always one of the hardest parts of setting up a TPS simulation. As it happens, alanine dipeptide is a relatively ballistic system (velocity memory can matter) so it can be easier to generate a high temperature trajectory with molecular dynamics than with Monte Carlo. Therefore, we'll use MD to create our initial trajectory."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "772bdb6d",
+   "id": "733f1c19",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# use the same move, different thermodynamic state, and allow more steps\n",
-    "hi_temp = engine = OpenMMToolsMCEngine(\n",
-    "    thermodynamic_state=ThermodynamicState(system=testsystem.system, \n",
-    "                                           temperature=700*unit.kelvin),\n",
-    "    move=move,\n",
-    "#    options={'n_steps_per_frame': 10, 'n_frames_max': 10000},\n",
-    "    options={'n_steps_per_frame': 10, 'n_frames_max': 100},\n",
-    "    topology=ops_topology\n",
-    ").named('hi temp')"
+    "from openmmtools import integrators\n",
+    "hi_temp = paths.engines.openmm.Engine(\n",
+    "    topology=ops_topology,\n",
+    "    system=testsystem.system,\n",
+    "    integrator=integrators.VVVRIntegrator(temperature=750*unit.kelvin,\n",
+    "                                          collision_rate=1.0 / unit.picosecond,\n",
+    "                                          timestep=2.0 * unit.femtosecond),\n",
+    "    options={'n_steps_per_frame': 10,\n",
+    "             'n_frames_max': 20000}\n",
+    ")"
    ]
   },
   {
@@ -272,7 +273,11 @@
    "outputs": [],
    "source": [
     "visit_all = paths.VisitAllStatesEnsemble([C7ax, C7eq])\n",
-    "traj = hi_temp.generate(snapshot, visit_all.can_append)"
+    "try:\n",
+    "    traj = hi_temp.generate(snapshot, visit_all.can_append)\n",
+    "except paths.engines.EngineError as e:\n",
+    "    traj = e.last_trajectory  # for debugging\n",
+    "    raise"
    ]
   },
   {
@@ -284,6 +289,39 @@
    "source": [
     "# extract only the transition using scheme.initial_conditions_from_trajectories\n",
     "init_conds = scheme.initial_conditions_from_trajectories(traj)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a04d9362",
+   "metadata": {},
+   "source": [
+    "### Equilibrating our initial trajectory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77620694",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "equil = paths.PathSampling(\n",
+    "    storage=Storage(\"mc_equil.db\", mode='w'),\n",
+    "    move_scheme=scheme,\n",
+    "    sample_set=init_conds\n",
+    ")\n",
+    "equil.run_until_decorrelated()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c11fe847",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decorrelated = equil.sample_set"
    ]
   },
   {
@@ -313,8 +351,8 @@
    "source": [
     "tps = paths.PathSamplingling(\n",
     "    storage=storage,\n",
-    "    movescheme=scheme,\n",
-    "    initial_conditions=init_conds\n",
+    "    move_scheme=scheme,\n",
+    "    sample_set=init_conds\n",
     ")"
    ]
   },

--- a/examples/misc/mc_engine.ipynb
+++ b/examples/misc/mc_engine.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1ede3493",
+   "id": "c76eb74e",
    "metadata": {},
    "source": [
     "# The OpenMMTools Monte Carlo Engine\n",
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7f7e696",
+   "id": "62c50bb4",
    "metadata": {},
    "source": [
     "## Creating an MCMC sampler with OpenMMTools"
@@ -25,7 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83c6a60e",
+   "id": "b6d7dffa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fd3cd16",
+   "id": "9f0699b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd413a09",
+   "id": "e8f074e5",
    "metadata": {},
    "source": [
     "In the OpenMMTools MCMC package, each move applies to all the atoms in its `atom_subset`. So to create a move that randomly selects a single atom and randomly displaces that atom, you need to create a displacement move for each atom, then join them in a `WeightedMove`."
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1ea14e2",
+   "id": "b60d6bf6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2baf56b5",
+   "id": "47a8f25e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac95925b",
+   "id": "dd042be6",
    "metadata": {},
    "source": [
     "## Setting up path sampling with OpenPathSampling"
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffb97ab8",
+   "id": "0abcc7f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "403871a9",
+   "id": "c45c0174",
    "metadata": {},
    "source": [
     "### Creating the OPS engine\n",
@@ -123,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ab50fe7",
+   "id": "ef14d359",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,19 +134,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "683a7c36",
+   "id": "e11efce1",
    "metadata": {},
    "outputs": [],
    "source": [
     "engine = OpenMMToolsMCEngine(thermodynamic_state, move,\n",
     "                             {'n_steps_per_frame': 10,\n",
     "                              'n_frames_max': 1000},\n",
-    "                             topology=mdtraj_topology)"
+    "                             topology=ops_topology).named(\"engine\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "10bda885",
+   "id": "3f8ddfbf",
    "metadata": {},
    "source": [
     "### Defining CVs and stable states"
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de025fc1",
+   "id": "b58d192b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6dc7342",
+   "id": "2177932f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8f499c8",
+   "id": "ad6a0505",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a404464",
+   "id": "2dcd56fc",
    "metadata": {},
    "source": [
     "### Creating sampling network and move scheme\n",
@@ -217,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6db89880",
+   "id": "3c90d80b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d856514",
+   "id": "2c400df7",
    "metadata": {},
    "source": [
     "### Getting an initial transition trajectory\n",
@@ -238,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e239dab5",
+   "id": "772bdb6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,15 +248,15 @@
     "                                           temperature=700*unit.kelvin),\n",
     "    move=move,\n",
     "#    options={'n_steps_per_frame': 10, 'n_frames_max': 10000},\n",
-    "    options={'n_steps_per_frame': 10, 'n_frames_max': 1000},\n",
-    "    topology=mdtraj_topology\n",
-    ")"
+    "    options={'n_steps_per_frame': 10, 'n_frames_max': 100},\n",
+    "    topology=ops_topology\n",
+    ").named('hi temp')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac7b19c3",
+   "id": "22539c36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d92d442",
+   "id": "3a792e37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fe8dcb2",
+   "id": "f6e813ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f0dca9a",
+   "id": "e5893361",
    "metadata": {},
    "source": [
     "### Putting together the path sampling simulation"
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1be8dec",
+   "id": "de4f95b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae09c265",
+   "id": "0d3647d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a04a0fb8",
+   "id": "2b05c53d",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/openpathsampling/engines/openmm/mcengine.py
+++ b/openpathsampling/engines/openmm/mcengine.py
@@ -108,8 +108,13 @@ class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
 
 
     def _get_n_accepted(self):
-        return sum(dct['n_accepted']
-                   for dct in self._sampler.move.statistics)
+        statistics = self._sampler.move.statistics
+        if isinstance(statistics, dict):
+            # single move
+            return statistics['n_accepted']
+        else:
+            # sequence or weighted move
+            return sum(dct['n_accepted'] for dct in statistics)
 
 
     def generate_next_frame(self):

--- a/openpathsampling/engines/openmm/mcengine.py
+++ b/openpathsampling/engines/openmm/mcengine.py
@@ -1,9 +1,11 @@
 import openpathsampling as paths
 from openpathsampling.engines.openmm import Snapshot
+import copy
 
 try:
     from openmmtools import mcmc
     from openmmtools import states
+    import openmmtools
 except ImportError:
     HAS_OPENMMTOOLS=False
 else:
@@ -16,17 +18,51 @@ INITIALIZATION_ERROR = EngineNotInitializedError("Set current_snapshot "
                                                  "before using engine.")
 
 def snapshot_from_sampler_state(sampler_state, engine=None):
+    """Generate an OPS SnapShot from a OpenMMTools SamplerState
+
+    Parameters
+    ----------
+    sampler_state: openmmtools.states.SamplerState
+        The ``SamplerState`` containing the positions, velocities, and box
+        vectors to define the snapshot.
+    engine: :class:`.DynamicsEngine`, optional
+        The engine to associate with this snapshot; default is ``None``,
+        which will make some functionality (e.g, MDTraj integration)
+        impossible.
+    """
     return Snapshot.construct(
-        coordinates=sampler_state.positions.copy(),
-        velocities=sampler_state.velocities.copy(),
-        box_vectors=sampler_state.box_vectors.copy(),
+        coordinates=copy.copy(sampler_state.positions),
+        velocities=copy.copy(sampler_state.velocities),
+        box_vectors=copy.copy(sampler_state.box_vectors),
         engine=engine
     )
 
 class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
-    """Engine for the MCMC utilities in OpenMMTools
+    """Engine for the OpenMMTools MCMC package.
+
+    This takes user-provided ``thermodynamics_state`` and ``move``, and will
+    internally create a ``openmmtools.mcmc.MCMCSampler``, which will be used
+    to generate "trajectories."
+
+    Parameters
+    ----------
+    thermodynamic_state : openmmtools.states.thermodynamic_state
+        the thermodynamic state to sample
+    move : openmmtools.mcmc.MCMCMove
+        the Monte Carlo move to use to propagate the system
+    options : Dict
+        Dictionary with additional options. Allowed options are:
+
+            'n_steps_per_frame': int, default: 10
+                the number of individual steps per snapshot
+            'n_frames_max': int, default: 5000
+                maximum number of frames before a trajectory aborts
+
+    topology : :class:`.Topology`, optional
+        Topology information for this sysetm. If an :class:`.MDTrajTopology`
+        is provided, this will enable MDTraj integration.
     """
-    def __init__(self, thermodynamic_state, move, options):
+    def __init__(self, thermodynamic_state, move, options, topology=None):
         # we assume that we have standard n_atoms * 3 dimensions
         descriptor = paths.engines.SnapshotDescriptor.construct(
             Snapshot,
@@ -37,6 +73,7 @@ class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
         self.thermodynamic_state = thermodynamic_state
         self.move = move
         self.options = options
+        self.topology = topology
         # _sampler is the OpenMMTools MCMCSampler
         self._sampler = None
         self._current_snapshot = None
@@ -92,4 +129,26 @@ class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
 
         return self.current_snapshot
 
+    def to_dict(self):
+        serialize = openmmtools.utils.serialize
+        return {
+            'thermodynamic_state': serialize(self.thermodynamic_state),
+            'move': serialize(self.move),
+            'options': self.options,
+            'topology': self.topology,
+        }
+
+    @classmethod
+    def from_dict(cls, dct):
+        deserialize = openmmtools.utils.deserialize
+        dct['thermodynamic_state'] = deserialize(dct['thermodynamic_state'])
+        dct['move'] = deserialize(dct['move'])
+        return cls(**dct)
+
+    @property
+    def mdtraj_topology(self):
+        if self.topology is None:
+            raise RuntimeError("Can not convert to MDTraj: no topology "
+                               "associated with this engine.")
+        return self.topology.mdtraj
 

--- a/openpathsampling/engines/openmm/mcengine.py
+++ b/openpathsampling/engines/openmm/mcengine.py
@@ -119,7 +119,7 @@ class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
         # We only construct a new snapshot if a trial move has been
         # accepted. This way identical snapshots have the same UUID.
         n_acc_before = self._get_n_accepted()
-        self._sampler.run(1)
+        self._sampler.run(self.options['n_steps_per_frame'])
         n_acc_after = self._get_n_accepted()
         if n_acc_before != n_acc_after:
             self.current_snapshot = snapshot_from_sampler_state(

--- a/openpathsampling/engines/openmm/mcengine.py
+++ b/openpathsampling/engines/openmm/mcengine.py
@@ -62,6 +62,15 @@ class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
         Topology information for this sysetm. If an :class:`.MDTrajTopology`
         is provided, this will enable MDTraj integration.
     """
+
+    base_snapshot_type = Snapshot
+
+    # taken from OpenMM engine; this should change
+    _default_options = {
+        'n_steps_per_frame': 10,
+        'n_frames_max': 5000,
+    }
+
     def __init__(self, thermodynamic_state, move, options, topology=None):
         # we assume that we have standard n_atoms * 3 dimensions
         descriptor = paths.engines.SnapshotDescriptor.construct(

--- a/openpathsampling/engines/openmm/mcengine.py
+++ b/openpathsampling/engines/openmm/mcengine.py
@@ -1,0 +1,95 @@
+import openpathsampling as paths
+from openpathsampling.engines.openmm import Snapshot
+
+try:
+    from openmmtools import mcmc
+    from openmmtools import states
+except ImportError:
+    HAS_OPENMMTOOLS=False
+else:
+    HAS_OPENMMTOOLS=True
+
+class EngineNotInitializedError(Exception):
+    pass
+
+INITIALIZATION_ERROR = EngineNotInitializedError("Set current_snapshot "
+                                                 "before using engine.")
+
+def snapshot_from_sampler_state(sampler_state, engine=None):
+    return Snapshot.construct(
+        coordinates=sampler_state.positions.copy(),
+        velocities=sampler_state.velocities.copy(),
+        box_vectors=sampler_state.box_vectors.copy(),
+        engine=engine
+    )
+
+class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
+    """Engine for the MCMC utilities in OpenMMTools
+    """
+    def __init__(self, thermodynamic_state, move, options):
+        # we assume that we have standard n_atoms * 3 dimensions
+        descriptor = paths.engines.SnapshotDescriptor.construct(
+            Snapshot,
+            {'n_atoms': thermodynamic_state.system.getNumParticles(),
+             'n_spatial': 3}
+        )
+        super(OpenMMToolsMCEngine, self).__init__(options, descriptor)
+        self.thermodynamic_state = thermodynamic_state
+        self.move = move
+        self.options = options
+        # _sampler is the OpenMMTools MCMCSampler
+        self._sampler = None
+        self._current_snapshot = None
+
+    @property
+    def current_snapshot(self):
+        if self._current_snapshot is None:
+            raise INITIALIZATION_ERROR
+
+        return self._current_snapshot
+
+    @current_snapshot.setter
+    def current_snapshot(self, snapshot):
+        # early exit if we're setting with the existing snapshot
+        if snapshot == self._current_snapshot:
+            return
+
+        sampler_state = states.SamplerState(
+            positions=snapshot.coordinates,
+            velocities=snapshot.velocities,
+            box_vectors=snapshot.box_vectors
+        )
+        if self._sampler is None:
+            self._sampler = mcmc.MCMCSampler(
+                thermodynamic_state=self.thermodynamic_state,
+                sampler_state=sampler_state,
+                move=self.move
+            )
+        else:
+            self._sampler.sampler_state = sampler_state
+        self._current_snapshot = snapshot
+
+
+    def _get_n_accepted(self):
+        return sum(dct['n_accepted']
+                   for dct in self._sampler.move.statistics)
+
+
+    def generate_next_frame(self):
+        if self._sampler is None:
+            raise INITIALIZATION_ERROR
+
+        # We only construct a new snapshot if a trial move has been
+        # accepted. This way identical snapshots have the same UUID.
+        n_acc_before = self._get_n_accepted()
+        self._sampler.run(1)
+        n_acc_after = self._get_n_accepted()
+        if n_acc_before != n_acc_after:
+            self.current_snapshot = snapshot_from_sampler_state(
+                self._sampler.sampler_state,
+                engine=self
+            )
+
+        return self.current_snapshot
+
+

--- a/openpathsampling/engines/openmm/mcengine.py
+++ b/openpathsampling/engines/openmm/mcengine.py
@@ -140,7 +140,10 @@ class OpenMMToolsMCEngine(paths.engines.DynamicsEngine):
 
     @classmethod
     def from_dict(cls, dct):
-        deserialize = openmmtools.utils.deserialize
+        # deserialize = openmmtools.utils.deserialize
+        def deserialize(entry):
+            entry = copy.copy(entry)
+            return openmmtools.utils.deserialize(entry)
         dct['thermodynamic_state'] = deserialize(dct['thermodynamic_state'])
         dct['move'] = deserialize(dct['move'])
         return cls(**dct)

--- a/openpathsampling/tests/test_openmm_mcengine.py
+++ b/openpathsampling/tests/test_openmm_mcengine.py
@@ -136,6 +136,14 @@ class TestOpenMMToolsMCEngine(object):
         with pytest.raises(EngineNotInitializedError):
             mcengine.generate_next_frame()
 
+    def test_generate_integration(self, mcengine, snapshot):
+        # check that integration with the generate method: we should be able
+        # to create a candidate trajectory for the ensemble
+        ensemble = paths.LengthEnsemble(5)
+        traj = mcengine.generate(snapshot, ensemble.can_append)
+        assert isinstance(traj, paths.Trajectory)
+        assert ensemble(traj)
+
     def test_serialization_cycle(self, mcengine):
         # if we serialize then deserialize, the to_dict of the deserialized
         # object should be the same as the to_dict of the original

--- a/openpathsampling/tests/test_openmm_mcengine.py
+++ b/openpathsampling/tests/test_openmm_mcengine.py
@@ -1,0 +1,111 @@
+import pytest
+import openpathsampling as paths
+
+from openpathsampling.engines.openmm.mcengine import *
+
+### FIXTURES FOR TEST SETUP ################################################
+
+# TODO: move this fixture to a global conftest.py -- this should be reused
+@pytest.fixture(scope='session')
+def ad_vacuum_testsystem():
+    testsystems = pytest.importorskip('openmmtools.testsystems')
+    return testsystems.AlanineDipeptideVacuum()
+
+@pytest.fixture(scope='session')
+def thermodynamic_state(ad_vacuum_testsystem):
+    states = pytest.importorskip('openmmtools.states')
+    unit = pytest.importorskip('simtk.unit')
+    return states.ThermodynamicState(
+        system=ad_vacuum_testsystem.system,
+        temperature=298.0 * unit.kelvin
+    )
+
+@pytest.fixture(scope='session')
+def sampler_state(ad_vacuum_testsystem):
+    states = pytest.importorskip('openmmtools.states')
+    return states.SamplerState(positions=ad_vacuum_testsystem.positions)
+
+@pytest.fixture(scope='session')
+def minimized(sampler_state, thermodynamic_state):
+    mcmc = pytest.importorskip('openmmtools.mcmc')
+    move = mcmc.MCDisplacementMove()
+    sampler = mcmc.MCMCSampler(thermodynamic_state, sampler_state, move)
+    sampler.minimize()
+    return sampler.sampler_state
+
+@pytest.fixture
+def mcengine(thermodynamic_state, minimized):
+    mcmc = pytest.importorskip('openmmtools.mcmc')
+    move = mcmc.MCDisplacementMove()
+    mcengine = OpenMMToolsMCEngine(
+        thermodynamic_state,
+        move,
+        options={'n_steps_per_frame': 1,
+                 'n_frames_max': 1000}
+    ).named('mcengine')
+    return mcengine
+
+
+### TESTS FOR OPENMMTOOLS MC ENGINE ########################################
+
+def test_snapshot_from_sampler_state(sampler_state):
+    # the snapshot generated from snapshot_from_sampler_state should have
+    # attributes that correspond to those of the sampler_state
+    snapshot = snapshot_from_sampler_state(sampler_state, engine='foo')
+    assert snapshot.velocities is None is sampler_state.velocities
+    assert snapshot.coordinates is not sampler_state.positions
+    assert (snapshot.coordinates == sampler_state.positions).all()
+
+
+class TestOpenMMToolsMCEngine(object):
+    def test_current_snapshot(self, mcengine, sampler_state):
+        # when we set then get the current snapshot, we should get the same
+        # object (identical in memory) back
+        snap = snapshot_from_sampler_state(sampler_state)
+        mcengine.current_snapshot = snap
+        reloaded = mcengine.current_snapshot
+        assert snap is reloaded
+        # assert snap.coordinates is reloaded.coordinates
+        # assert snap.box_vectors is reloaded.box_vectors
+
+    def test_current_snapshot_set_same(self, mcengine, sampler_state):
+        # if we try to set the current snapshot the same snapshot we had
+        # before, the snapshot remains the same object in memory
+        pass
+
+    def test_current_snapshot_uninitialized_error(self, mcengine,
+                                                  sampler_state):
+        # if we try to get the current snapshot before the engine has been
+        # initialized (by setting the snapshot), we should raise an error
+        pass
+
+    def test_generate_next_frame(self, mcengine, minimized):
+        # generate_next_frame should create a valid snapshot
+        pytest.skip()
+
+    def test_serialization_cycle(self, mcengine):
+        # if we serialize then deserialize, the to_dict of the deserialized
+        # object should be the same as the to_dict of the original
+        pass
+
+    def test_mdtraj_topology_error(self, mcengine):
+        # if no MDTraj topology can be found, raise an error
+        pass
+
+    def test_trajectory_to_mdtraj(self, ):
+        # if an MDTraj topology is associated with the engine, we
+        # should be able to convert trajectories from this engine into
+        # MDTraj trajectories
+        pass
+
+    def test_get_n_accepted(self):
+        # (not API) ensure that we get the correct number of accepted steps
+        # from a mover
+        pytest.skip()
+
+    def test_generate_next_frame_accepted_move(self):
+        pass
+
+    def test_generate_next_frame_rejected_move(self):
+        pass
+

--- a/openpathsampling/tests/test_openmm_mcengine.py
+++ b/openpathsampling/tests/test_openmm_mcengine.py
@@ -57,18 +57,19 @@ def mcengine(thermodynamic_state, minimized):
 
 ### HELPER CLASSES FOR MOCKING #############################################
 
-class AlwaysMove(mcmc.MetropolizedMove):
-    def __init__(self, accept):
-        super(AlwaysMove, self).__init__()
-        self.accept = {'accept': 1, True: 1,
-                       'reject': 0, False: 0}[accept]
+if HAS_OPENMMTOOLS:
+    class AlwaysMove(mcmc.MetropolizedMove):
+        def __init__(self, accept):
+            super(AlwaysMove, self).__init__()
+            self.accept = {'accept': 1, True: 1,
+                           'reject': 0, False: 0}[accept]
 
-    def apply(self, thermodynamic_state, sampler_state):
-        self.n_accepted += self.accept
-        self.n_proposed += 1
+        def apply(self, thermodynamic_state, sampler_state):
+            self.n_accepted += self.accept
+            self.n_proposed += 1
 
-    def _propose_positions(self, positions):
-        pass
+        def _propose_positions(self, positions):
+            pass
 
 ### TESTS FOR OPENMMTOOLS MC ENGINE ########################################
 

--- a/openpathsampling/tests/test_openmm_mcengine.py
+++ b/openpathsampling/tests/test_openmm_mcengine.py
@@ -129,8 +129,6 @@ class TestOpenMMToolsMCEngine(object):
         serialized = mcengine.to_dict()
         deserialized = mcengine.__class__.from_dict(copy.copy(serialized))
         reserialized = deserialized.to_dict()
-        pytest.skip()
-        # this assertion currently fails: see choderalab/openmmtools#517
         assert serialized == reserialized
 
     def test_mdtraj_topology_error(self, mcengine):


### PR DESCRIPTION
This provides an engine that wraps the tools in [`openmmtools.mcmc`](https://openmmtools.readthedocs.io/en/0.18.1/mcmc.html). This will allow users to perform path sampling simulations of Monte Carlo "trajectories."

- [x] Basic dynamics
- [x] Serialization
- [x] Support for MDTraj
- [x] Allow same input options as `MCSampler` (don't required `WeightedMove`)
- [x] Docstrings
- [ ] Example
- [x] Tests