### PR TITLE
Remove engine binary after tests

### DIFF
--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -87,6 +87,8 @@ def teardown_module():
     # proc.wait()
     for testfile in glob.glob("test*out") + glob.glob("test*inp"):
         os.remove(testfile)
+    engine_binary = os.path.join(engine_dir, "engine")
+    os.remove(engine_binary)
 
 
 class TestExternalEngine(object):

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -83,12 +83,11 @@ def setup_module():
 
 
 def teardown_module():
-    # proc = psutil.Popen("make clean", cwd=engine_dir, shell=True)
-    # proc.wait()
+    # Delete compilation files
+    proc = psutil.Popen(["make", "clean"], cwd=engine_dir)
+    proc.wait()
     for testfile in glob.glob("test*out") + glob.glob("test*inp"):
         os.remove(testfile)
-    engine_binary = os.path.join(engine_dir, "engine")
-    os.remove(engine_binary)
 
 
 class TestExternalEngine(object):


### PR DESCRIPTION
@bdice identified an issue with our tests leaving files around after running the test. This is bad test design and should be avoided.

This PR fixes the offending test