### PR TITLE
Take care of coordinate modifcation in selector probability_ratio  

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -168,6 +168,17 @@ OPENMM_MDTRAJTOPOLOGY = Deprecation(
     deprecated_in=(1, 5, 0)
 )
 
+NEW_SNAPSHOT_SELECTOR = Deprecation(
+    problem=("new_snapshot=None; If snapshot has been copied or modified we "
+             "can't find it in trial_trajectory. This call signature will "
+             "update to "
+             "(old_snapshot, old_trajectory, new_snapshot, new_trajectory) "
+             "in {OPS} {version}. "),
+    remedy=("Call with kwargs and use new_snapshot=old_snapshot if "
+            " old_snapshot is not copied or modified in new_traj"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/pathmovers/spring_shooting.py
+++ b/openpathsampling/pathmovers/spring_shooting.py
@@ -3,6 +3,7 @@ import numpy as np
 from openpathsampling.high_level.move_strategy import levels
 from openpathsampling.pathmover import SampleNaNError, SampleMaxLengthError
 import openpathsampling.high_level.move_strategy as move_strategy
+from openpathsampling.deprecations import NEW_SNAPSHOT_SELECTOR
 from functools import reduce
 
 
@@ -192,6 +193,8 @@ class SpringShootingSelector(paths.ShootingPointSelector):
                 1.0 if anacceptable snapshot has been chosen 0.0 otherwise
         """
         # Check if an acceptable snapshot was selected
+        if new_snapshot is None:
+            NEW_SNAPSHOT_SELECTOR.warn(stacklevel=3)
         if self._acceptable_snapshot:
             return 1.0
         else:

--- a/openpathsampling/pathmovers/spring_shooting.py
+++ b/openpathsampling/pathmovers/spring_shooting.py
@@ -171,7 +171,7 @@ class SpringShootingSelector(paths.ShootingPointSelector):
             return sum(self._spring_biases(delta_max, k_spring))
 
     def probability_ratio(self, snapshot, initial_trajectory,
-                          trial_trajectory):
+                          trial_trajectory, new_snapshot=None):
         """
         Returns the acceptance probability of a trial trajectory, this is 1.0
         as long as a snapshot has been selected that is inside of the

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -1,8 +1,6 @@
 import math
 import logging
 
-import numpy as np
-
 from openpathsampling.netcdfplus import StorableNamedObject
 from openpathsampling import default_rng
 
@@ -34,9 +32,13 @@ class ShootingPointSelector(StorableNamedObject):
         else:
             return 0.0
 
-    def probability_ratio(self, snapshot, old_trajectory, new_trajectory):
+    def probability_ratio(self, snapshot, old_trajectory,
+                          new_trajectory, new_snapshot=None):
+        # TODO OPS 2.0: We should probabily alter the order and keyword names
+        # of this call
+        new_snapshot = new_snapshot or snapshot
         p_old = self.probability(snapshot, old_trajectory)
-        p_new = self.probability(snapshot, new_trajectory)
+        p_new = self.probability(new_snapshot, new_trajectory)
         return p_new / p_old
 
     def _biases(self, trajectory):
@@ -171,7 +173,7 @@ class UniformSelector(ShootingPointSelector):
 
     def pick(self, trajectory):
         idx = self._rng.integers(self.pad_start,
-                                len(trajectory) - self.pad_end)
+                                 len(trajectory) - self.pad_end)
         return idx
 
 
@@ -229,7 +231,9 @@ class FinalFrameSelector(ShootingPointSelector):
     def probability(self, snapshot, trajectory):  # pragma: no cover
         return 1.0  # there's only one choice
 
-    def probability_ratio(self, snapshot, old_trajectory, new_trajectory):
+    def probability_ratio(self, snapshot, old_trajectory,
+                          new_trajectory, new_snapshot=None):
+        # TODO OPS 2.0: alter the order + keywords in the call
         # must be matched by a final-frame selector somewhere
         return 1.0
 
@@ -253,6 +257,8 @@ class FirstFrameSelector(ShootingPointSelector):
     def probability(self, snapshot, trajectory):  # pragma: no cover
         return 1.0  # there's only one choice
 
-    def probability_ratio(self, snapshot, old_trajectory, new_trajectory):
+    def probability_ratio(self, snapshot, old_trajectory,
+                          new_trajectory, new_snapshot=None):
+        # TODO OPS 2.0: alter the order + keywords in the call
         # must be matched by a first-frame selector somewhere
         return 1.0

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -3,6 +3,7 @@ import logging
 
 from openpathsampling.netcdfplus import StorableNamedObject
 from openpathsampling import default_rng
+from openpathsampling.deprecations import NEW_SNAPSHOT_SELECTOR
 
 logger = logging.getLogger(__name__)
 init_log = logging.getLogger('openpathsampling.initialization')
@@ -36,6 +37,8 @@ class ShootingPointSelector(StorableNamedObject):
                           new_trajectory, new_snapshot=None):
         # TODO OPS 2.0: We should probabily alter the order and keyword names
         # of this call
