### PR TITLE
Account for modifier acceptance in engine movers

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -178,6 +178,14 @@ SNAPSHOTMODIFIER_PROB_RAT = Deprecation(
     deprecated_in=(1, 6, 0)
 )
 
+NOMODIFICATION_SUBSET_MASK = Deprecation(
+    problem=("subset_mask is nonsense for NoModification, is ignored in the "
+             "call, and will be removed as initialisation argument."),
+    remedy=("You should not use this keyword"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -168,6 +168,15 @@ OPENMM_MDTRAJTOPOLOGY = Deprecation(
     deprecated_in=(1, 5, 0)
 )
 
+SNAPSHOTMODIFIER_PROB_RAT = Deprecation(
+    problem=("This function will raise a NotImplementedError in "
+             "{OPS} {version}."),
+    remedy=("All SnapshotModifier subclasses should override the "
+            "probability_ratio function."),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import sys
 import warnings
-from collections import namedtuple
 from functools import wraps
 from inspect import isclass
 
@@ -13,6 +12,7 @@ numpydoc_deprecation = """
 .. deprecated:: {deprecated_in}
     {problem} {remedy}
 """
+
 
 class Deprecation(object):
     """
@@ -105,6 +105,7 @@ def update_docstring(thing_with_docstring, deprecation):
         docs = thing_with_docstring.__doc__
     return docs + deprecation.docstring_message()
 
+
 def version_tuple_to_string(version_tuple):
     """
     Parameters
@@ -193,6 +194,7 @@ def has_deprecations(cls):
             del obj.__new_docstring
     return cls
 
+
 def deprecate(deprecation):
     """Decorator to deprecate a class/method
 
@@ -219,6 +221,7 @@ def deprecate(deprecation):
         else:
             return wrapper
     return decorator
+
 
 def list_deprecations(version=None, deprecations=None):
     """List deprecations that should have been removed by ``version``

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -2317,7 +2317,8 @@ class ForwardFirstTwoWayShootingMover(AbstractTwoWayShootingMover):
         trial_trajectory : :class:`.Trajectory`
             the resulting trial trajectory
         details : dict
-            details dictionary (includes modified shooting point)
+            details dictionary (includes modified shooting point and
+            modification bias)
         """
         shoot_str = "Running {sh_dir} from frame {fnum} in [0:{maxt}]"
         logger.info(shoot_str.format(
@@ -2364,7 +2365,8 @@ class BackwardFirstTwoWayShootingMover(AbstractTwoWayShootingMover):
         trial_trajectory : :class:`.Trajectory`
             the resulting trial trajectory
         details : dict
-            details dictionary (includes modified shooting point)
+            details dictionary (includes modified shooting point and
+            modification bias)
         """
         shoot_str = "Running {sh_dir} from frame {fnum} in [0:{maxt}]"
         logger.info(shoot_str.format(
@@ -2522,6 +2524,7 @@ class MinusMover(SubPathMover):
             change.details = details
 
         return change
+
 
 class SingleReplicaMinusMover(MinusMover):
     """

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -25,8 +25,9 @@ logger = logging.getLogger(__name__)
 init_log = logging.getLogger('openpathsampling.initialization')
 
 
-# TODO: Remove if really not used anymore otherwise might move to utils or tools
-def make_list_of_pairs(l):
+# TODO: Remove if really not used anymore
+# otherwise might move to utils or tools
+def make_list_of_pairs(inlist):
     """
     Converts input from several possible formats into a list of pairs: used
     to clean input for swap-like moves.
@@ -40,34 +41,37 @@ def make_list_of_pairs(l):
 
     Parameters
     ----------
-    l : list
+    inlist : list
         input list, either flat list of length 2N, a list of pairs or None
 
     Returns
     -------
     list of pairs
     """
-    if l is None:
+    if inlist is None:
         return None
 
-    _ = len(l)  # raises TypeError, avoids everything else
+    _ = len(inlist)  # raises TypeError, avoids everything else
 
     # based on first element, decide whether this should be a list of lists
     # or a flat list
     try:
-        _ = len(l[0])
+        _ = len(inlist[0])
         list_of_lists = True
     except TypeError:
         list_of_lists = False
 
     if list_of_lists:
-        for elem in l:
+        for elem in inlist:
             assert len(elem) == 2, "List of lists: inner list length != 2"
-        outlist = l
+        outlist = inlist
     else:
-        assert len(l) % 2 == 0, "Flattened list: length not divisible by 2"
+        assert len(inlist) % 2 == 0, \
+            "Flattened list: length not divisible by 2"
         outlist = [
-            [a, b] for (a, b) in zip(l[slice(0, None, 2)], l[slice(1, None, 2)])
+            [a, b] for (a, b) in zip(
+                inlist[slice(0, None, 2)],
+                inlist[slice(1, None, 2)])
         ]
     # Note that one thing we don't check is whether the items are of the
     # same type. That might be worth doing someday; for now, we trust that
@@ -128,7 +132,7 @@ class PathMover(with_metaclass(abc.ABCMeta, TreeMixin, StorableNamedObject)):
     in the PathMover, but have it be a separate class ~~~DWHS
     """
 
-    #__metaclass__ = abc.ABCMeta
+    # __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         StorableNamedObject.__init__(self)
@@ -228,11 +232,10 @@ class PathMover(with_metaclass(abc.ABCMeta, TreeMixin, StorableNamedObject)):
             return {
                 InOutSet([])
             }
-        elif len(self.input_ensembles) == 1 and len(self.output_ensembles) == 1:
-            return InOutSet([
-                InOut(
-                    [((self.input_ensembles[0], self.output_ensembles[0], 0), 1)]
-                )])
+        elif (len(self.input_ensembles) == len(self.output_ensembles) == 1):
+            in_ens = self.input_ensembles[0]
+            out_ens = self.output_ensembles[0]
+            return InOutSet([InOut([((in_ens, out_ens, 0), 1)])])
         else:
             # Fallback could be all possibilities, but for now we ask the user!
             raise NotImplementedError(
@@ -699,8 +702,8 @@ class SampleMover(PathMover):
     def _accept(self, trials):
         """Function to determine the acceptance of a trial
 
-        Defaults to calling the Metropolis acceptance criterion for all returned
-        trial samples. Means all samples most be valid and accepted.
+        Defaults to calling the Metropolis acceptance criterion for all
+        returned trial samples. Means all samples most be valid and accepted.
         """
         return self.metropolis(trials)
 
@@ -800,7 +803,8 @@ class EngineMover(SampleMover):
                 input_sample, shooting_index, e.last_trajectory, 'max_length')
 
             if EngineMover.reject_max_length:
-                raise SampleMaxLengthError('Sample with MaxLength', trial, details)
+                raise SampleMaxLengthError('Sample with MaxLength', trial,
+                                           details)
 
         else:
             trial, details = self._build_sample(
@@ -866,7 +870,7 @@ class EngineMover(SampleMover):
         initial_snapshot = trajectory[shooting_index]  # .copy()
         run_f = paths.PrefixTrajectoryEnsemble(self.target_ensemble,
                                                trajectory[0:shooting_index]
-                                              ).can_append
+                                               ).can_append
         partial_trajectory = self.engine.generate(initial_snapshot,
                                                   running=[run_f])
         trial_trajectory = (trajectory[0:shooting_index] +
@@ -879,7 +883,7 @@ class EngineMover(SampleMover):
         initial_snapshot = trajectory[shooting_index].reversed  # _copy()
         run_f = paths.SuffixTrajectoryEnsemble(self.target_ensemble,
                                                trajectory[shooting_index + 1:]
-                                              ).can_prepend
+                                               ).can_prepend
         partial_trajectory = self.engine.generate(initial_snapshot,
                                                   running=[run_f])
         trial_trajectory = (partial_trajectory.reversed +
@@ -1036,12 +1040,13 @@ class ReplicaExchangeMover(SampleMover):
         return [self.ensemble1, self.ensemble2]
 
     def _generate_in_out(self):
+        ens1 = self.ensemble1
+        ens2 = self.ensemble2
+        move_type = 1 * InOut._use_move_type
         return InOutSet([
-            InOut([
-                ((self.ensemble1, self.ensemble2, 1 * InOut._use_move_type), 1),
-                ((self.ensemble2, self.ensemble1, 1 * InOut._use_move_type), 1)
+            InOut([((ens1, ens2, move_type), 1),
+                   ((ens2, ens1, move_type), 1)])
             ])
-        ])
 
     def __call__(self, sample1, sample2):
         # convert sample to the language used here before
@@ -1120,12 +1125,13 @@ class StateSwapMover(SampleMover):
         return [self.ensemble1, self.ensemble2]
 
     def _generate_in_out(self):
+        ens1 = self.ensemble1
+        ens2 = self.ensemble2
+        move_type = -1 * InOut._use_move_type
         return InOutSet([
-            InOut([
-                ((self.ensemble1, self.ensemble2, -1 * InOut._use_move_type), 1),
-                ((self.ensemble2, self.ensemble1, -1 * InOut._use_move_type), 1)
+            InOut([((ens1, ens2, move_type), 1),
+                   ((ens2, ens1, move_type), 1)])
             ])
-        ])
 
     def __call__(self, sample1, sample2):
         # convert sample to the language used here before
@@ -1453,16 +1459,18 @@ class EnsembleHopMover(SampleMover):
             replica = self.change_replica
 
         logger.info(
-            "Attempting ensemble hop from {e1} to {e2} replica ID {rid}".format(
+            "Attempting ensemble hop from {e1} to {e2} "
+            "replica ID {rid}".format(
                 e1=repr(ens_from), e2=repr(ens_to), rid=repr(replica)))
 
         trajectory = rep_sample.trajectory
         logger.debug("  selected replica: " + str(replica))
         logger.debug("  initial ensemble: " + repr(rep_sample.ensemble))
 
-        logger.info("Hop starts from legal ensemble: "+str(ens_from(trajectory)))
-        logger.info("Hop ends in legal ensemble: "+str(ens_to(trajectory)))
-
+        logger.info("Hop starts from legal ensemble: " +
+                    str(ens_from(trajectory)))
+        logger.info("Hop ends in legal ensemble: " +
+                    str(ens_to(trajectory)))
 
         # TODO: remove this and generalize!!!
         if type(self.bias) is float:
@@ -1926,9 +1934,10 @@ class PartialAcceptanceSequentialMover(SequentialMover):
         movechanges = []
         for mover in self.movers:
             logger.info(str(self.name)
-                        + " starting mover index " + str(self.movers.index(mover))
+                        + " starting mover index "
+                        + str(self.movers.index(mover))
                         + " (" + mover.name + ")"
-                       )
+                        )
             # Run the sub mover
             movepath = mover.move(subglobal)
             samples = movepath.results
@@ -1957,7 +1966,9 @@ class ConditionalSequentialMover(SequentialMover):
     """
 
     def _generate_in_out(self):
-        return InOutSet(sum([sub.in_out for sub in self.submovers], InOutSet()))
+        return InOutSet(
+            sum([sub.in_out for sub in self.submovers], InOutSet())
+        )
 
     def move(self, sample_set):
         logger.debug("Starting conditional sequential move")
@@ -2116,8 +2127,8 @@ class EnsembleFilterMover(SubPathMover):
         self.ensembles = ensembles
 
         if not set(self.mover.output_ensembles) & set(self.ensembles):
-            # little sanity check, if the underlying move will be removed by the
-            # filter throw a warning
+            # little sanity check, if the underlying move will be removed by
+            # the filter throw a warning
             raise ValueError(
                 'Your filter removes the underlying move completely. ' +
                 'Please check your ensembles and submovers!')
@@ -2179,6 +2190,7 @@ class SpecializedRandomChoiceMover(RandomChoiceMover):
             details=details
         )
         return change
+
 
 class OneWayShootingMover(SpecializedRandomChoiceMover):
     """
@@ -2268,7 +2280,6 @@ class AbstractTwoWayShootingMover(EngineMover):
             modifier=modifier
         )
         # TODO OPS 2.0: This init signature should be aligned with EngineMover
-        #self.modifier = modifier
 
     # required for concrete class; not really used
     @property
@@ -2299,6 +2310,7 @@ class AbstractTwoWayShootingMover(EngineMover):
     def _run(self, trajectory, shooting_index):
         # to override the default implementation in EngineMover
         raise NotImplementedError
+
 
 class ForwardFirstTwoWayShootingMover(AbstractTwoWayShootingMover):
     def _run(self, trajectory, shooting_index):
@@ -2382,16 +2394,16 @@ class BackwardFirstTwoWayShootingMover(AbstractTwoWayShootingMover):
 
         bkwd_partial = self._make_backward_trajectory(trajectory, modified,
                                                       shooting_index)
-        #logger.info("Complete backward shot (length " +
-                    #str(len(bkwd_partial)) + ")")
+        # logger.info("Complete backward shot (length " +
+        #             str(len(bkwd_partial)) + ")")
         # TODO: come up with a test that shows why you need mid_traj here;
         # should be a SeqEns with OptionalEnsembles. Exact example is hard!
         mid_traj = bkwd_partial.reversed + trajectory[shooting_index + 1:]
         mid_traj_shoot_idx = len(bkwd_partial) - 1
         fwd_partial = self._make_forward_trajectory(mid_traj, modified,
                                                     mid_traj_shoot_idx)
-        #logger.info("Complete forward shot (length " +
-                    #str(len(fwd_partial)) + ")")
+        # logger.info("Complete forward shot (length " +
+        #             str(len(fwd_partial)) + ")")
 
         # join the two
         trial_trajectory = bkwd_partial.reversed + fwd_partial[1:]

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -222,18 +222,10 @@ class RandomVelocities(SnapshotModifier):
         new_snap = make_snapshot(snapshot)
         return new_snap
 
-    def _calc_kinetic_energy(self, snapshot):
-        velocities = snapshot.velocities
-        v_2 = velocities**2
-        masses = snapshot.masses
-        ekin = 0.5*np.sum(v_2*masses[:, np.newaxis])
-        return ekin
-
     def probability_ratio(self, old_snapshot, new_snapshot):
-        # Should always be 1.0 but might not due to constraints
-        e_old = self._calc_kinetic_energy(old_snapshot)
-        e_new = self._calc_kinetic_energy(new_snapshot)
-        return np.exp(-self.beta*(e_new-e_old))
+        # Should always be 1.0 becasue it is directly sampled from the right
+        # distribution
+        return 1.0
 
 
 class GeneralizedDirectionModifier(SnapshotModifier):

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -6,7 +6,8 @@ import functools
 import numpy as np
 
 from openpathsampling.netcdfplus import StorableNamedObject
-from openpathsampling.deprecations import SNAPSHOTMODIFIER_PROB_RAT
+from openpathsampling.deprecations import (SNAPSHOTMODIFIER_PROB_RAT,
+                                           NOMODIFICATION_SUBSET_MASK)
 logger = logging.getLogger(__name__)
 
 
@@ -113,9 +114,24 @@ class SnapshotModifier(StorableNamedObject):
 
 
 class NoModification(SnapshotModifier):
-    """Modifier with no change: returns a copy of the snapshot."""
+    """Modifier with no change: "
+
+    Parameters
+    ----------
+    as_copy : bool, default True
+        if True calls return a copy of the snapshot, else the snapshot itself.
+    """
+    def __init__(self, subset_mask=None, as_copy=True):
+        # TODO OPS 2.0: subset mask should be removed from this init call
+        if subset_mask is not None:
+            NOMODIFICATION_SUBSET_MASK.warn(stacklevel=3)
+        # masking is nonsense for no modification, but used in testing so this
+        # is here to conserve API
+        super(NoModification, self).__init__(subset_mask=subset_mask)
+        self.as_copy = as_copy
+
     def __call__(self, snapshot):
-        return snapshot.copy()
+        return snapshot.copy() if self.as_copy else snapshot
 
     def probability_ratio(self, old_snapshot, new_snapshot):
         """This modifier does not alter the snapshot, so equal probability."""

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -6,8 +6,8 @@ import functools
 import numpy as np
 
 from openpathsampling.netcdfplus import StorableNamedObject
-from openpathsampling.deprecations import (SNAPSHOTMODIFIER_PROB_RAT,
-                                           NOMODIFICATION_SUBSET_MASK)
+from openpathsampling.deprecations import SNAPSHOTMODIFIER_PROB_RAT
+
 logger = logging.getLogger(__name__)
 
 

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -288,14 +288,21 @@ class TestForwardFirstTwoWayShootingMover(TestShootingMover):
         )
         traj, details = mover._run(self.init_samp[0].trajectory, 4)
         assert_allclose(traj.xyz[:,0,0], [-0.1, 0.2, 0.4, 0.6, 0.8])
-        assert_equal(list(details.keys()), ['modified_shooting_snapshot'])
+        assert_equal(list(details.keys()),
+                     ['modified_shooting_snapshot',
+                      'bias_snapshot_modification']
+                     )
         assert_equal(details['modified_shooting_snapshot'], traj[2])
         assert_not_in(details['modified_shooting_snapshot'],
                       self.init_samp[0].trajectory)
+        assert details['bias_snapshot_modification'] == 1.0
 
         traj, details = mover._run(self.init_samp[0].trajectory, 3)
         assert_allclose(traj.xyz[:,0,0], [-0.1, 0.1, 0.3, 0.5, 0.7])
-        assert_equal(list(details.keys()), ['modified_shooting_snapshot'])
+        assert_equal(list(details.keys()),
+                     ['modified_shooting_snapshot',
+                      'bias_snapshot_modification'])
+        assert details['bias_snapshot_modification'] == 1.0
         assert_equal(details['modified_shooting_snapshot'], traj[2])
         assert_not_in(details['modified_shooting_snapshot'],
                       self.init_samp[0].trajectory)

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -280,6 +280,15 @@ class TestOneWayShootingMover(TestShootingMover):
 class TestForwardFirstTwoWayShootingMover(TestShootingMover):
     _MoverType = ForwardFirstTwoWayShootingMover
     # this allows us to run the exact same tests for backward-first
+    def test_modifier_default(self):
+        mover = self._MoverType(
+            ensemble=self.tps,
+            selector=UniformSelector(),
+            modifier=None,
+            engine=self.dyn
+        )
+        assert isinstance(mover.modifier, paths.NoModification)
+
     def test_run(self):
         mover = self._MoverType(
             ensemble=self.tps,

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -300,20 +300,15 @@ class TwoWayShootingMoverTest(TestShootingMover):
         )
         traj, details = mover._run(self.init_samp[0].trajectory, 4)
         assert_allclose(traj.xyz[:, 0, 0], [-0.1, 0.2, 0.4, 0.6, 0.8])
-        assert (list(details.keys()) ==
-                ['modified_shooting_snapshot', 'bias_snapshot_modification']
-                )
+        assert list(details.keys()) == ['modified_shooting_snapshot']
+
         assert details['modified_shooting_snapshot'] == traj[2]
         assert (details['modified_shooting_snapshot'] not in
                 self.init_samp[0].trajectory)
-        assert details['bias_snapshot_modification'] == 1.0
 
         traj, details = mover._run(self.init_samp[0].trajectory, 3)
         assert_allclose(traj.xyz[:, 0, 0], [-0.1, 0.1, 0.3, 0.5, 0.7])
-        assert (list(details.keys()) ==
-                ['modified_shooting_snapshot', 'bias_snapshot_modification']
-                )
-        assert details['bias_snapshot_modification'] == 1.0
+        assert list(details.keys()) == ['modified_shooting_snapshot']
         assert details['modified_shooting_snapshot'] == traj[2]
         assert (details['modified_shooting_snapshot'] not in
                 self.init_samp[0].trajectory)

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -232,3 +232,17 @@ class TestConstrainedSelector(SelectorTest):
         mod_traj += mytraj[idx+1:]
         prob = self.sel.probability_ratio(frame, mytraj, mod_traj, mod_frame)
         assert prob == expected
+
+
+class TestDeprecations(object):
+    @pytest.mark.parametrize('selector_class', [ShootingPointSelector,
+                                                FirstFrameSelector,
+                                                FinalFrameSelector])
+    def test_new_snapshot(self, selector_class):
+        selector = selector_class()
+        mytraj = make_1d_traj(coordinates=[-0.5, -0.4, -0.3, -0.1,
+                                           0.1, 0.2, 0.3, 0.5])
+        with pytest.deprecated_call(match='new_snapshot'):
+            _ = selector.probability_ratio(mytraj[1], mytraj, mytraj)
+        # Reset the warning for the next class
+        NEW_SNAPSHOT_SELECTOR.has_warned = False

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -5,9 +5,6 @@ from builtins import range
 from past.utils import old_div
 from builtins import object
 import pytest
-from nose.tools import (assert_equal, assert_not_equal, raises,
-                        assert_almost_equal, assert_true)
-from nose.plugins.skip import SkipTest
 from numpy.testing import assert_array_almost_equal
 from .test_helpers import u
 
@@ -76,7 +73,7 @@ class TestNoModification(object):
         new_1Dx = mod.apply_to_subset(copy_1Dx, np.array([-1.0, -2.0]))
         assert_array_almost_equal(new_1Dx, np.array([0.0, -1.0, -2.0, 3.0]))
         # and check that memory points to the right things; orig unchanged
-        assert_true(copy_1Dx is new_1Dx)
+        assert copy_1Dx is new_1Dx
         assert_array_almost_equal(self.snapshot_1D.coordinates,
                                   np.array([0.0, 1.0, 2.0, 3.0]))
 
@@ -89,7 +86,7 @@ class TestNoModification(object):
                                                      [-2.0, -2.1, -2.2],
                                                      [3.0, 3.1, 3.2]]))
         # and check that memory points to the right things; orig unchanged
-        assert_true(copy_3Dx is new_3Dx)
+        assert copy_3Dx is new_3Dx
         assert_array_almost_equal(self.snapshot_3D.coordinates,
                                   np.array([[0.0, 0.1, 0.2],
                                             [1.0, 1.1, 1.2],
@@ -107,10 +104,10 @@ class TestNoModification(object):
                                   new_3D.coordinates)
         assert_array_almost_equal(self.snapshot_3D.velocities,
                                   new_3D.velocities)
-        assert_true(self.snapshot_1D.coordinates is not new_1D.coordinates)
-        assert_true(self.snapshot_1D.velocities is not new_1D.velocities)
-        assert_true(self.snapshot_3D.coordinates is not new_3D.coordinates)
-        assert_true(self.snapshot_3D.velocities is not new_3D.velocities)
+        assert self.snapshot_1D.coordinates is not new_1D.coordinates
+        assert self.snapshot_1D.velocities is not new_1D.velocities
+        assert self.snapshot_3D.coordinates is not new_3D.coordinates
+        assert self.snapshot_3D.velocities is not new_3D.velocities
 
     def test_probability_ratio(self):
         # This should always return 1.0 even for invalid input
@@ -153,50 +150,50 @@ class TestRandomizeVelocities(object):
         # stochastic.
         randomizer = RandomVelocities(beta=old_div(1.0, 5.0))
         new_1x2D = randomizer(self.snap_1x2D)
-        assert_equal(new_1x2D.coordinates.shape, new_1x2D.velocities.shape)
-        assert_array_almost_equal(new_1x2D.coordinates,
-                                  self.snap_1x2D.coordinates)
-        assert_true(new_1x2D is not self.snap_1x2D)
-        assert_true(new_1x2D.coordinates is not self.snap_1x2D.coordinates)
-        assert_true(new_1x2D.velocities is not self.snap_1x2D.velocities)
+        assert new_1x2D.coordinates.shape == new_1x2D.velocities.shape
+        assert (pytest.approx(new_1x2D.coordinates) ==
+                self.snap_1x2D.coordinates)
+        assert new_1x2D is not self.snap_1x2D
+        assert new_1x2D.coordinates is not self.snap_1x2D.coordinates
+        assert new_1x2D.velocities is not self.snap_1x2D.velocities
         for val in new_1x2D.velocities.flatten():
-            assert_not_equal(val, 0.0)
+            assert val != 0.0
         assert randomizer.probability_ratio(self.snap_1x2D, new_1x2D) == 1.0
 
         new_2x3D = randomizer(self.snap_2x3D)
-        assert_equal(new_2x3D.coordinates.shape, new_2x3D.velocities.shape)
+        assert new_2x3D.coordinates.shape == new_2x3D.velocities.shape
         assert_array_almost_equal(new_2x3D.coordinates,
                                   self.snap_2x3D.coordinates)
-        assert_true(new_2x3D is not self.snap_2x3D)
-        assert_true(new_2x3D.coordinates is not self.snap_2x3D.coordinates)
-        assert_true(new_2x3D.velocities is not self.snap_2x3D.velocities)
+        assert new_2x3D is not self.snap_2x3D
+        assert new_2x3D.coordinates is not self.snap_2x3D.coordinates
+        assert new_2x3D.velocities is not self.snap_2x3D.velocities
         for val in new_2x3D.velocities.flatten():
-            assert_not_equal(val, 0.0)
+            assert val != 0.0
 
         new_3x1D = randomizer(self.snap_3x1D)
-        assert_equal(new_3x1D.coordinates.shape, new_3x1D.velocities.shape)
+        assert new_3x1D.coordinates.shape == new_3x1D.velocities.shape
         assert_array_almost_equal(new_3x1D.coordinates,
                                   self.snap_3x1D.coordinates)
-        assert_true(new_3x1D is not self.snap_3x1D)
-        assert_true(new_3x1D.coordinates is not self.snap_3x1D.coordinates)
-        assert_true(new_3x1D.velocities is not self.snap_3x1D.velocities)
+        assert new_3x1D is not self.snap_3x1D
+        assert new_3x1D.coordinates is not self.snap_3x1D.coordinates
+        assert new_3x1D.velocities is not self.snap_3x1D.velocities
         for val in new_3x1D.velocities.flatten():
-            assert_not_equal(val, 0.0)
+            assert val != 0.0
 
     def test_subset_call(self):
         randomizer = RandomVelocities(beta=old_div(1.0, 5.0), subset_mask=[0])
         new_2x3D = randomizer(self.snap_2x3D)
-        assert_equal(new_2x3D.coordinates.shape, new_2x3D.velocities.shape)
+        assert new_2x3D.coordinates.shape == new_2x3D.velocities.shape
         assert_array_almost_equal(new_2x3D.coordinates,
                                   self.snap_2x3D.coordinates)
-        assert_true(new_2x3D is not self.snap_2x3D)
-        assert_true(new_2x3D.coordinates is not self.snap_2x3D.coordinates)
-        assert_true(new_2x3D.velocities is not self.snap_2x3D.velocities)
+        assert new_2x3D is not self.snap_2x3D
+        assert new_2x3D.coordinates is not self.snap_2x3D.coordinates
+        assert new_2x3D.velocities is not self.snap_2x3D.velocities
         # show that the unchanged atom is, in fact, unchanged
         assert_array_almost_equal(new_2x3D.velocities[1],
                                   self.snap_2x3D.velocities[1])
         for val in new_2x3D.velocities[0]:
-            assert_not_equal(val, 0.0)
+            assert val != 0.0
 
     def test_no_beta_bad_engine(self):
         engine = self.snap_2x3D.engine
@@ -208,7 +205,7 @@ class TestRandomizeVelocities(object):
         # note: this is only a smoke test; correctness depends on OpenMM's
         # tests of its constraint approaches.
         if not omt:
-            raise SkipTest("Requires OpenMMTools (not installed)")
+            pytest.skip("Requires OpenMMTools (not installed)")
         test_system = omt.testsystems.AlanineDipeptideVacuum()
         template = omm_engine.snapshot_from_testsystem(test_system)
         engine = omm_engine.Engine(
@@ -225,9 +222,7 @@ class TestRandomizeVelocities(object):
         assert_array_almost_equal(template.coordinates,
                                   new_snap.coordinates)
         # velocities changed
-        assert_equal(np.isclose(template.velocities,
-                                new_snap.velocities).all(),
-                     False)
+        assert not np.isclose(template.velocities, new_snap.velocities).all()
         engine.generate(new_snap, [lambda x, foo: len(x) <= 4])
 
         # when the engine does have an existing snapshot
@@ -245,11 +240,10 @@ class TestRandomizeVelocities(object):
         assert_array_almost_equal(template.coordinates,
                                   new_snap.coordinates)
         # velocities changed
-        assert_equal(np.isclose(template.velocities,
-                                new_snap.velocities).all(),
-                     False)
+        assert not np.isclose(template.velocities, new_snap.velocities).all()
+
         # internal snapshot unchanged
-        assert_equal(engine.current_snapshot, zero_snap)
+        assert engine.current_snapshot == zero_snap
         engine.generate(new_snap, [lambda x, foo: len(x) <= 4])
 
     def test_probability_ratio(self):
@@ -286,9 +280,9 @@ class TestGeneralizedDirectionModifier(object):
 
         # create the OpenMM versions
         if not omt:
-            raise SkipTest("Requires OpenMMTools (not installed)")
+            pytest.skip("Requires OpenMMTools (not installed)")
         if not u:
-            raise SkipTest("Requires openmm.unit (not installed)")
+            pytest.skip("Requires openmm.unit (not installed)")
         u_vel = old_div(u.nanometer, u.picosecond)
         self.openmm_modifier = GeneralizedDirectionModifier(1.2 * u_vel)
         ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)
@@ -310,13 +304,12 @@ class TestGeneralizedDirectionModifier(object):
     def test_verify_snapshot_openmm(self):
         self.openmm_modifier._verify_snapshot(self.openmm_snap)
 
-    @raises(RuntimeError)
     def test_verify_snapshot_no_dofs(self):
-        assert_true(isinstance(self.test_snap.engine,
-                               omm_engine.tools.OpenMMToolsTestsystemEngine))
-        self.openmm_modifier._verify_snapshot(self.test_snap)
+        assert isinstance(self.test_snap.engine,
+                          omm_engine.tools.OpenMMToolsTestsystemEngine)
+        with pytest.raises(RuntimeError, match="missing n_degrees_of_freedom"):
+            self.openmm_modifier._verify_snapshot(self.test_snap)
 
-    @raises(RuntimeError)
     def test_verify_snapshot_constraints(self):
         ad_vacuum_constr = omt.testsystems.AlanineDipeptideVacuum()
         constrained_engine = omm_engine.Engine(
@@ -327,7 +320,8 @@ class TestGeneralizedDirectionModifier(object):
         constr_snap = self.test_snap.copy_with_replacement(
             engine=constrained_engine
         )
-        self.openmm_modifier._verify_snapshot(constr_snap)
+        with pytest.raises(RuntimeError, match="constraints"):
+            self.openmm_modifier._verify_snapshot(constr_snap)
 
     def test_verify_engine_constraints(self):
         ad_vacuum_constr = omt.testsystems.AlanineDipeptideVacuum()
@@ -384,7 +378,7 @@ class TestGeneralizedDirectionModifier(object):
         results = self.openmm_modifier._dv_widths(n_atoms, n_atoms)
         expected = np.array([1.2] * n_atoms) * u.nanometer / u.picosecond
         for truth, beauty in zip(expected, results):
-            assert_almost_equal(truth, beauty)
+            assert pytest.approx(truth._value) == beauty._value
 
     def test_rescale_linear_momenta_constant_energy_toy(self):
         velocities = np.array([[1.5, -1.0], [-1.0, 2.0], [0.25, -1.0]])
@@ -406,7 +400,7 @@ class TestGeneralizedDirectionModifier(object):
         new_ke = sum(sum(new_momenta * new_vel))
         # tests require that the linear momentum be 0, and KE be correct
         assert_array_almost_equal(total_momenta, np.array([0.0]*2))
-        assert_almost_equal(new_ke, 20.0)
+        assert pytest.approx(new_ke) == 20.0
 
     def test_remove_momentum_rescale_energy_openmm(self):
         # don't actually need to do everything with OpenMM, but do need to
@@ -441,8 +435,8 @@ class TestGeneralizedDirectionModifier(object):
         # tests require that the linear momentum be 0, and KE be correct
         assert_array_almost_equal(total_momenta,
                                   np.array([0.0]*2) * u_vel * u_mass)
-        assert_equal(new_ke.unit, (20.0 * u_energy).unit)
-        assert_almost_equal(new_ke._value, (20.0 * u_energy)._value)
+        assert new_ke.unit == (20.0 * u_energy).unit
+        assert pytest.approx(new_ke._value) == (20.0 * u_energy)._value
 
     def test_probability_ratio(self):
         # Should always be 1 as KE is conserved
@@ -491,11 +485,11 @@ class TestVelocityDirectionModifier(object):
                 )
 
     def test_select_atoms_to_modify(self):
-        assert_equal(self.toy_modifier._select_atoms_to_modify(2), [0, 1])
+        assert self.toy_modifier._select_atoms_to_modify(2) == [0, 1]
         if omt:  # TODO: separate out tests
             n_atoms = len(self.openmm_snap.coordinates)
-            assert_equal(self.openmm_modifier._select_atoms_to_modify(n_atoms),
-                         list(range(n_atoms)))
+            assert (self.openmm_modifier._select_atoms_to_modify(n_atoms) ==
+                    list(range(n_atoms)))
 
     def test_call(self):
         new_toy_snap = self.toy_modifier(self.toy_snapshot)
@@ -505,10 +499,10 @@ class TestVelocityDirectionModifier(object):
         old_vel = self.toy_snapshot.velocities
         same_vel = [np.allclose(new_vel[i], old_vel[i])
                     for i in range(len(new_vel))]
-        assert_equal(Counter(same_vel), Counter({True: 1, False: 2}))
+        assert Counter(same_vel) == Counter({True: 1, False: 2})
         for new_v, old_v in zip(new_vel, old_vel):
-            assert_almost_equal(sum([v**2 for v in new_v]),
-                                sum([v**2 for v in old_v]))
+            assert (pytest.approx(sum([v**2 for v in new_v])) ==
+                    sum([v**2 for v in old_v]))
 
         if omt:  # TODO: separate out tests
             new_omm_snap = self.openmm_modifier(self.openmm_snap)
@@ -521,13 +515,14 @@ class TestVelocityDirectionModifier(object):
                         for i in range(len(new_vel))]
             same_vel = [np.allclose(new_vel[i], old_vel[i])
                         for i in range(len(new_vel))]
-            assert_equal(Counter(same_vel), Counter({False: n_atoms}))
+            assert Counter(same_vel) == Counter({False: n_atoms})
             u_vel_sq = (old_div(u.nanometers, u.picoseconds))**2
             for new_v, old_v in zip(new_vel, old_vel):
-                assert_almost_equal(
-                    sum([(v**2).value_in_unit(u_vel_sq) for v in new_v]),
-                    sum([(v**2).value_in_unit(u_vel_sq) for v in old_v])
-                )
+                assert (pytest.approx(sum([(v**2).value_in_unit(u_vel_sq)
+                                           for v in new_v])
+                                      ) ==
+                        sum([(v**2).value_in_unit(u_vel_sq) for v in old_v])
+                        )
 
     def test_call_with_linear_momentum_fix(self):
         toy_modifier = VelocityDirectionModifier(
@@ -540,7 +535,7 @@ class TestVelocityDirectionModifier(object):
         momenta = velocities * new_toy_snap.masses[:, np.newaxis]
         assert_array_almost_equal(sum(momenta), np.array([0.0]*2))
         double_ke = sum(sum(momenta * velocities))
-        assert_almost_equal(double_ke, 86.0)
+        assert pytest.approx(double_ke) == 86.0
 
         if omt:  # TODO: separate out tests
             u_vel = old_div(u.nanometer, u.picosecond)
@@ -601,13 +596,13 @@ class TestSingleAtomVelocityDirectionModifier(object):
 
     def test_select_atoms_to_modify(self):
         selected = self.toy_modifier._select_atoms_to_modify(2)
-        assert_equal(len(selected), 1)
+        assert len(selected) == 1
         selected = [self.toy_modifier._select_atoms_to_modify(2)[0]
                     for i in range(20)]
         count = Counter(selected)
-        assert_equal(set([0, 1]), set(count.keys()))
-        assert_true(count[0] > 0)
-        assert_true(count[1] > 0)
+        assert set([0, 1]) == set(count.keys())
+        assert count[0] > 0
+        assert count[1] > 0
 
     def test_call(self):
         new_toy_snap = self.toy_modifier(self.toy_snapshot)
@@ -617,10 +612,10 @@ class TestSingleAtomVelocityDirectionModifier(object):
         old_vel = self.toy_snapshot.velocities
         same_vel = [np.allclose(new_vel[i], old_vel[i])
                     for i in range(len(new_vel))]
-        assert_equal(Counter(same_vel), Counter({True: 2, False: 1}))
+        assert Counter(same_vel) == Counter({True: 2, False: 1})
         for new_v, old_v in zip(new_vel, old_vel):
-            assert_almost_equal(sum([v**2 for v in new_v]),
-                                sum([v**2 for v in old_v]))
+            assert (pytest.approx(sum([v**2 for v in new_v])) ==
+                    sum([v**2 for v in old_v]))
 
         if omt:  # TODO: separate out tests
             new_omm_snap = self.openmm_modifier(self.openmm_snap)
@@ -633,14 +628,12 @@ class TestSingleAtomVelocityDirectionModifier(object):
                         for i in range(len(new_vel))]
             same_vel = [np.allclose(new_vel[i], old_vel[i])
                         for i in range(len(new_vel))]
-            assert_equal(Counter(same_vel),
-                         Counter({True: n_atoms-1, False: 1}))
+            assert Counter(same_vel) == Counter({True: n_atoms-1, False: 1})
             u_vel_sq = (old_div(u.nanometers, u.picoseconds))**2
             for new_v, old_v in zip(new_vel, old_vel):
-                assert_almost_equal(
-                    sum([(v**2).value_in_unit(u_vel_sq) for v in new_v]),
-                    sum([(v**2).value_in_unit(u_vel_sq) for v in old_v])
-                )
+                assert (pytest.approx(
+                    sum([(v**2).value_in_unit(u_vel_sq) for v in new_v])) ==
+                    sum([(v**2).value_in_unit(u_vel_sq) for v in old_v]))
 
     def test_call_with_linear_momentum_fix(self):
         toy_modifier = SingleAtomVelocityDirectionModifier(
@@ -653,7 +646,7 @@ class TestSingleAtomVelocityDirectionModifier(object):
         momenta = velocities * new_toy_snap.masses[:, np.newaxis]
         assert_array_almost_equal(sum(momenta), np.array([0.0]*2))
         double_ke = sum(sum(momenta * velocities))
-        assert_almost_equal(double_ke, 86.0)
+        assert pytest.approx(double_ke) == 86.0
 
         if omt:  # TODO: separate out tests
             u_vel = old_div(u.nanometer, u.picosecond)

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -9,7 +9,7 @@ from nose.tools import (assert_equal, assert_not_equal, raises,
                         assert_almost_equal, assert_true)
 from nose.plugins.skip import SkipTest
 from numpy.testing import assert_array_almost_equal
-from .test_helpers import make_1d_traj, u
+from .test_helpers import u
 
 import openpathsampling as paths
 import openpathsampling.engines as peng
@@ -31,6 +31,7 @@ import logging
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+
 
 class TestNoModification(object):
     def setup(self):
@@ -56,7 +57,7 @@ class TestNoModification(object):
 
     # test methods from the abstract base class along with NoModification
     def test_extract_subset(self):
-        mod = NoModification(subset_mask=[1,2])
+        mod = NoModification(subset_mask=[1, 2])
         sub_1Dx = mod.extract_subset(self.snapshot_1D.coordinates)
         assert_array_almost_equal(sub_1Dx, np.array([1.0, 2.0]))
         sub_1Dv = mod.extract_subset(self.snapshot_1D.velocities)
@@ -70,7 +71,7 @@ class TestNoModification(object):
                                                      [2.5, 2.6, 2.7]]))
 
     def test_apply_to_subset(self):
