### PR TITLE
Python versions should be strings in YAML

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.9
+          python-version: "3.9"
       - name: "Install requirements"
         run: source devtools/conda_install_reqs.sh
       - name: "Install OPS"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
-          - 3.9
-          - 3.8
-          - 3.7
-          - 2.7
+          - "3.9"
+          - "3.8"
+          - "3.7"
+          - "2.7"
         MINIMAL: [""]
         include:
-          - CONDA_PY: 3.7
+          - CONDA_PY: "3.7"
             MINIMAL: "minimal"
 
     steps:


### PR DESCRIPTION
Reduce likelihood of mistakes when adding 3.10 to the matrix -- getting ahead of this: https://twitter.com/choldgraf/status/1446666661650599936