### PR TITLE
Limit nightly CI and release/deployment CI to the base repository (not forks).

### DIFF
--- a/.github/workflows/autorelease-deploy.yml
+++ b/.github/workflows/autorelease-deploy.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   deploy_pypi:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Deploy to PyPI"
     steps:

--- a/.github/workflows/autorelease-gh-rel.yml
+++ b/.github/workflows/autorelease-gh-rel.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release-gh:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Cut release"
     steps:

--- a/.github/workflows/autorelease-prep.yml
+++ b/.github/workflows/autorelease-prep.yml
@@ -12,6 +12,7 @@ defaults:
 
 jobs:
   deploy_testpypi:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Deployment test"
     steps:
@@ -47,6 +48,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
         name: "Deploy to testpypi"
   test_testpypi:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Test deployed"
     needs: deploy_testpypi

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   docs:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "docs"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   tests:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Tests"
     strategy:


### PR DESCRIPTION
See issue #1061. This prevents forks from running nightly CI on the primary branches, which should only be needed in the base repository.

Maintainers: feel free to push to this branch directly, or make a copy of this branch on the base repo `openpathsampling/openpathsampling` if needed for testing purposes. It is hard to test scheduled CI triggers but I think this should work since I based it on other GitHub workflows.