-        mod = NoModification(subset_mask=[1,2])
+        mod = NoModification(subset_mask=[1, 2])
         copy_1Dx = self.snapshot_1D.coordinates.copy()
         new_1Dx = mod.apply_to_subset(copy_1Dx, np.array([-1.0, -2.0]))
         assert_array_almost_equal(new_1Dx, np.array([0.0, -1.0, -2.0, 3.0]))
@@ -115,6 +116,7 @@ class TestNoModification(object):
         # This should always return 1.0 even for invalid input
         assert self.modifier.probability_ratio(None, None) == 1.0
 
+
 class TestRandomizeVelocities(object):
     def setup(self):
         # TODO: check against several possibilities, including various
@@ -149,7 +151,7 @@ class TestRandomizeVelocities(object):
         # NOTE: these tests basically check the API. Tests for correctness
         # are in `test_snapshot_modifier.ipynb`, because they are inherently
         # stochastic.
-        randomizer = RandomVelocities(beta=old_div(1.0,5.0))
+        randomizer = RandomVelocities(beta=old_div(1.0, 5.0))
         new_1x2D = randomizer(self.snap_1x2D)
         assert_equal(new_1x2D.coordinates.shape, new_1x2D.velocities.shape)
         assert_array_almost_equal(new_1x2D.coordinates,
@@ -182,7 +184,7 @@ class TestRandomizeVelocities(object):
             assert_not_equal(val, 0.0)
 
     def test_subset_call(self):
-        randomizer = RandomVelocities(beta=old_div(1.0,5.0), subset_mask=[0])
+        randomizer = RandomVelocities(beta=old_div(1.0, 5.0), subset_mask=[0])
         new_2x3D = randomizer(self.snap_2x3D)
         assert_equal(new_2x3D.coordinates.shape, new_2x3D.velocities.shape)
         assert_array_almost_equal(new_2x3D.coordinates,
@@ -254,6 +256,7 @@ class TestRandomizeVelocities(object):
         # Should be sampled correctio, so this has to be 1.0
         randomizer = RandomVelocities(beta=20)
         assert randomizer.probability_ratio(None, None) == 1.0
+
 
 class TestGeneralizedDirectionModifier(object):
     def setup(self):
@@ -352,7 +355,7 @@ class TestGeneralizedDirectionModifier(object):
             rigid_water=False
         )
         ad_explicit_tmpl = omm_engine.snapshot_from_testsystem(ad_explicit)
-        explicit_engine= omm_engine.Engine(
+        explicit_engine = omm_engine.Engine(
             topology=ad_explicit_tmpl.topology,
             system=ad_explicit.system,
             integrator=omt.integrators.VVVRIntegrator()
@@ -412,8 +415,10 @@ class TestGeneralizedDirectionModifier(object):
         u_mass = old_div(u.dalton, u.AVOGADRO_CONSTANT_NA)
         u_energy = old_div(u.kilojoule_per_mole, u.AVOGADRO_CONSTANT_NA)
 
-        velocities = \
-                np.array([[1.5, -1.0], [-1.0, 2.0], [0.25, -1.0]]) * u_vel
+        velocities = np.array([[1.5, -1.0],
+                               [-1.0, 2.0],
+                               [0.25, -1.0]]
+                              ) * u_vel
         masses = np.array([1.0, 1.5, 4.0]) * u_mass
         new_vel = self.openmm_modifier._remove_linear_momentum(
             velocities=velocities,
@@ -443,6 +448,7 @@ class TestGeneralizedDirectionModifier(object):
         # Should always be 1 as KE is conserved
         assert self.toy_modifier_all.probability_ratio(None, None) == 1.0
 
+
 class TestVelocityDirectionModifier(object):
     def setup(self):
         import openpathsampling.engines.toy as toys
@@ -469,7 +475,8 @@ class TestVelocityDirectionModifier(object):
                 remove_linear_momentum=False
             )
             if omt:  # TODO: separate out tests
-                ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)
+                ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(
+                    constraints=None)
                 self.test_snap = omm_engine.snapshot_from_testsystem(ad_vacuum)
                 self.openmm_engine = omm_engine.Engine(
                     topology=self.test_snap.topology,
@@ -479,7 +486,8 @@ class TestVelocityDirectionModifier(object):
 
                 self.openmm_snap = self.test_snap.copy_with_replacement(
                     engine=self.openmm_engine,
-                    velocities=np.ones(shape=self.test_snap.velocities.shape) * u_vel
+                    velocities=np.ones(
+                        shape=self.test_snap.velocities.shape) * u_vel
                 )
 
     def test_select_atoms_to_modify(self):
@@ -550,6 +558,7 @@ class TestVelocityDirectionModifier(object):
             assert_array_almost_equal(total_momenta,
                                       np.array([0.0]*3) * u_vel * u_mass)
 
+
 class TestSingleAtomVelocityDirectionModifier(object):
     def setup(self):
         import openpathsampling.engines.toy as toys
@@ -575,7 +584,8 @@ class TestSingleAtomVelocityDirectionModifier(object):
                 delta_v=1.2*u_vel,
                 remove_linear_momentum=False
             )
-            ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(constraints=None)
+            ad_vacuum = omt.testsystems.AlanineDipeptideVacuum(
+                constraints=None)
             self.test_snap = omm_engine.snapshot_from_testsystem(ad_vacuum)
             self.openmm_engine = omm_engine.Engine(
                 topology=self.test_snap.topology,
@@ -585,7 +595,8 @@ class TestSingleAtomVelocityDirectionModifier(object):
 
             self.openmm_snap = self.test_snap.copy_with_replacement(
                 engine=self.openmm_engine,
-                velocities=np.ones(shape=self.test_snap.velocities.shape) * u_vel
+                velocities=np.ones(
+                    shape=self.test_snap.velocities.shape) * u_vel
             )
 
     def test_select_atoms_to_modify(self):
@@ -622,7 +633,8 @@ class TestSingleAtomVelocityDirectionModifier(object):
                         for i in range(len(new_vel))]
             same_vel = [np.allclose(new_vel[i], old_vel[i])
                         for i in range(len(new_vel))]
-            assert_equal(Counter(same_vel), Counter({True: n_atoms-1, False: 1}))
+            assert_equal(Counter(same_vel),
+                         Counter({True: n_atoms-1, False: 1}))
             u_vel_sq = (old_div(u.nanometers, u.picoseconds))**2
             for new_v, old_v in zip(new_vel, old_vel):
                 assert_almost_equal(

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -666,11 +666,13 @@ class TestSingleAtomVelocityDirectionModifier(object):
 
 
 class TestSnapshotModifierDeprecation(object):
-    # TODO OPS 2.0: Depr should b completed and this test altered to check for
+    # TODO OPS 2.0: Depr should be completed and this test altered to check for
     # the error
     def test_raise_deprecation(self):
         class DummyMod(SnapshotModifier):
-            pass
+            # TODO PY 2.7, don't override __call__ for  PY 3.x
+            def __call__(self, a):
+                pass
         dummy_mod = DummyMod()
         with pytest.warns(DeprecationWarning) as warn:
             a = dummy_mod.probability_ratio(None, None)

--- a/openpathsampling/tests/test_spring_shooting.py
+++ b/openpathsampling/tests/test_spring_shooting.py
@@ -109,10 +109,14 @@ class TestSpringShootingSelector(SelectorTest):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=1)
         sel._acceptable_snapshot = True
-        ratio = sel.probability_ratio(None, None, None)
+        # TODO OPS 2.0:  Last value here is not None to silence deprecation
+        # warnings, should be set to None after the completion
+        ratio = sel.probability_ratio(None, None, None, 1)
         assert ratio == 1.0
         sel._acceptable_snapshot = False
-        ratio = sel.probability_ratio(None, None, None)
+        # TODO OPS 2.0:  Last value here is not None to silence deprecation
+        # warnings, should be set to None after the completion
+        ratio = sel.probability_ratio(None, None, None, 1)
         assert ratio == 0.0
 
     def test_sanity_breaking_fw_pick(self):

--- a/openpathsampling/tests/test_spring_shooting.py
+++ b/openpathsampling/tests/test_spring_shooting.py
@@ -297,7 +297,7 @@ class TestSpringShootingSelector(SelectorTest):
         sel.restart_from_step(step)
         assert sel.trial_snapshot == 10
 
-    def test_deprectation(self):
+    def test_deprecation(self):
         sel = self.default_selector
         # Override to mimick a good pick
         sel._acceptable_snapshot = True

--- a/openpathsampling/tests/test_spring_shooting.py
+++ b/openpathsampling/tests/test_spring_shooting.py
@@ -14,6 +14,7 @@ from openpathsampling.pathmovers.spring_shooting import (
     ForwardSpringMover, BackwardSpringMover,
     SpringShootingMover, SpringShootingStrategy,
     SpringShootingMoveScheme)
+from openpathsampling.deprecations import NEW_SNAPSHOT_SELECTOR
 
 
 class FakeStep(object):
@@ -295,6 +296,15 @@ class TestSpringShootingSelector(SelectorTest):
         step = FakeStep(details)
         sel.restart_from_step(step)
         assert sel.trial_snapshot == 10
+
+    def test_deprectation(self):
+        sel = self.default_selector
+        # Override to mimick a good pick
+        sel._acceptable_snapshot = True
+        with pytest.warns(DeprecationWarning, match="new_snapshot"):
+            _ = sel.probability_ratio(None, None, None)
+        # Reset warning
+        NEW_SNAPSHOT_SELECTOR.has_warned = False
 
 
 class MoverTest(SelectorTest):


### PR DESCRIPTION
Closes #794 for all OPS classes
However, a new issue should be opened to discuss a refactor of `EngineMover` to take this and the other bias options [described in this comment](https://github.com/openpathsampling/openpathsampling/issues/794#issuecomment-923830025) into account for OPS 2.0.

Custom implementations of both `EngineMover` and `SnapshotModifier` should tyake care to implement this correctly on their end.

Big assumption (that might break API): **A key that starts with "bias" should not be present in `run_details` if it is not intended to be used for the bias calculation of a sample** 

todo:

- [x] add functionality
- [x]  add tests
- [x]  update docstrings
- [x]  make touched files pep8 compliant
- [x]  remove nose from touched tests (partial #756)

commit descriptions:
4f017dd adds probability_ratio to snapshot modifiers
ad7fad0 allows the usage of this probability ratio to be used as a bias in EngineMovers
0e42bb9 reverts an oversight in my thought pattern about the acceptance bias of velocities that are directly sampled from the correct boltzman distribution
ad33488 and b351417 add tests for the added functionality
abf0d99 alters the docstrings that were already present
276e3b3 fixes pep8 complaints from my env
f591ca7 drops nose from the tests
8a6057e Fixes an py2.7 issue in the tests where you can't initiate a class without overwriting *all* abstract methods

[Edit]: added a link to the mentioned comment