### PR TITLE
improvements to unpatch after using SimStore

### DIFF
--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -57,6 +57,13 @@ _PREPATCH = {
     ]
 }
 
+_UNPATCH_MODULES = [
+    paths.netcdfplus,
+    paths.collectivevariable,
+    paths.collectivevariables,
+    paths
+]
+
 def monkey_patch_saving(paths):
     paths.netcdfplus.FunctionPseudoAttribute.to_dict = \
             function_pseudo_attribute_to_dict
@@ -93,8 +100,11 @@ def unpatch(paths):
     for cls, old in _PREPATCH.items():
         cls.to_dict = old['to']
         cls.from_dict = old['from']
-    importlib.reload(paths.netcdfplus)
-    importlib.reload(paths.collectivevariable)
-    importlib.reload(paths.collectivevariables)
-    importlib.reload(paths)
+
+    # we loop over the modules twice as quick-and-dirty solution to avoid
+    # figuring the DAG topological order for imports (should actually in
+    # order leaf to root)
+    for module in _UNPATCH_MODULES * 2:
+        importlib.reload(module)
+
     return paths

--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -93,4 +93,8 @@ def unpatch(paths):
     for cls, old in _PREPATCH.items():
         cls.to_dict = old['to']
         cls.from_dict = old['from']
+    importlib.reload(paths.netcdfplus)
+    importlib.reload(paths.collectivevariable)
+    importlib.reload(paths.collectivevariables)
+    importlib.reload(paths)
     return paths


### PR DESCRIPTION
There's an `unpatch` method in the `monkey_patches` to undo the patches that tell OPS that you'll be using SimStore. This generally isn't used by users (who tend to be either fully in SimStore or fully not, at least within a given session), but it is important for unit testing.

This PR adds some `importlib.reload` commands that are required to fully undo the patch.