### PR TITLE
Raise FileNotFoundError if sql backend tries to read a file that does not exist

### DIFF
--- a/openpathsampling/experimental/simstore/my_types.py
+++ b/openpathsampling/experimental/simstore/my_types.py
@@ -1,8 +1,9 @@
 import re
 import numpy as np
 ndarray_re = re.compile(
-    "ndarray\.(?P<dtype>[a-z0-9]+)(?P<shape>\([0-9\,\ ]+\))"
+    r"ndarray\.(?P<dtype>[a-z0-9]+)(?P<shape>\([0-9\,\ ]+\))"
 )
+
 
 def parse_ndarray_type(type_name):
     m_ndarray = ndarray_re.match(type_name)
@@ -12,15 +13,15 @@ def parse_ndarray_type(type_name):
         return dtype, shape
     return None
 
+
 # TODO: this needs to be set up in a way to make it extensible (without
 # editing core code)
 def backend_registration_type(type_name):
     backend_type = type_name
     ndarray_info = parse_ndarray_type(type_name)
-    if parse_ndarray_type(type_name):
+    if ndarray_info:
         backend_type = 'ndarray'
     return backend_type
-
 
 
 uuid_types = ['uuid', 'lazy']
@@ -31,5 +32,3 @@ ndarray_types = ['ndarray']
 all_types = uuid_types + uuid_list_types + builtin_types + ndarray_types
 all_uuid_types = ['uuid', 'lazy', 'list_uuid']
 json_obj_types = ['json', 'json_obj']
-
-

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -142,6 +142,10 @@ class SQLStorageBackend(StorableNamedObject):
                 # act as if the mode is 'w'; note we change this back later
                 self.mode = 'w'
 
