### PR TITLE
Fixes for OpenMM 7.6 RC

### DIFF
--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -5,7 +5,7 @@
 name: "Check for OpenMM RC"
 on:
   schedule:
-    - cron: "0 9 * * */2"
+    - cron: "0 9 * * *"
 
 jobs:
   check-rc:

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   check-rc:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Check for OpenMM RC"
     steps:

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -4,8 +4,8 @@ name: "Test OpenMM Release Candidate"
 on:
   workflow_dispatch:
   # use this for debugging
-  pull_request:
-    branch: master
+  #pull_request:
+    #branch: master
 
 defaults:
   run:

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -4,8 +4,8 @@ name: "Test OpenMM Release Candidate"
 on:
   workflow_dispatch:
   # use this for debugging
-  #pull_request:
-    #branch: master
+  pull_request:
+    branch: master
 
 defaults:
   run:

--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -166,7 +166,6 @@ from .high_level.ms_outer_interface import MSOuterTISInterface
 from .high_level.part_in_b_tps import (
     PartInBFixedLengthTPSNetwork, PartInBFixedLengthTPSTransition
 )
-
 from .ensembles import *
 from .pathmovers import *
 from .collectivevariables import *

--- a/openpathsampling/engines/features/shared.py
+++ b/openpathsampling/engines/features/shared.py
@@ -12,12 +12,12 @@ def unmask_quantity(quantity):
 
     Parameters
     ----------
-    quantity : simtk.unit.Quantity wrapping a numpy (masked) array
+    quantity : openmm.unit.Quantity wrapping a numpy (masked) array
         quantity to unmask
 
     Returns
     -------
-    simtk.unit.Quantity
+    openmm.unit.Quantity
         wraps a regular numpy array, not a masked array
     """
     try:
@@ -39,7 +39,7 @@ class StaticContainer(StorableObject):
 
     Parameters
     ----------
-    coordinates : simtk.unit.Quantity wrapping Nx3 np array of dimension length
+    coordinates : openmm.unit.Quantity wrapping Nx3 np array of dimension length
         atomic coordinates
     box_vectors : periodic box vectors
         the periodic box vectors
@@ -182,7 +182,7 @@ class KineticContainer(StorableObject):
 
     Attributes
     ----------
-    velocities : simtk.unit.Quantity wrapping Nx3 np array of dimension length
+    velocities : openmm.unit.Quantity wrapping Nx3 np array of dimension length
         atomic velocities
     engine : :class:`.DynamicsEngine`
         the engine that creating this data

--- a/openpathsampling/engines/features/statics.py
+++ b/openpathsampling/engines/features/statics.py
@@ -51,7 +51,7 @@ def coordinates(snapshot):
     -------
     coordinates: numpy.ndarray, shape=(atoms, 3), dtype=numpy.float32
         the atomic coordinates of the configuration. The coordinates are
-        wrapped in a `simtk.unit.Unit`.
+        wrapped in a :class:`openmm.unit.Unit`.
     """
 
     if snapshot.statics is not None:
@@ -79,7 +79,7 @@ def box_vectors(snapshot):
     -------
     box_vectors: numpy.ndarray, shape=(3, 3), dtype=numpy.float32
         the box_vectors of the configuration. The coordinates are wrapped in a
-        simtk.unit.Unit.
+        openmm.unit.Unit.
     """
     if snapshot.statics is not None:
         return unmask_quantity(snapshot.statics.box_vectors)
@@ -125,7 +125,7 @@ def xyz(snapshot):
         atomic coordinates without dimensions. Be careful.
 
     """
-    import simtk.unit as u
+    from openpathsampling.integration_tools import unit as u
 
     coord = snapshot.coordinates
     if type(coord) is u.Quantity:

--- a/openpathsampling/engines/gromacs/__init__.py
+++ b/openpathsampling/engines/gromacs/__init__.py
@@ -1,9 +1,9 @@
 def requires_mdtraj(*args, **kwargs):  # pragma: no cover
     raise RuntimeError("This requires MDTraj, which is not installed")
 
-try:
-    import mdtraj
-except ImportError:
+from openpathsampling.integration_tools import HAS_MDTRAJ
+
+if not HAS_MDTRAJ:
     Engine = requires_mdtraj
     ExternalMDSnapshot = requires_mdtraj
     snapshot_from_gro = requires_mdtraj

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -9,8 +9,9 @@ intermediary to monitor when a path needs to be terminated.
 import logging
 logger = logging.getLogger(__name__)
 
