### PR TITLE
add access via slice

### DIFF
--- a/openpathsampling/experimental/simstore/storage.py
+++ b/openpathsampling/experimental/simstore/storage.py
@@ -69,7 +69,7 @@ class GeneralStorage(StorableNamedObject):
                                                         {})
 
         # self._pseudo_tables = {table_name: dict()
-                               # for table_name in self.simulation_classes}
+        #                        for table_name in self.simulation_classes}
         self._simulation_objects = {}
         self._pseudo_tables = {table_name: PseudoTable()
                                for table_name in self.simulation_classes}
@@ -159,8 +159,8 @@ class GeneralStorage(StorableNamedObject):
         # check validity
         self.class_info.register_info(class_info_list, schema)
         # for info in class_info_list:
-            # info.set_defaults(schema)
-            # self.class_info.add_class_info(info)
+        #     info.set_defaults(schema)
+        #     self.class_info.add_class_info(info)
 
         schema_types = [type_str for attr_list in schema.values()
                         for _, type_str in attr_list]
@@ -213,7 +213,6 @@ class GeneralStorage(StorableNamedObject):
 
         return uuid_dict
 
-
     def _uuids_by_table(self, input_uuids, cache, get_table_name):
         # find all UUIDs we need to save with this object
         logger.debug("Listing all objects to save")
@@ -243,7 +242,6 @@ class GeneralStorage(StorableNamedObject):
         loaded = self.load(lazies, allow_lazy=False)
         uuid_mapping.update({get_uuid(obj): obj for obj in loaded})
         return uuid_mapping
-
 
     def save(self, obj_list, use_cache=True):
         if type(obj_list) is not list:
@@ -384,11 +382,11 @@ class GeneralStorage(StorableNamedObject):
         logger.debug("Getting internal structure of %d non-cached objects",
                      len(uuid_list))
         to_load, lazy_uuids, dependencies, uuid_to_table = \
-                get_all_uuids_loading(uuid_list=uuid_list,
-                                      backend=self.backend,
-                                      schema=self.schema,
-                                      existing_uuids=self.cache,
-                                      allow_lazy=allow_lazy)
+            get_all_uuids_loading(uuid_list=uuid_list,
+                                  backend=self.backend,
+                                  schema=self.schema,
+                                  existing_uuids=self.cache,
+                                  allow_lazy=allow_lazy)
         logger.debug("Loading %d objects; creating %d lazy proxies",
                      len(to_load), len(lazy_uuids))
 
@@ -421,7 +419,6 @@ class GeneralStorage(StorableNamedObject):
                 self._sf_handler.register_function(result)
 
         return new_results
-
 
     def deserialize_uuids(self, ordered_uuids, uuid_to_table,
                           uuid_to_table_row, new_uuids=None):
@@ -479,7 +476,7 @@ class GeneralStorage(StorableNamedObject):
                     my_cls = cls
                     # self._pseudo_tables[key][uuid] = obj
                     # if obj.is_named:
-                        # self._pseudo_tables[key][obj.name] = obj
+                    #     self._pseudo_tables[key][obj.name] = obj
             if my_cls is None:
                 self._pseudo_tables['misc_simulation'].append(obj)
 
@@ -511,7 +508,7 @@ class GeneralStorage(StorableNamedObject):
         elif attr in self._pseudo_tables:
             return self._pseudo_tables[attr]
         else:
-            raise AttributeError("'{}' object has no attribute '{}'"\
+            raise AttributeError("'{}' object has no attribute '{}'"
                                  .format(self.__class__.__name__, attr))
 
 
@@ -563,6 +560,7 @@ class MixedCache(abc.MutableMapping):
     def __iter__(self):
         return itertools.chain(self.fixed_cache, self.cache)
 
+
 class StorageTable(abc.Sequence):
     # NOTE: currently you still need to be able to hold the whole table in
     # memory ... at least, with the SQL backend.
@@ -609,12 +607,11 @@ class StorageTable(abc.Sequence):
         else:
             return self.storage.load(rows)
 
-
     def __len__(self):
         return self.storage.backend.table_len(self.table)
 
     def cache_all(self):
-        old_blocksize = self.iter_block_size
+        # old_blocksize = self.iter_block_size
         self.iter_block_size = len(self)
         _ = list(iter(self))
 
@@ -625,6 +622,7 @@ class StorageTable(abc.Sequence):
     # TODO: subclass for MCSteps with additional method .ordered, returning
     # things in the order of the mccycle number -- also, manage special
     # caching
+
 
 class PseudoTable(abc.MutableSequence):
     # TODO: use this in the main code

--- a/openpathsampling/experimental/simstore/test_storage.py
+++ b/openpathsampling/experimental/simstore/test_storage.py
@@ -5,6 +5,7 @@ import pytest
 from .serialization_helpers import get_uuid
 from .test_utils import all_objects, UnnamedUUID, MockUUIDObject
 
+
 class TestStorageTable(object):
     def setup(self):
         pass
@@ -26,7 +27,8 @@ class TestPseudoTable(object):
     def setup(self):
         self.objs = {None: UnnamedUUID(normal_attr=10)}
         self.objs.update(all_objects)
-        self.pseudo_table = PseudoTable(list(self.objs.values()))
+        self.obj_list = list(self.objs.values())
+        self.pseudo_table = PseudoTable(self.obj_list)
 
     @pytest.mark.parametrize('name', ['int', None])
     def test_get_by_uuid(self, name):
@@ -38,11 +40,28 @@ class TestPseudoTable(object):
     @pytest.mark.parametrize('name', ['int', None])
     def test_getitem(self, name):
         obj = self.objs[name]
-        uuid = get_uuid(obj)
         idx = self.pseudo_table.index(obj)
         assert self.pseudo_table[idx] == obj
         if name is not None:
             assert self.pseudo_table[name] == obj
+
+    @pytest.mark.parametrize("s", [slice(None),  # [:]
+                                   slice(5),  # [:5]
+                                   slice(-5),  # [:-5]
+                                   slice(1, 2),  # [1:2]
+                                   slice(100),  # longer slice than possible
+                                   slice(6, 4, -1),  # [6:4:-1]
+                                   slice(5, 5),  # empty
+                                   ])
+    def test_getslice(self, s):
+        truths = self.obj_list[s]
+        tests = self.pseudo_table[s]
+        for i, j in zip(truths, tests):
+            assert i == j
+
+    def test_bogus_access(self):
+        with pytest.raises(TypeError, match="tuple"):
+            self.pseudo_table[(1, 2, 3)]
 
     @pytest.mark.parametrize('name', ['int2', None])
     def test_setitem(self, name):
@@ -55,7 +74,7 @@ class TestPseudoTable(object):
         self.pseudo_table[len_table-1] = item
         assert item in self.pseudo_table
         assert self.pseudo_table[len_table-1] == item
-        if name != None:
+        if name is not None:
             assert self.pseudo_table[name] == item
 
     @pytest.mark.parametrize('name', ['int2', None])
@@ -69,7 +88,7 @@ class TestPseudoTable(object):
         self.pseudo_table.append(item)
         assert item in self.pseudo_table
         assert self.pseudo_table[len_table] == item
-        if name != None:
+        if name is not None:
             assert self.pseudo_table[name] == item
 
     def test_delitem(self):
@@ -79,7 +98,7 @@ class TestPseudoTable(object):
         del self.pseudo_table[int_idx]
         assert len(self.pseudo_table) == len(all_objects)
         assert self.objs['int'] not in self.pseudo_table
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match='int'):
             self.pseudo_table['int']
 
     def test_len(self):
@@ -96,5 +115,5 @@ class TestPseudoTable(object):
         self.pseudo_table.insert(len_table, item)
         assert item in self.pseudo_table
         assert self.pseudo_table[len_table] == item
-        if name != None:
+        if name is not None:
             assert self.pseudo_table[name] == item


### PR DESCRIPTION
Today, I got annoyed today that I could not do
`steps = storage.steps[:100]` in some test code using simstore.

This adds handling of slices in the `__getitem__` logic. 
It behaves as a `list` would do (so an empty list on an empty slice, a list with a single item for slices like `[4:5]`, a single item with `int` and a `TypeError` if it is not an `int` or `slice`)

It should also leverage batched loading, if I understood the code correctly

One assumption that I added is that the `name` of objects can only be strings (for `_name_to_uuid`, I don't know if this is currently an assumption/requirement, but all tests seem to pass on this.

This code is `python > .3.6` (f strings) and the tests are `python > 3.7` (leverages dict order)