+            if self.mode == 'r' and not file_exists:
+                raise FileNotFoundError(
+                    f"No such file or directory: '{filename}'")
+
             self.connection_uri = self.filename_from_dialect(
                 filename,
                 self.sql_dialect

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -241,11 +241,12 @@ class SQLStorageBackend(StorableNamedObject):
         More info: https://docs.sqlalchemy.org/en/latest/core/engines.html
         """
         filename = kwargs.pop('filename', None)
+        mode = kwargs.get('mode', 'r')
         obj = cls(**kwargs)
         obj.filename = filename
         obj.connection_uri = connection_uri
         obj._metadata = sql.MetaData(bind=engine)
-        obj._initialize_with_mode(self.mode)
+        obj._initialize_with_mode(mode)
         return obj
 
 

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -273,3 +273,7 @@ class TestSQLStorageBackend(object):
             expected = tuple(samp_dct[k]
                              for k in ['replica', 'ensemble', 'trajectory'])
             assert row[2:] == expected
+
+    def test_non_existing_file(self):
+        with pytest.raises(FileNotFoundError, match="foo.sql"):
+            SQLStorageBackend("foo.sql")

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -1,6 +1,6 @@
 from .sql_backend import *
 import pytest
-
+sqla = pytest.importorskip("sqlalchemy")
 
 class TestSQLStorageBackend(object):
     def setup(self):
@@ -88,7 +88,7 @@ class TestSQLStorageBackend(object):
             'write': SQLStorageBackend('test1.sql', mode='w'),
             'append': SQLStorageBackend('test2.sql', mode='a'),
         }[db]
-        table_names = database.engine.table_names()
+        table_names = sqla.inspect(database.engine).get_table_names()
         assert set(table_names) == self.default_table_names
         assert self._col_names_set('uuid') == {'uuid', 'table', 'row'}
         assert self._col_names_set('tables') == {'name', 'idx', 'module',
@@ -100,7 +100,7 @@ class TestSQLStorageBackend(object):
             'snapshot1': [('filename', 'str'), ('index', 'int')]
         }
         self.database.register_schema(new_schema, self.table_to_class)
-        table_names = self.database.engine.table_names()
+        table_names = sqla.inspect(self.database.engine).get_table_names()
         assert set(table_names) == self.default_table_names | {'snapshot1'}
         assert self._col_names_set('snapshot1') == {'idx', 'uuid',
                                                     'filename', 'index'}
@@ -177,7 +177,6 @@ class TestSQLStorageBackend(object):
         uuid_table_rows = self.database.load_uuids_table(uuids)
         loaded_table = self.database.load_table_data(uuid_table_rows)
         assert len(loaded_table) == 3
-        pytest.skip()
 
     def test_load_save_large_numbers(self):
         # mainly a smoke test to ensure that we reload everything correctly

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -1,6 +1,5 @@
 from .sql_backend import *
 import pytest
-sqla = pytest.importorskip("sqlalchemy")
 
 class TestSQLStorageBackend(object):
     def setup(self):
@@ -88,7 +87,7 @@ class TestSQLStorageBackend(object):
             'write': SQLStorageBackend('test1.sql', mode='w'),
             'append': SQLStorageBackend('test2.sql', mode='a'),
         }[db]
-        table_names = sqla.inspect(database.engine).get_table_names()
+        table_names = sql.inspect(database.engine).get_table_names()
         assert set(table_names) == self.default_table_names
         assert self._col_names_set('uuid') == {'uuid', 'table', 'row'}
         assert self._col_names_set('tables') == {'name', 'idx', 'module',
@@ -100,7 +99,7 @@ class TestSQLStorageBackend(object):
             'snapshot1': [('filename', 'str'), ('index', 'int')]
         }
         self.database.register_schema(new_schema, self.table_to_class)
-        table_names = sqla.inspect(self.database.engine).get_table_names()
+        table_names = sql.inspect(self.database.engine).get_table_names()
         assert set(table_names) == self.default_table_names | {'snapshot1'}
         assert self._col_names_set('snapshot1') == {'idx', 'uuid',
                                                     'filename', 'index'}

--- a/openpathsampling/experimental/simstore/type_ident.py
+++ b/openpathsampling/experimental/simstore/type_ident.py
@@ -3,11 +3,14 @@ import numbers
 import numpy as np
 from .serialization_helpers import has_uuid
 
+
 class TypeStringError(RuntimeError):
     pass
 
+
 class TypeIdentificationError(RuntimeError):
     pass
+
 
 class TypingManager(object):
     def __init__(self, type_ids):
@@ -69,7 +72,7 @@ class StandardTypeIdentifier(object):
 
 class NumpyTypeIdentifier(object):
     ndarray_re = re.compile(
-        "ndarray\.(?P<dtype>[a-z0-9]+)(?P<shape>\([0-9\,\ ]+\))"
+        r"ndarray\.(?P<dtype>[a-z0-9]+)(?P<shape>\([0-9\,\ ]+\))"
     )
     def __init__(self):
         self.name = 'ndarray'

--- a/openpathsampling/experimental/simstore/uuids.py
+++ b/openpathsampling/experimental/simstore/uuids.py
@@ -9,6 +9,7 @@ if sys.version_info > (3, ):
     unicode = str
     long = int
 
+
 def has_uuid(obj):
     return hasattr(obj, '__uuid__')
 
@@ -22,6 +23,7 @@ def get_uuid(obj):
             return obj
         else:
             raise e
+
 
 def set_uuid(obj, uuid):
     obj.__uuid__ = long(uuid)
@@ -37,7 +39,7 @@ def decode_uuid(uuid_str):
 
 # use the regular expression when looking through an entire JSON string; use
 # the is_uuid_string method for individual objects
-encoded_uuid_re = re.compile("UUID\((?P<uuid>[\-]?[0-9]+)\)")
+encoded_uuid_re = re.compile(r"UUID\((?P<uuid>[\-]?[0-9]+)\)")
 
 
 def is_uuid_string(obj):
@@ -45,5 +47,3 @@ def is_uuid_string(obj):
         isinstance(obj, (str, unicode))
         and obj[:5] == 'UUID(' and obj[-1] == ')'
     )
-
-

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -45,7 +45,7 @@ if HAS_SIMTK:
     )
 
 ### DIRECT SERIALIZATION #################################################
-_simtk_re = re.compile("simtk\((.*)\)\*((ndarray|float).*)")
+_simtk_re = re.compile(r"simtk\((.*)\)\*((ndarray|float).*)")
 
 
 def simtk_unit_from_string(unit_str):


### PR DESCRIPTION
I tried reading a file that did not exist in that directory, this lead to 2 things happening:
1) the file was created (this made it so that it took way too long before I figured out what was going on)
2) the code failed with: 
```
~/github_files/openpathsampling/openpathsampling/experimental/simstore/sql_backend.py in __init__(self, filename, mode, sql_dialect, **kwargs)
    148             )
    149             engine = sql.create_engine(self.connection_uri, **self.kwargs)
--> 150             self._initialize_from_engine(engine)
    151             self.mode = mode  # in case we changed when checking existence
    152 

~/github_files/openpathsampling/openpathsampling/experimental/simstore/sql_backend.py in _initialize_from_engine(self, engine)
    154         self.engine = engine
    155         self._metadata = sql.MetaData(bind=self.engine)
--> 156         self._initialize_with_mode(self.mode)
    157 
    158     @property

~/github_files/openpathsampling/openpathsampling/experimental/simstore/sql_backend.py in _initialize_with_mode(self, mode)
    208         elif mode == "r" or mode == "a":
    209             self.metadata.reflect(self.engine)
--> 210             self.schema = self.database_schema()
    211             self.table_to_number, self.number_to_table = \
    212                     self.internal_tables_from_db()

~/github_files/openpathsampling/openpathsampling/experimental/simstore/sql_backend.py in database_schema(self)
    592             schema dictionary
    593         """
--> 594         schema_table = self.metadata.tables['schema']
    595         sel = schema_table.select()
    596         with self.engine.connect() as conn:

KeyError: 'schema'
```
This PR ( in 7d90a63) adds logic to raise a FileNotFound error with a test

Implementing the code and running that test led to some Warning/Errors being raised, so I fixed those in the following commits:

293c867 resolves an error my coding enviroment was throwing about `self` not being defined in a `classmethod`
3d8f488 resolves a couple `DeprecationWarning: invalid escape sequence \(` (or `\.` )inside regex strings and resolves some pep8 complaints in touched files
b8d6947 resolves `SADeprecationWarning: The Engine.table_names() method is deprecated and will be removed in a future release.  Please refer to Inspector.get_table_names(). (deprecated since: 1.4)` in the proposed way ([documentation link](https://docs.sqlalchemy.org/en/14/core/reflection.html#fine-grained-reflection-with-inspector)) and removes a leftover `pytest.skip()` at the end of a completed test
