### PR TITLE
New `iter_generate` for OPS 2.0

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -29,6 +29,9 @@ except ImportError:  # pragma: no cover
         version.full_version += ".dev-" + version.git_version[:7]
     isrelease = str(ops_setup.preferences['released'])
 
+
+from . import utils
+
 from .analysis.path_histogram import PathDensityHistogram
 
 from .analysis.replica_network import (

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -471,14 +471,16 @@ class DynamicsEngine(StorableNamedObject):
                                     trusted=False)
 
         if stop:
-            return trajectory
+            yield trajectory
+            return
 
         self.start()
         snapshot = None
         while not stop:
 
-            # first we check for maximum length
-            if len(trajectory) >= max_length:
+            # first we check for maximum length; forcible setting
+            # max_length to None will allow infinite trajectories
+            if max_length is not None and len(trajectory) >= max_length:
                 # should only hit on ==, but >= as safety
                 raise EngineMaxLengthError(
                     "Hit maximum trajectory length: %d frames" % max_length,

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -425,6 +425,9 @@ class DynamicsEngine(StorableNamedObject):
 
         return trajectory
 
+    def iter_generate_2(self, initial, running=None, direction=+1):
+        pass
+
     def iter_generate(self, initial, running=None, direction=+1,
                       intervals=10, max_length=0):
         r"""
@@ -692,6 +695,13 @@ class DynamicsEngine(StorableNamedObject):
             returns `True` if the snapshot is okay to be used
         """
         return True
+
+    def validate_snapshot(self, snapshot, trajectory):
+        if not self.is_valid_snapshot(snapshot):
+            raise EngineError("Snapshot is not valid.")
+
+    def snapshot_validation_handler(self, error, snapshot):
+        return error
 
     @classmethod
     def check_snapshot_type(cls, snapshot):

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -1,10 +1,13 @@
 import logging
+import sys
 
 import simtk.openmm
 import simtk.openmm.app
 import simtk.unit as u
 
-from openpathsampling.engines import DynamicsEngine, SnapshotDescriptor
+from openpathsampling.engines import (
+    DynamicsEngine, SnapshotDescriptor, EngineNaNError
+)
 from openpathsampling.engines.openmm import tools
 from .snapshot import Snapshot
 import numpy as np
@@ -400,15 +403,15 @@ class OpenMMEngine(DynamicsEngine):
 
         return True
 
-    def validate_snapshot(self, snapshot):
+    def validate_snapshot(self, snapshot, trajectory):
         if not self.is_valid_snapshot(snapshot):
-            raise EngineNaNError("Engine generated NaN")
+            raise EngineNaNError("Snapshot contains NaN", trajectory)
 
-    def snapshot_validation_handler(self, error, snapshot):
+    def snapshot_error_handler(self, error, snapshot, trajectory):
         e = sys.exc_info()
         se = str(e).lower()
         if 'nan' in se and ('particle' in se or 'coordinates' in se):
-            return EngineNaNError("Engine generated NaN")
+            return EngineNaNError("Snapshot contains NaN", trajectory)
         return error
 
     @property

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -400,6 +400,17 @@ class OpenMMEngine(DynamicsEngine):
 
         return True
 
+    def validate_snapshot(self, snapshot):
+        if not self.is_valid_snapshot(snapshot):
+            raise EngineNaNError("Engine generated NaN")
+
+    def snapshot_validation_handler(self, error, snapshot):
+        e = sys.exc_info()
+        se = str(e).lower()
+        if 'nan' in se and ('particle' in se or 'coordinates' in se):
+            return EngineNaNError("Engine generated NaN")
+        return error
+
     @property
     def current_snapshot(self):
         if self._current_snapshot is None:

--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -10,6 +10,7 @@ from functools import wraps
 from openpathsampling.engines import NoEngine
 import numpy as np
 import numpy.testing as npt
+import openpathsampling as paths
 
 try:
     import simtk.unit as u
@@ -334,3 +335,8 @@ class NaNEngine(NoEngine):
     @staticmethod
     def is_valid_snapshot(snapshot):
         return False
+
+    def validate_snapshot(self, snapshot, trajectory):
+        if not self.is_valid_snapshot(snapshot):
+            raise paths.engines.EngineNaNError("Snapshot contains NaN",
+                                               trajectory)

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -178,7 +178,7 @@ class TestOpenMMEngine(object):
         assert_equal(self.engine.snapshot_timestep, 4 * u.femtoseconds)
 
     @raises_with_message_like(paths.engines.EngineMaxLengthError,
-                              "Hit maximal length")
+                              "Hit maximum")
     def test_fail_length(self):
         self.engine.options['on_max_length'] = 'fail'
         self.engine.options['n_max_length'] = 2
