### PR TITLE
Fix syntax warning

### DIFF
--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -45,7 +45,7 @@ class ExampleExternalEngine(peng.ExternalEngine):
         # nothing exists, linecache returns '', so we return None.
         # Otherwise, try to make a snapshot and return "partial" if we fail
         line = linecache.getline(filename, first_line)
-        if line is '':
+        if line == '':
             snap = None
         else:
             try:

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -1,6 +1,3 @@
-from nose.tools import (assert_equal, assert_not_equal, assert_almost_equal,
-                        raises, assert_true)
-from nose.plugins.skip import Skip, SkipTest
 from .test_helpers import assert_items_equal
 
 import openpathsampling as paths
@@ -12,9 +9,7 @@ from openpathsampling.engines.external_engine import *
 import numpy as np
 
 import psutil
-import shlex
 
-import time
 import os
 import glob
 import linecache
@@ -35,6 +30,7 @@ class ExampleExternalEngine(peng.ExternalEngine):
     """
     SnaphotClass = ToySnapshot
     InternalizedSnapshotClass = ToySnapshot
+
     def read_frame_from_file(self, filename, frame_num):
         # under most circumstances, start with linecache.checkcache and
         # setting the value of the first line
@@ -80,15 +76,18 @@ class ExampleExternalEngine(peng.ExternalEngine):
         return (engine_path + " " + str(self.engine_sleep)
                 + " " + str(self.output_file) + " " + str(self.input_file))
 
+
 def setup_module():
     proc = psutil.Popen("make", cwd=engine_dir)
     proc.wait()
+
 
 def teardown_module():
     # proc = psutil.Popen("make clean", cwd=engine_dir, shell=True)
     # proc.wait()
     for testfile in glob.glob("test*out") + glob.glob("test*inp"):
         os.remove(testfile)
+
 
 class TestExternalEngine(object):
     def setup(self):
@@ -98,16 +97,16 @@ class TestExternalEngine(object):
                                  'n_atoms': 1}
         )
         slow_options = {
-            'n_frames_max' : 10000,
-            'engine_sleep' : 100,
-            'name_prefix' : "test",
-            'engine_directory' : engine_dir
+            'n_frames_max': 10000,
+            'engine_sleep': 100,
+            'name_prefix': "test",
+            'engine_directory': engine_dir
         }
         fast_options = {
-            'n_frames_max' : 10000,
-            'engine_sleep' : 0,
-            'name_prefix' : "test",
-            'engine_directory' : engine_dir
+            'n_frames_max': 10000,
+            'engine_sleep': 0,
+            'name_prefix': "test",
+            'engine_directory': engine_dir
         }
         self.template = peng.toy.Snapshot(coordinates=np.array([[0.0]]),
                                           velocities=np.array([[1.0]]))
@@ -123,19 +122,19 @@ class TestExternalEngine(object):
         eng = self.fast_engine
         # check that it isn't running yet
         try:
-            assert_equal(eng.proc.is_running(), False)
+            assert not eng.proc.is_running()
         except AttributeError:
-            pass # if eng.proc doesn't exist, then it isn't running
+            pass  # if eng.proc doesn't exist, then it isn't running
 
         # start it; check that it is running
         eng.start(self.template)
-        assert_equal(eng.proc.is_running(), True)
+        assert eng.proc.is_running()
         # zombies also run
-        assert_not_equal(eng.proc.status(), psutil.STATUS_ZOMBIE)
+        assert eng.proc.status() != psutil.STATUS_ZOMBIE
 
         # stop it; check that it isn't running
         eng.stop(None)
-        assert_equal(eng.proc.is_running(), False)
+        assert not eng.proc.is_running()
 
     def test_read_frame_from_file(self):
         eng = self.slow_engine
@@ -143,13 +142,13 @@ class TestExternalEngine(object):
         testf.write("1.0 1.0\n2.0 1.0\n3.0 1.0\n")
         testf.close()
         snap2 = eng.read_frame_from_file("testf1.data", 1)
-        assert_equal(snap2.xyz[0][0], 2.0)
+        assert snap2.xyz[0][0] == 2.0
         snap1 = eng.read_frame_from_file("testf1.data", 0)
-        assert_equal(snap1.xyz[0][0], 1.0)
+        assert snap1.xyz[0][0] == 1.0
         snap3 = eng.read_frame_from_file("testf1.data", 2)
-        assert_equal(snap3.xyz[0][0], 3.0)
+        assert snap3.xyz[0][0] == 3.0
         snap4 = eng.read_frame_from_file("testf1.data", 3)
-        assert_equal(snap4, None)
+        assert snap4 is None
         os.remove('testf1.data')
 
     def test_read_frame_while_writing_file(self):
@@ -158,16 +157,16 @@ class TestExternalEngine(object):
         testf.write("6.0 1.0\ninvalid")
         testf.close()
         snap1 = eng.read_frame_from_file("testf2.data", 0)
-        assert_equal(snap1.xyz[0][0], 6.0)
+        assert snap1.xyz[0][0] == 6.0
         snap2 = eng.read_frame_from_file("testf2.data", 1)
-        assert_equal(snap2, "partial")
+        assert snap2 == "partial"
         os.remove('testf2.data')
 
         testf = open('testf3.data', 'w')
         testf.write("6.0 ")
         testf.close()
         snap3 = eng.read_frame_from_file("testf3.data", 0)
-        assert_equal(snap3, "partial")
+        assert snap3 == "partial"
         os.remove('testf3.data')
 
     def test_generate_next_frame(self):
@@ -181,14 +180,14 @@ class TestExternalEngine(object):
         self.slow_engine.initialized = True
         traj = self.slow_engine.generate(self.template,
                                          [self.ensemble.can_append])
-        assert_equal(len(traj), 5)
+        assert len(traj) == 5
 
     def test_fast_run(self):
         # generate traj in LengthEnsemble if frames come as fast as possible
         self.fast_engine.initialized = True
         traj = self.fast_engine.generate(self.template,
                                          [self.ensemble.can_append])
-        assert_equal(len(traj), 5)
+        assert len(traj) == 5
 
     def test_in_shooting_move(self):
         for testfile in glob.glob("test*out") + glob.glob("test*inp"):
@@ -196,7 +195,7 @@ class TestExternalEngine(object):
         ens10 = paths.LengthEnsemble(10)
         init_traj = self.fast_engine.generate(self.template,
                                               [ens10.can_append])
-        assert_equal(ens10(init_traj), True)
+        assert ens10(init_traj)
         init_conds = paths.SampleSet([
             paths.Sample(replica=0, ensemble=ens10, trajectory=init_traj)
         ])
@@ -208,7 +207,7 @@ class TestExternalEngine(object):
                         [[5.0]], [[6.0]], [[7.0]], [[8.0]], [[9.0]]]
         assert_items_equal(init_conds[0].trajectory.xyz, default_traj)
         for step in range(10):
-            assert_equal(len(prev_sample_set), 1)
+            assert len(prev_sample_set) == 1
             change = shooter.move(prev_sample_set)
             new_sample_set = prev_sample_set.apply_samples(change.results)
             assert_items_equal(new_sample_set[0].trajectory.xyz,
@@ -216,11 +215,12 @@ class TestExternalEngine(object):
             prev_traj = prev_sample_set[0].trajectory
             new_traj = new_sample_set[0].trajectory
             shared = prev_traj.shared_configurations(new_traj)
-            assert_true(0 < len(list(shared)) < len(new_traj))
+            assert (0 < len(list(shared)) < len(new_traj))
             prev_sample_set = new_sample_set
 
         for testfile in glob.glob("test*out") + glob.glob("test*inp"):
             os.remove(testfile)
+
 
 class TestFilenameSetter(object):
     def test_default_setter(self):


### PR DESCRIPTION
When I looked at the tests in #1043, I noticed a:
```
  /home/runner/work/openpathsampling/openpathsampling/openpathsampling/tests/test_external_engine.py:48: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if line is '':
```

This solves that warning, drops `nose` from that particular test file (part of #756), and solve some style complaints