-from mdtraj.formats import TRRTrajectoryFile
-import mdtraj as md
+from openpathsampling.integration_tools import md, HAS_MDTRAJ
+if HAS_MDTRAJ:
+    from mdtraj.formats import TRRTrajectoryFile
 
 from openpathsampling.engines import ExternalEngine
 from openpathsampling.engines import features

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 from openpathsampling.integration_tools import md, HAS_MDTRAJ
 if HAS_MDTRAJ:
-    from mdtraj.formats import TRRTrajectoryFile
+    TRRTrajectoryFile = md.formats.TRRTrajectoryFile
 
 from openpathsampling.engines import ExternalEngine
 from openpathsampling.engines import features

--- a/openpathsampling/engines/openmm/__init__.py
+++ b/openpathsampling/engines/openmm/__init__.py
@@ -1,10 +1,9 @@
 def missing_openmm(*args, **kwargs):
     raise RuntimeError("Install OpenMM to use this feature")
 
-try:
-    import simtk.openmm
-    import simtk.openmm.app
-except ImportError:
+from openpathsampling.integration_tools import HAS_OPENMM
+
+if not HAS_OPENMM:
     HAS_OPENMM = False
     Engine = missing_openmm
     empty_snapshot_from_openmm_topology = missing_openmm

--- a/openpathsampling/engines/openmm/__init__.py
+++ b/openpathsampling/engines/openmm/__init__.py
@@ -4,7 +4,6 @@ def missing_openmm(*args, **kwargs):
 from openpathsampling.integration_tools import HAS_OPENMM
 
 if not HAS_OPENMM:
-    HAS_OPENMM = False
     Engine = missing_openmm
     empty_snapshot_from_openmm_topology = missing_openmm
     snapshot_from_pdb = missing_openmm

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -1,8 +1,7 @@
 import logging
 
-import simtk.openmm
-import simtk.openmm.app
-import simtk.unit as u
+from openpathsampling.integration_tools import openmm
+from openpathsampling.integration_tools import unit as u
 
 from openpathsampling.engines import DynamicsEngine, SnapshotDescriptor
 from openpathsampling.engines.openmm import tools
@@ -53,9 +52,9 @@ def restore_custom_integrator_interface(integrator):
 
 
 class OpenMMEngine(DynamicsEngine):
-    """OpenMM dynamics engine based on 'simtk.openmm` system and integrator.
+    """OpenMM dynamics engine based on OpenMM system and integrator.
 