+        if new_snapshot is None:
+            NEW_SNAPSHOT_SELECTOR.warn(stacklevel=3)
         new_snapshot = new_snapshot or snapshot
         p_old = self.probability(snapshot, old_trajectory)
         p_new = self.probability(new_snapshot, new_trajectory)
@@ -235,6 +238,9 @@ class FinalFrameSelector(ShootingPointSelector):
                           new_trajectory, new_snapshot=None):
         # TODO OPS 2.0: alter the order + keywords in the call
         # must be matched by a final-frame selector somewhere
+
+        if new_snapshot is None:
+            NEW_SNAPSHOT_SELECTOR.warn(stacklevel=3)
         return 1.0
 
 
@@ -261,4 +267,7 @@ class FirstFrameSelector(ShootingPointSelector):
                           new_trajectory, new_snapshot=None):
         # TODO OPS 2.0: alter the order + keywords in the call
         # must be matched by a first-frame selector somewhere
+
+        if new_snapshot is None:
+            NEW_SNAPSHOT_SELECTOR.warn(stacklevel=3)
         return 1.0

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -83,6 +83,7 @@ class TestGaussianBiasSelector(SelectorTest):
         expected = pytest.approx(self.f[frame] / norm)
         assert self.sel.probability(traj[frame], traj) == expected
 
+
 class TestBiasedSelector(SelectorTest):
     def setup(self):
         super(TestBiasedSelector, self).setup()
@@ -124,6 +125,7 @@ class TestBiasedSelector(SelectorTest):
         traj = self.mytraj
         expected = pytest.approx(f[frame] / norm)
         assert sel.probability(traj[frame], traj) == expected
+
 
 class TestFirstFrameSelector(SelectorTest):
     def test_pick(self):
@@ -223,8 +225,9 @@ class TestConstrainedSelector(SelectorTest):
         frame = mytraj[idx]
         # Alter 0.1 to 0.11 and replace the original snapshot with the modded
         # one
-        mod_frame = frame.copy_with_replacement(coordinates=0.11)
+        mod_frame = frame.copy_with_replacement(coordinates=[[0.11]])
         mod_traj = mytraj[:idx]
         mod_traj += paths.Trajectory([mod_frame])
         mod_traj + mytraj[idx+1:]
-        assert self.sel.probability_ratio(frame, mytraj, mod_traj) == 1.0
+        prob = self.sel.probability_ratio(frame, mytraj, mod_traj, mod_frame)
+        assert prob == 1.0

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -214,3 +214,17 @@ class TestConstrainedSelector(SelectorTest):
         for idx1, frame in enumerate(mytraj):
             if (idx1 != expected_idx):
                 assert self.sel.f(frame, mytraj) == 0.0
