### PR TITLE
Switch CI install to mamba

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           if [ -z "$MINIMAL" ] ; then
             source devtools/conda_install_reqs.sh
+            python -m pip install nose pytest pytest-cov coveralls nbval
           else
             python -m pip install -r devtools/minimal.txt \
                                   -r devtools/minimal_testing.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
-          - 2.7
+          #- 2.7
         MINIMAL: [""]
         include:
           - CONDA_PY: 3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,8 @@ jobs:
           python -m pip install autorelease
       - name: "Install"
         run: |
-          python -m pip install --no-deps -e .
+          #python -m pip install --no-deps -e .
+          python -m pip install -e .
           python -c "import openpathsampling"
       - name: "Versions"
         run: conda list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
         with: 
           auto-update-conda: true
           python-version: ${{ matrix.CONDA_PY }}
+          miniforge-variant: Mambaforge
       - name: "Install requirements"
         env:
           MINIMAL: ${{ matrix.MINIMAL }}

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="jupyter pyemma"
+INTEGRATIONS="openmm openmtools pyemma"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -47,7 +47,7 @@ echo "TESTING=$TESTING"
 # TODO: allow different installs for different versions
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
-ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS $EXPERIMENTAL" # $TESTING"
+ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="openmm openmmtools pyemma"
+INTEGRATIONS="future svgwrite ujson"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"
@@ -50,7 +50,7 @@ echo "TESTING=$TESTING"
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
 ALL_PACKAGES="$WORKAROUNDS " #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
-ALL_PACKAGES="$WORKAROUNDS $EXPERIMENTAL $INTEGRATIONS" #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
+ALL_PACKAGES="$WORKAROUNDS $EXPERIMENTAL " #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="future svgwrite ujson numpy scipy pandas"
+INTEGRATIONS="future svgwrite ujson numpy scipy pandas matplotlib networkx"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -9,12 +9,19 @@
 
 DEVTOOLS_DIR=`dirname "${BASH_SOURCE[0]}"`
 
+if [ ! command -v mamba ]
+then
+    EXE="conda"
+else
+    EXE="mamba"
+fi
+
 if [ ! -z "$OPS_ENV" ]
 then
-    conda create -q -y --name $OPS_ENV conda future pyyaml python=$CONDA_PY
+    $EXE create -q -y --name $OPS_ENV conda future pyyaml python=$CONDA_PY
     source activate $OPS_ENV
 else
-    conda install -y -q future pyyaml  # ensure that these are available
+    $EXE install -y -q future pyyaml  # ensure that these are available
 fi
 
 # for some reason, these approaches to pinning don't always work (but conda
@@ -43,4 +50,4 @@ echo "TESTING=$TESTING"
 ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS $EXPERIMENTAL $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
-conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES
+$EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -42,7 +42,7 @@ echo "REQUIREMENTS=$REQUIREMENTS"
 echo "INTEGRATIONS=$INTEGRATIONS"
 echo "EXPERIMENTAL=$EXPERIMENTAL"
 echo "WORKAROUNDS=$WORKAROUNDS"
-echo "TESTING=$TESTING"
+#echo "TESTING=$TESTING"
 
 # TODO: allow different installs for different versions
 # (needed this when msmbuilder was only available on older pythons; similar

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="openmm openmtools pyemma"
+INTEGRATIONS="openmm openmmtools pyemma"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -48,6 +48,7 @@ echo "TESTING=$TESTING"
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
 ALL_PACKAGES="$WORKAROUNDS " #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
+ALL_PACKAGES="$WORKAROUNDS $EXPERIMENTAL" #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="future svgwrite ujson"
+INTEGRATIONS="future svgwrite ujson numpy scipy pandas"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -48,7 +48,7 @@ echo "TESTING=$TESTING"
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
 ALL_PACKAGES="$WORKAROUNDS " #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
-ALL_PACKAGES="$WORKAROUNDS $EXPERIMENTAL" #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
+ALL_PACKAGES="$WORKAROUNDS $EXPERIMENTAL $INTEGRATIONS" #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -47,7 +47,7 @@ echo "TESTING=$TESTING"
 # TODO: allow different installs for different versions
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
-ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
+ALL_PACKAGES="$WORKAROUNDS " #$REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -47,7 +47,7 @@ echo "TESTING=$TESTING"
 # TODO: allow different installs for different versions
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
-ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
+ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS" # $INTEGRATIONS" # $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,6 +37,8 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
+INTEGRATIONS="jupyter pyemma"
+
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"
 echo "INTEGRATIONS=$INTEGRATIONS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="future svgwrite ujson numpy scipy pandas matplotlib networkx"
+INTEGRATIONS="future svgwrite ujson numpy scipy pandas matplotlib networkx netcdf4 psutil"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -37,7 +37,7 @@ INTEGRATIONS=`cat ${DEVTOOLS_DIR}/tested_integrations.txt | tr "\n" " "`
 EXPERIMENTAL=`cat ${DEVTOOLS_DIR}/experimental_reqs.txt | tr "\n" " "`
 PY_INSTALL="python=$CONDA_PY"
 
-INTEGRATIONS="future svgwrite ujson numpy scipy pandas matplotlib networkx netcdf4 psutil"
+INTEGRATIONS="future svgwrite ujson numpy scipy pandas matplotlib networkx netcdf4 psutil mdtraj"
 
 echo "PY_INSTALL=$PY_INSTALL"
 echo "REQUIREMENTS=$REQUIREMENTS"

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -42,12 +42,12 @@ echo "REQUIREMENTS=$REQUIREMENTS"
 echo "INTEGRATIONS=$INTEGRATIONS"
 echo "EXPERIMENTAL=$EXPERIMENTAL"
 echo "WORKAROUNDS=$WORKAROUNDS"
-#echo "TESTING=$TESTING"
+echo "TESTING=$TESTING"
 
 # TODO: allow different installs for different versions
 # (needed this when msmbuilder was only available on older pythons; similar
 # situations may come up in the future)
-ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS $EXPERIMENTAL $TESTING"
+ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS $EXPERIMENTAL" # $TESTING"
 
 echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
 $EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES


### PR DESCRIPTION
Py27 builds have taken too long for a while, and now they're so bad that they're failing CI. (20+ minutes was bad, but then it jumped to 2 hours -- and now it takes more than 6 hours?!?!?!) I don't know why this is getting worse, but this is insane.

In this PR, I'm going to try to switch to [mamba](https://github.com/mamba-org/mamba). I've personally been using mamba for a while now. I tested locally and could build a Py27 environment for OPS in a few minutes, using the same command that hangs in CI. (The conda version of the same command is *still* trying to run -- the problem isn't with GitHub actions, since it affects me, too.)