-    The engine will create a :class:`simtk.openmm.app.Simulation` instance
+    The engine will create a :class:`openmm.app.Simulation` instance
     and uses this to generate new frames.
 
     """
@@ -86,9 +85,9 @@ class OpenMMEngine(DynamicsEngine):
         topology : openpathsampling.engines.topology.MDTrajTopology
             a template snapshots which provides the topology object to be used
             to create the openmm engine
-        system : simtk.openmm.app.System
+        system : openmm.app.System
             the openmm system object
-        integrator : simtk.openmm.Integrator
+        integrator : openmm.Integrator
             the openmm integrator object
         openmm_properties : dict
             optional setting for creating the openmm simuation object. Typical
@@ -158,7 +157,7 @@ class OpenMMEngine(DynamicsEngine):
 
         Parameters
         ----------
-        integrator : simtk.openmm.Integrator
+        integrator : openmm.Integrator
             the openmm integrator object
         openmm_properties : dict
             optional setting for creating the openmm simuation object. Typical
@@ -264,7 +263,7 @@ class OpenMMEngine(DynamicsEngine):
 
         Parameters
         ----------
-        platform : str or `simtk.openmm.Platform` or None
+        platform : str or :class:`openmm.Platform` or None
             either a string with a name of the platform or a platform object
             if None it will default to the fastest currently available platform
 
@@ -279,22 +278,22 @@ class OpenMMEngine(DynamicsEngine):
 
         if self._simulation is None:
             if type(platform) is str:
-                self._simulation = simtk.openmm.app.Simulation(
+                self._simulation = openmm.app.Simulation(
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
                     integrator=self.integrator,
-                    platform=simtk.openmm.Platform.getPlatformByName(platform),
+                    platform=openmm.Platform.getPlatformByName(platform),
                     platformProperties=self.openmm_properties
                 )
             elif platform is None:
-                self._simulation = simtk.openmm.app.Simulation(
+                self._simulation = openmm.app.Simulation(
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
                     integrator=self.integrator,
                     platformProperties=self.openmm_properties
                 )
             else:
-                self._simulation = simtk.openmm.app.Simulation(
+                self._simulation = openmm.app.Simulation(
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
                     integrator=self.integrator,
@@ -309,13 +308,13 @@ class OpenMMEngine(DynamicsEngine):
     @staticmethod
     def available_platforms():
         return [
-            simtk.openmm.Platform.getPlatform(platform_idx).getName()
-            for platform_idx in range(simtk.openmm.Platform.getNumPlatforms())
+            openmm.Platform.getPlatform(platform_idx).getName()
+            for platform_idx in range(openmm.Platform.getNumPlatforms())
         ]
 
     def to_dict(self):
-        system_xml = simtk.openmm.XmlSerializer.serialize(self.system)
-        integrator_xml = simtk.openmm.XmlSerializer.serialize(self.integrator)
+        system_xml = openmm.XmlSerializer.serialize(self.system)
+        integrator_xml = openmm.XmlSerializer.serialize(self.integrator)
 
         return {
             'system_xml': system_xml,
@@ -337,11 +336,11 @@ class OpenMMEngine(DynamicsEngine):
         properties = {str(key): str(value)
                       for key, value in properties.items()}
 
-        integrator = simtk.openmm.XmlSerializer.deserialize(integrator_xml)
+        integrator = openmm.XmlSerializer.deserialize(integrator_xml)
         integrator = restore_custom_integrator_interface(integrator)
         return OpenMMEngine(
             topology=topology,
-            system=simtk.openmm.XmlSerializer.deserialize(system_xml),
+            system=openmm.XmlSerializer.deserialize(system_xml),
             integrator=integrator,
             options=options,
             openmm_properties=properties
@@ -360,13 +359,13 @@ class OpenMMEngine(DynamicsEngine):
 
         # Parameters
         # ----------
-        # item : simtk.unit.Quantity or iterable of simtk.unit.Quantity
+        # item : unit.Quantity or iterable of unit.Quantity
             # the input with units
 
         # Returns
         # -------
         # float or iterable
-            # resulting value in the simtk.units.md_unit_system, but without
+            # resulting value in the unit.md_unit_system, but without
             # units attached
         # """
         # try:

--- a/openpathsampling/engines/openmm/features/__init__.py
+++ b/openpathsampling/engines/openmm/features/__init__.py
@@ -1,9 +1,6 @@
-try:
-    import simtk.openmm
-    import simtk.openmm.app
-except ImportError:
-    pass
-else:
+from openpathsampling.integration_tools import HAS_OPENMM
+
+if HAS_OPENMM:
     from openpathsampling.engines.features import *
     from openpathsampling.engines.features.shared import StaticContainer, KineticContainer
     from . import masses

--- a/openpathsampling/engines/openmm/features/instantaneous_temperature.py
+++ b/openpathsampling/engines/openmm/features/instantaneous_temperature.py
@@ -1,5 +1,5 @@
-import simtk.openmm as mm
-import simtk.unit as u
+from openpathsampling.integration_tools import openmm as mm
+from openpathsampling.integration_tools import unit as u
 
 @property
 def n_degrees_of_freedom(snapshot):
@@ -17,7 +17,7 @@ def instantaneous_temperature(snapshot):
     """
     Returns
     -------
-    instantaneous_temperature : simtk.unit.Quantity (temperature)
+    instantaneous_temperature : openmm.unit.Quantity (temperature)
         instantaneous temperature from the kinetic energy of this snapshot
     """
     # TODO: this can be generalized as a feature that works with any

--- a/openpathsampling/engines/openmm/features/masses.py
+++ b/openpathsampling/engines/openmm/features/masses.py
@@ -1,4 +1,4 @@
-import simtk.unit as u
+from openpathsampling.integration_tools import unit as u
 import numpy as np
 
 @property
@@ -6,8 +6,8 @@ def masses_per_mole(snapshot):
     """
     Returns
     -------
-    masses_per_mole : list of simtk.unit.Quantity with length n_atoms
-        atomic masses (with simtk.unit attached) in units of mass/mole
+    masses_per_mole : list of openmm.unit.Quantity with length n_atoms
+        atomic masses (with openmm.unit attached) in units of mass/mole
     """
     try:
         simulation = snapshot.engine.simulation