+
+    def test_probability_ratio_modified_coordinates(self):
+        # Test if probability ratio still works when coordinates are modified
+        mytraj = make_1d_traj(coordinates=[-0.5, -0.4, -0.3, -0.1,
+                                           0.1, 0.2, 0.3, 0.5])
+        idx = self.sel.pick(mytraj)
+        frame = mytraj[idx]
+        # Alter 0.1 to 0.11 and replace the original snapshot with the modded
+        # one
+        mod_frame = frame.copy_with_replacement(coordinates=0.11)
+        mod_traj = mytraj[:idx]
+        mod_traj += paths.Trajectory([mod_frame])
+        mod_traj + mytraj[idx+1:]
+        assert self.sel.probability_ratio(frame, mytraj, mod_traj) == 1.0

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -217,7 +217,8 @@ class TestConstrainedSelector(SelectorTest):
             if (idx1 != expected_idx):
                 assert self.sel.f(frame, mytraj) == 0.0
 
-    def test_probability_ratio_modified_coordinates(self):
+    @pytest.mark.parametrize("new_coord,expected", [(0.11, 1.0), (-0.09, 0.0)])
+    def test_probability_ratio_modified_coordinates(self, new_coord, expected):
         # Test if probability ratio still works when coordinates are modified
         mytraj = make_1d_traj(coordinates=[-0.5, -0.4, -0.3, -0.1,
                                            0.1, 0.2, 0.3, 0.5])
@@ -225,9 +226,9 @@ class TestConstrainedSelector(SelectorTest):
         frame = mytraj[idx]
         # Alter 0.1 to 0.11 and replace the original snapshot with the modded
         # one
-        mod_frame = frame.copy_with_replacement(coordinates=[[0.11]])
+        mod_frame = frame.copy_with_replacement(coordinates=[[new_coord]])
         mod_traj = mytraj[:idx]
         mod_traj += paths.Trajectory([mod_frame])
-        mod_traj + mytraj[idx+1:]
+        mod_traj += mytraj[idx+1:]
         prob = self.sel.probability_ratio(frame, mytraj, mod_traj, mod_frame)
-        assert prob == 1.0
+        assert prob == expected


### PR DESCRIPTION
From writing down the code in [this comment](https://github.com/openpathsampling/openpathsampling/pull/1075#issuecomment-935750466) I noticed that selector.probability_ratio might not properly work for snapshots that get their coordinates altered.



### How does this fail?
- `selector.probability_ratio` takes a frame, normally the original selected shooting point, the original trajectory, and a new trajectory
-  that frame can be modified before generating the new trajectory, which would lead to the situation that new_traj.index(frame) raises a `ValueError` if the coordinates were modified
- the added test in 3ad2cc3 shows that this behaviour indeed fails

### Why is the ValueError raised when you alter the coordinates, but not with velocity modifications?
- `Trajectory` objects are essentially `list`s and inherits their way of checking for 'index'
- ~~`Trajectory.index(snapshot)` looks at the `hash`es of all internal `Snapshots` and compares them against `hash(snapshot)`~~
(Not true; in general it checks `==`, which for all objects in OPS this checks their `__uuid__` (which is also used as part of the hash))
-  ~~`hash(snapshot)` is determined by the coordinates -> identical coordinates generate identical hashes~~ (This is not true and based on me misremembering things)
- ~~altering the coordinates of a `snapshot` alters the `hash`~~ (This is not true and based on me misremembering things)
-  ~~the hash of original frame does therefor is not found in the altered trajectory, leading to a failure of the `index` call~~

### Why is this only an issue for this selector
-  All other selectors sidestep the issue by not relying on the snapshot hash (either by setting the ratio to 1.0 or the probability of all snapshots to 1.0)

### Solution
This PR adds a keyword argument `new_snapshot` to `probability_ratio`, which defaults to `snapshot` if not given for all internal OPS selectors.

### Possible OPS 2.0 alterations
@dwhswenson  Should we update the call signature of this function to `(old_snapshot, old_trajectory, new_snapshot, new_trajectory)` in 2.0 and raise a Deprecation warning if new_snapshot is not defined for 1.X?

The integration of calling the probability ratio with the new snapshot inside the `EngineMover` will be done as part of #1075 