### PR TITLE
Change ShootingPointAnalysisError to an Exception

### DIFF
--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -72,8 +72,7 @@ class SnapshotByCoordinateDict(TransformedDict):
                                                        *args, **kwargs)
 
 
-class ShootingPointAnalysisError(AssertionError):
-    # TODO this should inherit from a different Error type in OPS 2.0
+class ShootingPointAnalysisError(ValueError):
     pass
 
 

--- a/openpathsampling/analysis/shooting_point_analysis.py
+++ b/openpathsampling/analysis/shooting_point_analysis.py
@@ -72,7 +72,7 @@ class SnapshotByCoordinateDict(TransformedDict):
                                                        *args, **kwargs)
 
 
-class ShootingPointAnalysisError(ValueError):
+class ShootingPointAnalysisError(Exception):
     pass
 
 


### PR DESCRIPTION
This changes the Error type of the ShootingPointAnalysis from an `AssertionError` (to ensure backwards compatability) to an more reasonable ~`ValueError`~ `Exception` for OPS 2.0. 

(I could not figure out how to do an easy DeprecationWarning on this; My current guess would be to write a metaclass that would update the MRO/`__bases__` of this error to a subclass of tuple that would warn if the index that contained the `AssertionError` was accessed, something like [this SO answer](https://stackoverflow.com/a/20832588/15100302)) 

Edit: this also merges the current master into OPS 2.0

Edit 2: after 2d95011 this now becomes an `Exception` instead of a `ValueError`