@@ -35,8 +35,8 @@ def masses(snapshot):
     """
     Returns
     -------
-    masses : list of simtk.unit.Quantity with length n_atoms
-        atomic masses (with simtk.unit attached) in units of mass
+    masses : list of openmm.unit.Quantity with length n_atoms
+        atomic masses (with openmm.unit attached) in units of mass
     """
     masses_per_mole = snapshot.masses_per_mole
     masses = masses_per_mole / u.AVOGADRO_CONSTANT_NA

--- a/openpathsampling/engines/openmm/features/traj_quantities.py
+++ b/openpathsampling/engines/openmm/features/traj_quantities.py
@@ -1,5 +1,5 @@
 import numpy as np
-from simtk import unit
+from openpathsampling.integration_tools import unit
 
 functions = ['trajectory_coordinates', 'trajectory_box_vectors',
              'trajectory_velocities']
@@ -9,7 +9,7 @@ def _trajectory_units(traj, feature, unit_):
         try:
             obj = obj.value_in_unit(unit_)
         except AttributeError:
-            pass  # not a simtk.unit.Quantity
+            pass  # not an openmm.unit.Quantity
         return obj
 
     vals = [getattr(snap, feature) for snap in traj]

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -13,7 +13,7 @@ if HAS_OPENMM:
     from openpathsampling.engines.topology import Topology, MDTrajTopology
     try:
         # openmm >= 7.6
-        _internal = openmm.app.internal
+        from openmm.app import internal as _internal
     except AttributeError:
         # openmm < 7.6
         from simtk.openmm.app import internal as _internal

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -14,7 +14,7 @@ if HAS_OPENMM:
     try:
         # openmm >= 7.6
         from openmm.app import internal as _internal
-    except AttributeError:
+    except ImportError:
         # openmm < 7.6
         from simtk.openmm.app import internal as _internal
 

--- a/openpathsampling/engines/openmm/tools.py
+++ b/openpathsampling/engines/openmm/tools.py
@@ -11,7 +11,13 @@ if HAS_OPENMM:
     # them from being made)
     from .snapshot import Snapshot
     from openpathsampling.engines.topology import Topology, MDTrajTopology
-    _internal = openmm.app.internal
+    try:
+        # openmm >= 7.6
+        _internal = openmm.app.internal
+    except AttributeError:
+        # openmm < 7.6
+        from simtk.openmm.app import internal as _internal
+
     reducePeriodicBoxVectors = _internal.unitcell.reducePeriodicBoxVectors
 
 

--- a/openpathsampling/engines/topology.py
+++ b/openpathsampling/engines/topology.py
@@ -2,11 +2,7 @@ import numpy as np
 import pandas as pd
 
 from openpathsampling.netcdfplus import StorableNamedObject
-from openpathsampling.integration_tools import error_if_no_mdtraj
-try:
-    import mdtraj as md
-except ImportError:
-    pass
+from openpathsampling.integration_tools import error_if_no_mdtraj, md
 
 import logging
 logger = logging.getLogger(__name__)

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -4,16 +4,13 @@ from openpathsampling.experimental.simstore.attribute_handlers import (
 )
 import re
 
-try:
-    import simtk.unit
-except ImportError:
-    HAS_SIMTK = False
-else:
-    HAS_SIMTK = True
+from openpathsampling.integration_tools import HAS_SIMTK, unit
+
+if HAS_SIMTK:
     # note that we need to force simstore to not treat this as an iterable
     from openpathsampling.experimental.simstore.class_lookup import \
         is_storage_iterable
-    is_storage_iterable.force_false(simtk.unit.Quantity)
+    is_storage_iterable.force_false(unit.Quantity)
 
 ### JSON SERIALIZATION ###################################################
 
@@ -22,9 +19,9 @@ def unit_to_dict(obj):
             for p, power in obj.iter_base_or_scaled_units()}
 
 def unit_from_dict(dct):
-    unit = simtk.unit.Unit({})
+    unit = unit.Unit({})
     for u_name, u_power in dct.items():
-        unit *= getattr(simtk.unit, u_name) ** u_power
+        unit *= getattr(unit, u_name) ** u_power
     return unit
 
 def quantity_to_dict(obj):
