### PR TITLE
add no_copy option to NoModifier and Deprecate 'subset_mask'

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -168,6 +168,13 @@ OPENMM_MDTRAJTOPOLOGY = Deprecation(
     deprecated_in=(1, 5, 0)
 )
 
+NOMODIFICATION_SUBSET_MASK = Deprecation(
+    problem=("subset_mask is nonsense for NoModification, is ignored in the "
+             "call, and will be removed as initialisation argument."),
+    remedy=("You should not use this keyword"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/snapshot_modifier.py
+++ b/openpathsampling/snapshot_modifier.py
@@ -9,6 +9,7 @@ import numpy as np
 import openpathsampling as paths
 from openpathsampling.netcdfplus import StorableNamedObject, StorableObject
 
+from openpathsampling.deprecations import NOMODIFICATION_SUBSET_MASK
 logger = logging.getLogger(__name__)
 
 
@@ -109,9 +110,24 @@ class SnapshotModifier(StorableNamedObject):
         raise NotImplementedError
 
 class NoModification(SnapshotModifier):
-    """Modifier with no change: returns a copy of the snapshot."""
+    """Modifier with no change: "
+
+    Parameters
+    ----------
+    as_copy : bool, default True
+        if True calls return a copy of the snapshot, else the snapshot itself.
+    """
+    def __init__(self, subset_mask=None, as_copy=True):
+        # TODO OPS 2.0: subset mask should be removed from this init call
+        if subset_mask is not None:
+            NOMODIFICATION_SUBSET_MASK.warn(stacklevel=3)
+        # masking is nonsense for no modification, but used in testing so this
+        # is here to conserve API
+        super(NoModification, self).__init__(subset_mask=subset_mask)
+        self.as_copy = as_copy
+
     def __call__(self, snapshot):
-        return snapshot.copy()
+        return snapshot.copy() if self.as_copy else snapshot
 
 class RandomVelocities(SnapshotModifier):
     """Randomize velocities according to the Boltzmann distribution.


### PR DESCRIPTION
This is a cherry picked version of https://github.com/openpathsampling/openpathsampling/pull/1075/commits/79c961ee94b03dbbd05cabc20c52d95a798e1682 from #1075 in order to seperate out the comments

Copies of relevant comments:
> @dwhswenson wrote:
> More thoughts coming later, but here's a really quick one:
>
>    even with NoModification I am pretty sure new == old but not new is old (only a copy is returned).
>
>Looking at the code, you're correct. In usage here, I think we want the default modifier (for one-way shooting, e.g.) to return `new`  such that new is old. My suggestion (pretty easy change to the current code):
>```
>class NoModification(SnapshotModifier):
>   def __init__(self, as_copy=True):
>     # masking change to only certain atoms is nonsense for no modification
>       super(NoModification, self).__init__(subset_mask=None)
>       self.as_copy = as_copy
>
>    def __call__(self, snapshot):
>        return snapshot.copy() if self.as_copy else snapshot
>```
> Then use NoModification(as_copy=False) as the default in the changes here.

> @sroet wrote:
> That was way more nasty than expected, as we actually test for subset_mask on NoModification (as a proxy for subclassing SnapshotModifier) Also, apparently old.copy() != old for toy snapshots, I did not really investigate this, but I am afraid we are losing precision on the copy when seeing all the assert_almost_equal in the tests for this modifier...

> @dwhswenson wrote:
> > I can cherry pick over that commit into a separate PR if that is preferred
> 
> Yeah, if it's going to be a headache, let's move it into a separate PR to keep discussion a little cleaner.
> 
> > That was way more nasty than expected, as we actually test for subset_mask on NoModification (as a proxy for subclassing `SnapshotModifier`)
> 
> That part is easily fixed by subclassing in tests. I was lazy before; sorry! man_shrugging
> 
> > Also, apparently `old.copy() != old` for toy snapshots, I did not really investigate this, but I am afraid we are losing precision on the copy when seeing all the `assert_almost_equal` in the tests for this modifier...
> 
> I'm not surprised by this. There's enough bouncing between C and Python representations that I wouldn't be surprised if these are only `almost_equal`.