@@ -187,15 +187,15 @@ class TestOpenMMEngine(object):
     @raises_with_message_like(paths.engines.EngineMaxLengthError,
                               'Failed to generate trajectory without hitting '
                               'max length')
-    def test_retry_length(self):
-        self.engine.on_max_length = 'retry'
-        self.engine.options['n_max_length'] = 2
-        self.engine.options['retries_when_max_length'] = 2
-        _ = self.engine.generate(self.engine.current_snapshot, [true_func])
+    # def test_retry_length(self):
+        # self.engine.on_max_length = 'retry'
+        # self.engine.options['n_max_length'] = 2
+        # self.engine.options['retries_when_max_length'] = 2
+        # _ = self.engine.generate(self.engine.current_snapshot, [true_func])
 
     # OpenMM CPU will throw an error and not return a snapshot with nan
     @raises_with_message_like(dyn.EngineNaNError,
-                              '`nan` in snapshot')
+                              'Snapshot contains NaN')
     def test_fail_nan(self):
         self.engine.on_max_length = 'retry'
         self.engine.options['n_max_length'] = 2


### PR DESCRIPTION
One of the things I want to do in OPS 2.0 is simplify code in API-breaking ways, when the API isn't something that is widely used. One case of this is `DynamicsEngine.iter_generate`. The existing `iter_generate`has a huge complexity rating (McCabe cyclomatic complexity of 46; CodeClimate "cognitive complexity" of 92). This comes because it tries to implement a bunch of user-facing options for error handling into one catch-all function, instead of letting the client code handle the errors. This is all the stuff about how to handle NaNs or max-length error (whether to restart/retry/etc.)

In path sampling, many of those options would be just wrong. A trajectory that generates a NaN is a rejected trajectory. Retrying will bias the sampling. In addition, when I tried to write tests for it, it became clear that some of that functionality isn't even implemented correctly.

So this PR rewrites `iter_generate` without the extra error handling functionality. That error handling should be done in the calling code. We raise errors that should make it clear to calling code what the problem is; special treatments in case of certain error types can be done by calling code (this is never something that should be done on a per-engine level, but something that should be done on a situational basis).

There are two places where engine writers can change the error handling:

* `engine.is_valid_snapshot()`: Check whether the created snapshot is valid. Generally will just return a bool. If you want to use the default error behavior (raise an `EngineError`), this is all you need to change.
* `engine.snapshot_error_handler()`: If you want to modify the error in some way, or if there are some errors that you can recover from, do that here. If you want an error to be raised, then return the error. If you can recover from the error and create a valid snapshot, then return the valid snapshot.

For most users, this makes no difference. It means that under the hood we're using a different function. The API break is the drop of engine-level support for error handling, and a small change in the call signature of `iter_generate` (removing the `intervals` parameter). I don't think anyone will miss these things.

- [x] Code for new `iter_generate`
- [x] Use new `iter_generate` for all tests
- [ ] Add support for correcting snapshot
- [ ] Unit tests for new `iter_generate`; full coverage
- [ ] Update docs on writing engines
- [ ] Remove options for NaN handling from engines
- [ ] Remove docstrings about NaN handling from engines