@@ -38,7 +35,7 @@ def quantity_from_dict(dct):
 
 if HAS_SIMTK:
     simtk_quantity_codec = JSONCodec(
-        cls=simtk.unit.Quantity,
+        cls=unit.Quantity,
         to_dict=quantity_to_dict,
         from_dict=quantity_from_dict,
         is_my_dict=lambda x: '__simtk_unit__' in x
@@ -51,7 +48,6 @@ _simtk_re = re.compile(r"simtk\((.*)\)\*((ndarray|float).*)")
 def simtk_unit_from_string(unit_str):
     # TODO: add safety checks; parse the AST and ensure that all attributes
     # are of `unit` and that all operations are mul/div/pow
-    from simtk import unit
     return eval(unit_str, {'unit': unit})
 
 

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -4,9 +4,9 @@ from openpathsampling.experimental.simstore.attribute_handlers import (
 )
 import re
 
-from openpathsampling.integration_tools import HAS_SIMTK, unit
+from openpathsampling.integration_tools import HAS_SIMTK_UNIT, unit
 
-if HAS_SIMTK:
+if HAS_SIMTK_UNIT:
     # note that we need to force simstore to not treat this as an iterable
     from openpathsampling.experimental.simstore.class_lookup import \
         is_storage_iterable
@@ -33,7 +33,7 @@ def quantity_from_dict(dct):
     return dct['value'] * unit
 
 
-if HAS_SIMTK:
+if HAS_SIMTK_UNIT:
     simtk_quantity_codec = JSONCodec(
         cls=unit.Quantity,
         to_dict=quantity_to_dict,

--- a/openpathsampling/experimental/storage/simtk_unit.py
+++ b/openpathsampling/experimental/storage/simtk_unit.py
@@ -19,18 +19,18 @@ def unit_to_dict(obj):
             for p, power in obj.iter_base_or_scaled_units()}
 
 def unit_from_dict(dct):
-    unit = unit.Unit({})
+    units = unit.Unit({})
     for u_name, u_power in dct.items():
-        unit *= getattr(unit, u_name) ** u_power
-    return unit
+        units *= getattr(unit, u_name) ** u_power
+    return units
 
 def quantity_to_dict(obj):
     return {'value': obj.value_in_unit(obj.unit),
             '__simtk_unit__': unit_to_dict(obj.unit)}
 
 def quantity_from_dict(dct):
-    unit = unit_from_dict(dct['__simtk_unit__'])
-    return dct['value'] * unit
+    units = unit_from_dict(dct['__simtk_unit__'])
+    return dct['value'] * units
 
 
 if HAS_SIMTK_UNIT:
@@ -73,9 +73,9 @@ class SimtkQuantityHandler(AttributeHandler):
     def is_my_type(type_str):
         m_simtk_quantity = _simtk_re.match(type_str)
         if m_simtk_quantity:
-            unit = m_simtk_quantity.group(1)
+            units = m_simtk_quantity.group(1)
             wrapped_type = m_simtk_quantity.group(2)
-            return unit, wrapped_type
+            return units, wrapped_type
 
     def serialize(self, obj):
         unwrapped = obj.value_in_unit(self.unit)

--- a/openpathsampling/experimental/storage/test_simtk_unit.py
+++ b/openpathsampling/experimental/storage/test_simtk_unit.py
@@ -12,7 +12,7 @@ from openpathsampling.integration_tools import HAS_SIMTK_UNIT, unit
 
 class TestSimtkUnitCodec(object):
     def setup(self):
-        if not HAS_SIMTK:
+        if not HAS_SIMTK_UNIT:
             pytest.skip("openmm.unit not installed")
         my_unit = unit.nanometer / unit.picosecond**2
         self.values = {

--- a/openpathsampling/experimental/storage/test_simtk_unit.py
+++ b/openpathsampling/experimental/storage/test_simtk_unit.py
@@ -8,16 +8,12 @@ from ..storage import Storage
 
 from .simtk_unit import *
 
-try:
-    from simtk import unit
-except ImportError:
-    HAS_SIMTK = False
-else:
-    HAS_SIMTK = True
+from openpathsampling.integration_tools import HAS_SIMTK_UNIT, unit
 
 class TestSimtkUnitCodec(object):
     def setup(self):
-        pytest.importorskip('simtk.unit')
+        if not HAS_SIMTK:
+            pytest.skip("openmm.unit not installed")
         my_unit = unit.nanometer / unit.picosecond**2
         self.values = {
             'float': 1.0 * my_unit,

--- a/openpathsampling/integration_tools.py
+++ b/openpathsampling/integration_tools.py
@@ -50,12 +50,12 @@ def error_if_no_simtk_unit(name):
 try:
     # MDTraj currently imports OpenMM from the simtk namespace, leading
     # to warnings being issued that we can't control (and cause our
-    # notebook tests for fail)
-    logger = logging.getLogger()
-    level = logger.level
-    logger.setLevel(logging.ERROR)
+    # notebook tests for fail). So we need to disable here.
+    logging.disable(logging.WARNING)
     import mdtraj as md
-    logger.setLevel(level)
+    logging.disable(logging.NOTSET)
+    # The problem with this is that it will shadow any remaining places
+    # we're having this problem -- the simtk import is only done once.
 except ImportError:
     md = None
     HAS_MDTRAJ = False

--- a/openpathsampling/integration_tools.py
+++ b/openpathsampling/integration_tools.py
@@ -3,6 +3,7 @@ Tools for integration with miscellaneous non-required packages.
 """
 
 import importlib
+import logging
 
 
 def error_if_no(name, package_name, has_package):
@@ -27,7 +28,6 @@ def _chain_import(*packages):
     # we raise the last error given
     raise error
 
-
 # openmm.unit ########################################################
 try:
     unit = _chain_import('openmm.unit', 'simtk.unit')
@@ -48,7 +48,14 @@ def error_if_no_simtk_unit(name):
 
 # mdtraj ############################################################
 try:
+    # MDTraj currently imports OpenMM from the simtk namespace, leading
+    # to warnings being issued that we can't control (and cause our
+    # notebook tests for fail)
+    logger = logging.getLogger()
+    level = logger.level
+    logger.setLevel(logging.ERROR)
     import mdtraj as md
+    logger.setLevel(level)
 except ImportError:
     md = None
     HAS_MDTRAJ = False

--- a/openpathsampling/integration_tools.py
+++ b/openpathsampling/integration_tools.py
@@ -28,10 +28,9 @@ def _chain_import(*packages):
     raise error
 
 
-# simtk.unit ########################################################
+# openmm.unit ########################################################
 try:
     unit = _chain_import('openmm.unit', 'simtk.unit')
-    # from simtk import unit
 except ImportError:
     unit = None
     is_simtk_quantity = lambda obj: False
@@ -62,7 +61,6 @@ def error_if_no_mdtraj(name):
 # openmm ############################################################
 try:
     openmm = _chain_import('openmm', 'simtk.openmm')
-    # from simtk import openmm
 except ImportError:
     openmm = None
     HAS_OPENMM = False

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -86,6 +86,8 @@ class ObjectJSON(object):
         'simtk',
         'simtk.unit',
         'simtk.openmm'
+        'openmm',
+        'openmm.unit',
     ]
 
     def __init__(self, unit_system=None):
@@ -139,7 +141,6 @@ class ObjectJSON(object):
                 '_integer': str(obj)}
 
         elif obj.__class__.__module__ != builtin_module:
-            #if obj.__class__ is units.Quantity:
             if is_simtk_quantity(obj):
                 # This is number with a unit so turn it into a list
                 if self.unit_system is not None:
@@ -326,7 +327,7 @@ class ObjectJSON(object):
 
     @staticmethod
     def unit_from_dict(unit_dict):
-        # this will *only* work if simtk.unit is installed
+        # this will *only* work if openmm.unit is installed
         this_unit = unit.Unit({})
         for unit_name, unit_multiplication in unit_dict.items():
             this_unit *= getattr(unit, unit_name) ** unit_multiplication

--- a/openpathsampling/netcdfplus/netcdfplus.py
+++ b/openpathsampling/netcdfplus/netcdfplus.py
@@ -21,12 +21,8 @@ if sys.version_info > (3, ):
 logger = logging.getLogger(__name__)
 init_log = logging.getLogger('openpathsampling.initialization')
 
-try:
-    from simtk import unit as u
-except ImportError:
-    HAS_SIMTK_UNIT = False
-else:
-    HAS_SIMTK_UNIT = True
+from openpathsampling.integration_tools import unit as u
+from openpathsampling.integration_tools import HAS_SIMTK_UNIT
 
 
 # ==============================================================================
@@ -111,9 +107,7 @@ class NetCDFPlus(netCDF4.Dataset):
             self.getter = getter
             self.setter = setter
 
-            try:
-                from simtk import unit as u
-            except ImportError:
+            if not HAS_SIMTK_UNIT:
                 self.support_simtk_unit = False
 
         def __setitem__(self, key, value):
@@ -320,7 +314,7 @@ class NetCDFPlus(netCDF4.Dataset):
 
             self.stores.restore()
 
-            # Create a dict of simtk.Unit() instances for all netCDF.Variable()
+            # Create a dict of openmm.Unit() instances for all netCDF.Variable()
             for variable_name in self.variables:
                 variable = self.variables[variable_name]
 
@@ -1003,7 +997,6 @@ class NetCDFPlus(netCDF4.Dataset):
                     unit = self.units[var_name]
 
                     def _get(my_getter):
-                        import simtk.unit as u
                         if my_getter is None:
                             return lambda v: u.Quantity(v, unit)
                         else:
@@ -1158,8 +1151,6 @@ class NetCDFPlus(netCDF4.Dataset):
 
         if self.support_simtk_unit and simtk_unit is not None:
 
-            import simtk.unit as u
-
             if isinstance(simtk_unit, u.Unit):
                 unit_instance = simtk_unit
                 symbol = unit_instance.get_symbol()
@@ -1243,14 +1234,10 @@ class NetCDFPlus(netCDF4.Dataset):
         test_type = value
 
         if NetCDFPlus.support_simtk_unit:
-            import simtk.unit as u
-
             if type(test_type) is u.Quantity:
                 # could be a Quantity([..])
                 simtk_unit = test_type.unit
                 test_type = test_type._value
-        else:
-            u = None
 
         if type(test_type) is np.ndarray:
             dimensions = test_type.shape

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -124,7 +124,7 @@ class RandomVelocities(SnapshotModifier):
     are all in the same unit system. In particular, ``1.0 / beta * masses``
     must be in units of ``velocity**2``.
 
-    For the OpenMMEngine, for example (after ``from simtk import unit as
+    For the OpenMMEngine, for example (after ``from openmm import unit as
     u``), the ``beta`` parameter for 300 K would be created with
 
     .. code-block:: python
@@ -133,7 +133,7 @@ class RandomVelocities(SnapshotModifier):
 
     Parameters
     ----------
-    beta : float or simtk.unit.Quantity
+    beta : float or openmm.unit.Quantity
         inverse temperature (including kB) for the distribution
     engine : :class:`.DynamicsEngine` or None
         engine to be used for constraints; if None, use the snapshot's
@@ -394,7 +394,7 @@ class GeneralizedDirectionModifier(SnapshotModifier):
             velocities adjusted to have the desired kinetic energy
         """
         # from here, we're doing the KE rescaling
-        # can't just use the dot product because of simtk.units
+        # can't just use the dot product because of openmm.unit
         momenta = velocities * masses[:, np.newaxis]
         dof_ke = momenta * velocities
         zero_energy = 0 * dof_ke[0][0]

--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -11,11 +11,7 @@ from openpathsampling.engines import NoEngine
 import numpy as np
 import numpy.testing as npt
 
-try:
-    import simtk.unit as u
-except ImportError:
-    u = None
-
+from openpathsampling.integration_tools import unit as u
 from openpathsampling.integration_tools import is_simtk_quantity_type
 
 try:

--- a/openpathsampling/tests/test_integration_tools.py
+++ b/openpathsampling/tests/test_integration_tools.py
@@ -12,5 +12,5 @@ def test_chain_import(modules):
     assert mod is os.path
 
 def test_chain_import_error():
-    with pytest.raises(ImportError):
+    with pytest.raises(ImportError, match="bar"):
         _chain_import('foo', 'bar')

--- a/openpathsampling/tests/test_integration_tools.py
+++ b/openpathsampling/tests/test_integration_tools.py
@@ -1,0 +1,16 @@
+import pytest
+
+from openpathsampling.integration_tools import _chain_import
+
+@pytest.mark.parametrize('modules', [
+    ('foo', 'os.path'),
+    ('os.path', 'foo')
+])
+def test_chain_import(modules):
+    import os.path
+    mod = _chain_import(*modules)
+    assert mod is os.path
+
+def test_chain_import_error():
+    with pytest.raises(ImportError):
+        _chain_import('foo', 'bar')

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -11,12 +11,13 @@ from past.utils import old_div
 import numpy as np
 from nose.tools import (assert_equal)
 from nose.plugins.skip import SkipTest
-try:
-    import simtk.openmm as mm
-    from simtk.openmm import app
-except ImportError:
-    mm = None
+
+from openpathsampling.integration_tools import openmm as mm
+
+if mm is None:
     app = None
+else:
+    app = mm.app
 
 import openpathsampling.engines.openmm as peng
 import openpathsampling.engines as dyn

--- a/openpathsampling/tests/test_openmm_tools.py
+++ b/openpathsampling/tests/test_openmm_tools.py
@@ -21,14 +21,11 @@ from .test_helpers import data_filename
 
 from openpathsampling.engines.openmm import Snapshot
 from openpathsampling.integration_tools import HAS_OPENMM, HAS_MDTRAJ
+from openpathsampling.integration_tools import unit, HAS_SIMTK_UNIT
 
-try:
-    from simtk.unit import nanometer as nm
-    from simtk.unit import picosecond as ps
-except ImportError:
-    HAS_SIMTK_UNIT = False
-else:
-    HAS_SIMTK_UNIT = True
+if HAS_SIMTK_UNIT:
+    nm = unit.nanometer
+    ps = unit.picosecond
 
 import numpy.testing as npt
 import numpy as np

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -276,7 +276,7 @@ class TestGeneralizedDirectionModifier(object):
         if not omt:
             raise SkipTest("Requires OpenMMTools (not installed)")
         if not u:
-            raise SkipTest("Requires simtk.unit (not installed)")
+            raise SkipTest("Requires openmm.unit (not installed)")
         u_vel = old_div(u.nanometer, u.picosecond)
         self.openmm_modifier = GeneralizedDirectionModifier(1.2 * u_vel)
         ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)

--- a/openpathsampling/tests/test_volume.py
+++ b/openpathsampling/tests/test_volume.py
@@ -13,12 +13,8 @@ from .test_helpers import (CallIdentity, raises_with_message_like,
 import unittest
 import pytest
 import numpy as np
-try:
-    from simtk import unit
-except ImportError:
-    HAS_SIMTK_UNIT = False
-else:
-    HAS_SIMTK_UNIT = True
+
+from openpathsampling.integration_tools import unit, HAS_SIMTK_UNIT
 
 import openpathsampling.volume as volume
 
@@ -173,7 +169,7 @@ class TestCVDefinedVolume(object):
     def test_unit_support(self):
         if not paths.integration_tools.HAS_SIMTK_UNIT:
             raise SkipTest
-        import simtk.unit as u
+        u = unit
 
         vol = volume.CVDefinedVolume(
             op_id, -0.5 * u.nanometers, 0.25 * u.nanometers)
@@ -200,7 +196,7 @@ class TestCVDefinedVolume(object):
             'array1': lambda s: np.array([1.0]),
             'simtk': None
         }[inp]
-        if func is None:  # only if simtk
+        if func is None:  # only if inp is 'simtk'
             func = lambda s: 1.0 * unit.nanometers
 
         cv = paths.FunctionCV('cv', func)

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -403,7 +403,7 @@ class CVDefinedVolume(Volume):
 
     def _is_iterable(self, val):
         try:
-            # simtk.Quantity erroneously allows iter, so use len
+            # openmm.Quantity erroneously allows iter, so use len
             # besides, CVs shouldn't return generators
             _ = len(val)
         except TypeError:
@@ -425,7 +425,7 @@ class CVDefinedVolume(Volume):
 
         # we explicitly test for infinity to allow the user to
         # define `lambda_min/max='inf'` also when using units
-        # a simtk unit cannot be compared to a python infinite float
+        # an openmm unit cannot be compared to a python infinite float
         if self.lambda_min != float('-inf') and self.lambda_min > l:
             return False
 
@@ -489,8 +489,8 @@ class PeriodicCVDefinedVolume(CVDefinedVolume):
         """Wraps `value` into the periodic domain."""
 
         # this looks strange and mimics the modulo operation `%` while
-        # being fully compatible for simtk numbers and plain python as well
-        # working for ints and floats.
+        # being fully compatible for openmm quantities and plain python as
+        # well working for ints and floats.
         val = value - self._period_shift
 
         # little trick to check for positivity without knowing the the units


### PR DESCRIPTION
Good news: the [GitHub action I wrote](https://github.com/marketplace/actions/check-conda-for-release-candidates) to automatically test against OpenMM release candidates works! The tests ran against the newest RC.

Bad news: we explode with errors on the 7.6 RC. This is because the OpenMM import has moved out of the `simtk` namespace (so it is now correct to do `import openmm`; `import openmm.unit`). The old imports still work for the `simtk.openmm`, `simtk.openmm.app`, and `simtk.unit` namespaces. However, we were also using some OpenMM internals (specifically, `simtk.openmm.app.internal.unitcell.reducePeriodicBoxVectors`.) Importing from these does not work.

This PR fixes that, and makes the non-`simtk` import the preferred choice.