### PR TITLE
Prevent non-string names in StorableNamedObject

### DIFF
--- a/openpathsampling/netcdfplus/base.py
+++ b/openpathsampling/netcdfplus/base.py
@@ -7,6 +7,7 @@ from types import MethodType
 import sys
 if sys.version_info > (3, ):
     long = int
+    unicode = str
 
 logger = logging.getLogger(__name__)
 
@@ -413,12 +414,15 @@ class StorableNamedObject(StorableObject):
                 'Objects cannot be renamed to `%s` after is has been saved, '
                 'it is already named `%s`') %
                 (name, self._name))
-        else:
-            if name != self._name:
-                self._name = name
-                logger.debug(
-                    'Nameable object is renamed from `%s` to `%s`' %
-                    (self._name, name))
+
+        if not isinstance(name, (unicode, str)):
+            raise TypeError("Invalid name type: " + type(name).__name__)
+
+        if name != self._name:
+            self._name = name
+            logger.debug(
+                'Nameable object is renamed from `%s` to `%s`' %
+                (self._name, name))
 
     @property
     def is_named(self):

--- a/openpathsampling/tests/test_netcdfplus_base.py
+++ b/openpathsampling/tests/test_netcdfplus_base.py
@@ -1,0 +1,18 @@
+import pytest
+
+from openpathsampling.netcdfplus.base import *
+
+class TestStorableNamedObject(object):
+    def setup(self):
+        self.obj = StorableNamedObject()
+
+    def test_named(self):
+        assert not self.obj.is_named
+        obj = self.obj.named('foo')
+        assert obj is self.obj
+        assert self.obj.is_named
+        assert self.obj.name == 'foo'
+
+    def test_bad_name_type(self):
+        with pytest.raises(TypeError, match="Invalid name type"):
+            self.obj.named(1)


### PR DESCRIPTION
Objects in OPS can be named. These names should always be strings. This PR causes a `TypeError` to be raised if a non-string is assigned as the `name` of a `StorableNamedObject`.

Some context in discussion of https://github.com/openpathsampling/openpathsampling/pull/1050.