### PR TITLE
Update CI for OPS 2.0

### DIFF
--- a/.github/workflows/test-2.0.yml
+++ b/.github/workflows/test-2.0.yml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     name: "Unit Tests"
     strategy:
+      # NOTE: When changing the test matrix:
+      # * Update the after_n_builds in codecov.yml to match the number of
+      #   builds in the matrix
+      # * You may need to create another example run for the notebook tests
+      #   (see examples/ipynbtests.sh; examples/prep_example_data.py). This
+      #   is because Python internals (usually bytecode, which is saved in
+      #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
           - 3.7
@@ -23,9 +30,12 @@ jobs:
         MINIMAL: [""]
         include:
           - CONDA_PY: 3.7
-            MINIMAL: "Minimal"
+            MINIMAL: "minimal"
+
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/setup-python@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -34,6 +44,7 @@ jobs:
       - name: "Install requirements"
         env:
           MINIMAL: ${{ matrix.MINIMAL }}
+          CONDA_PY: ${{ matrix.CONDA_PY }}
         run: |
           if [ -z "$MINIMAL" ] ; then
             source devtools/conda_install_reqs.sh
@@ -41,22 +52,26 @@ jobs:
             python -m pip install -r devtools/minimal.txt \
                                   -r devtools/minimal_testing.txt
           fi
-      - name: "Install"
-        run: python -m pip install --no-deps -e .
-      - name: "Autorelease check"
-        run: |
           python -m pip install autorelease
-          python devtools/autorelease_check.py
+      - name: "Install"
+        run: |
+          python -m pip install --no-deps -e .
+          python -c "import openpathsampling"
       - name: "Versions"
         run: |
           conda info --envs
           conda list
+      - name: "Autorelease check"
+        run: python devtools/autorelease_check.py
       - name: "Unit tests"
-        run: |
-          python -c "import openpathsampling"
-          py.test -vv -s --cov=openpathsampling --cov-report xml
-      - name: "Test experimental features"
+        env:
+          PY_COLORS: "1"
+        run: py.test -vv -s --cov=openpathsampling --cov-report xml
+      - name: "Tests: Experimental"
         if: matrix.MINIMAL == ''
         run: py.test -vv -s openpathsampling/experimental
-      #- name: "Upload coverage"
+      #- name: "Report coverage"
         #run: bash <(curl -s https://codecov.io/bash)
+      - name: "Notebook tests"
+        if: matrix.MINIMAL == ''
+        run: pushd examples/ && ./ipynbtests.sh || exit 1 && popd

--- a/.github/workflows/test-2.0.yml
+++ b/.github/workflows/test-2.0.yml
@@ -24,7 +24,7 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
-          - 3.7
+          #- 3.7
           - 3.8
           - 3.9
         MINIMAL: [""]

--- a/.github/workflows/test-2.0.yml
+++ b/.github/workflows/test-2.0.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         CONDA_PY:
           - 3.7
-          #- 3.8
-          #- 3.9
+          - 3.8
+          - 3.9
         MINIMAL: [""]
         include:
           - CONDA_PY: 3.7

--- a/.github/workflows/test-2.0.yml
+++ b/.github/workflows/test-2.0.yml
@@ -24,7 +24,7 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
-          #- 3.7
+          - 3.7
           - 3.8
           - 3.9
         MINIMAL: [""]

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -18,8 +18,8 @@ case $PYTHON_VERSION in
         mistis=$dropbox_base_url/76981cbgxm639m3/toy_mistis_1k_OPS1_py36.nc
         ;;
     "3.7")
-        mstis=$dropbox_base_url/1ulzssv5p4lr61f/toy_mstis_1k_OPS1_py36.nc
-        mistis=$dropbox_base_url/76981cbgxm639m3/toy_mistis_1k_OPS1_py36.nc
+        mstis=$dropbox_base_url/s5d76vg5jyf84oa/toy_mstis_1k_OPS1_py37.nc
+        mistis=$dropbox_base_url/vzyywl3yli3pp8u/toy_mistis_1k_OPS1_py37.nc
         ;;
     "3.8")
         mstis=$dropbox_base_url/8rr0tt25xlm47cs/toy_mstis_1k_OPS1_py38.nc


### PR DESCRIPTION
The main development branch CI is in `.github/workflows/tests.yml`. The CI for the 2.0 development branch is in `.github/workflows/test-2.0.yml`. This PR ports improvements in `tests.yml` into `test-2.0.yml` (and, of course, targets the `dev-2.0` branch).

Useful improvements:

* Adds Python 3.8 and 3.9 to the test suite. This wasn't possible (no OpenMM available) before.
* Adds notebook tests. I'm not sure why this wasn't done before, but with core changes on the way, such as #1042, I'll feel a lot better having the more thorough test suite.