### PR TITLE
Add CITATIONS.md

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,0 +1,14 @@
+OPS was described in a pair of papers published in JCTC:
+
+1. David W.H. Swenson, Jan-Hendrik Prinz, Frank Noé, John D. Chodera, and
+   Peter G. Bolhuis. "OpenPathSampling: A flexible, open framework for path
+   sampling simulations. 1. Basics." J. Chem. Theory Comput. **15**, 813
+   (2019).
+   https://doi.org/10.1021/acs.jctc.8b00626
+2. David W.H. Swenson, Jan-Hendrik Prinz, Frank Noé, John D. Chodera, and
+   Peter G. Bolhuis. "OpenPathSampling: A flexible, open framework for path
+   sampling simulations. 2. Building and Customizing Path Ensembles and
+   Sample Schemes." J. Chem. Theory Comput. **15**, 837 (2019).
+   https://doi.org/10.1021/acs.jctc.8b00627
+
+Both citations: [openpathsampling.bib](https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/docs/openpathsampling.bib) (citation keys ``ops1`` and ``ops2``).

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,4 +1,4 @@
-OPS was described in a pair of papers published in JCTC:
+OpenPathSampling was described in a pair of papers published in JCTC:
 
 1. David W.H. Swenson, Jan-Hendrik Prinz, Frank Noé, John D. Chodera, and
    Peter G. Bolhuis. "OpenPathSampling: A flexible, open framework for path


### PR DESCRIPTION
closes #1063 

The current [citation file format](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md) does not seems to be able to handle more than 1 citation and OPS is normally cited with 2 (at least for 1.x)

However, github allows for [other citation files](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files#other-citation-files) which are then be linked to (I still have to check in what way exactly)

I therefor opted to go for the current text on the website about citation, but altered it to markdown instead of rst