### PR TITLE
Switch CI install to mamba

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,8 @@ jobs:
         run: conda list
       - name: "Autorelease check"
         run: python devtools/autorelease_check.py
+      #- name: "DEBUG: enable SSH login"
+        #uses: mxschmitt/action-tmate@v3
       - name: "Unit Tests"
         env:
           PY_COLORS: "1"
@@ -83,7 +85,3 @@ jobs:
         if: matrix.MINIMAL == ''
         run: |
           pushd examples/ && ./ipynbtests.sh || exit 1 && popd
-      - name: "Deploy docs"
-        if: matrix.CONDA_PY == '3.7' && matrix.MINIMAL == ''
-        run: |
-          echo "TODO"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
         with: 
           auto-update-conda: true
           python-version: ${{ matrix.CONDA_PY }}
+          miniforge-variant: Mambaforge
       - name: "Install requirements"
         env:
           MINIMAL: ${{ matrix.MINIMAL }}

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -60,9 +60,8 @@ if [ -z "$DRY" ]; then
     $INSTALL_CMD $PY_INSTALL $ALL_PACKAGES
 fi
 
-if [ -z "$OPS_ENV" ]
-then
-    source activate $OPS_ENV
+if [ -n "$OPS_ENV" ] && [ -z "$DRY" ]; then
+    conda activate $OPS_ENV
 fi
 
 # occasional workaround; usually a do-nothing

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -9,12 +9,19 @@
 
 DEVTOOLS_DIR=`dirname "${BASH_SOURCE[0]}"`
 
+if [ ! command -v mamba ]
+then
+    EXE="conda"
+else
+    EXE="mamba"
+fi
+
 if [ ! -z "$OPS_ENV" ]
 then
-    conda create -q -y --name $OPS_ENV conda future pyyaml python=$CONDA_PY
+    $EXE create -q -y --name $OPS_ENV conda future pyyaml python=$CONDA_PY
     source activate $OPS_ENV
 else
-    conda install -y -q future pyyaml  # ensure that these are available
+    $EXE install -y -q future pyyaml  # ensure that these are available
 fi
 
 # for some reason, these approaches to pinning don't always work (but conda
@@ -42,5 +49,5 @@ echo "TESTING=$TESTING"
 # situations may come up in the future)
 ALL_PACKAGES="$WORKAROUNDS $REQUIREMENTS $INTEGRATIONS $EXPERIMENTAL $TESTING"
 
-echo "conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
-conda install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES
+echo "$EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES"
+$EXE install -y -q -c conda-forge -c omnia $PY_INSTALL $ALL_PACKAGES

--- a/devtools/conda_install_reqs.sh
+++ b/devtools/conda_install_reqs.sh
@@ -63,6 +63,6 @@ $INSTALL_CMD $PY_INSTALL $ALL_PACKAGES
 # occasional workaround; usually a do-nothing
 if [ -n "$PIP_INSTALLS" ]
 then
-echo "python -m pip install $PIP_INSTALLS"
-python -m pip install $PIP_INSTALLS
+    echo "python -m pip install $PIP_INSTALLS"
+    python -m pip install $PIP_INSTALLS
 fi

--- a/openpathsampling/tests/test_reactive_flux_analysis.py
+++ b/openpathsampling/tests/test_reactive_flux_analysis.py
@@ -133,6 +133,7 @@ class TestReactiveFluxAnalysis(object):
 
     def teardown(self):
         if os.path.isfile(self.filename):
+            self.storage.close()
             os.remove(self.filename)
         paths.EngineMover.default_engine = None
 
@@ -142,8 +143,8 @@ class TestReactiveFluxAnalysis(object):
         return np.array([[1.0]])
 
     def test_analysis(self):
-        self.storage = paths.Storage(self.filename, mode="r")
-        self.analysis = paths.ReactiveFluxAnalysis(steps=self.storage.steps,
+        storage = paths.Storage(self.filename, mode="r")
+        self.analysis = paths.ReactiveFluxAnalysis(steps=storage.steps,
                                                    gradient=self.gradient)
 
         # check wrong analyze_single_step() argument


### PR DESCRIPTION
Third (and, I hope, final!) version of this. See also #1072 and #1071 for the history of trying to debug this problem.

Main points, quoting from previous:

> Py27 builds have taken too long for a while, and now they're so bad that they're failing CI. (20+ minutes was bad, but then it jumped to 2 hours -- and now it takes more than 6 hours?!?!?!) I don't know why this is getting worse, but this is insane.
> 
> In this PR, I'm going to try to switch to [mamba](https://github.com/mamba-org/mamba). I've personally been using mamba for a while now. I tested locally and could build a Py27 environment for OPS in a few minutes, using the same command that hangs in CI. (The conda version of the same command is _still_ trying to run -- the problem isn't with GitHub actions, since it affects me, too.)

However, that change resulted in a segfault that appears to have been because a test didn't close a storage before removing the file (which is fixed in this PR).

In addition to fixing that segfault and switching to `mamba` for installation, this PR:

* Adds a commented debugging step (allowing one to SSH into the worker) to the main CI workflow.
* Improves the requirements installation in several ways, including giving a way to override/replace conda installs with pip installs, and using a more consistent (and purely conda-forge) installation procedure.