### PR TITLE
unbreak API call to selector.probability_ratio

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -190,6 +190,20 @@ NEW_SNAPSHOT_SELECTOR = Deprecation(
     deprecated_in=(1, 6, 0)
 )
 
+NEW_SNAPSHOT_KWARG_SELECTOR = Deprecation(
+    problem=("'new_snapshot' should be a supported keyword in "
+             "selector.probability_ratio(); If snapshot has been copied or "
+             "modified we can't reliably find it in trial_trajectory. This "
+             "keyword must be supported in the expected signature: "
+             "(old_snapshot, old_trajectory, new_snapshot, new_trajectory) "
+             "in {OPS} {version}. "),
+    remedy=("kwarg 'new_snapshot' must to be supported, implement it as "
+            "new_snapshot=old_snapshot if new_traj is not used to calculate "
+            "the weight of old_snapshot"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -17,7 +17,8 @@ from .ops_logging import initialization_logging
 from .treelogic import TreeMixin
 
 from openpathsampling.deprecations import deprecate, has_deprecations
-from openpathsampling.deprecations import SAMPLE_DETAILS, MOVE_DETAILS
+from openpathsampling.deprecations import (SAMPLE_DETAILS, MOVE_DETAILS,
+                                           NEW_SNAPSHOT_KWARG_SELECTOR)
 
 from future.utils import with_metaclass
 
@@ -834,12 +835,20 @@ class EngineMover(SampleMover):
             new_snapshot = run_details.get("modified_shooting_snapshot",
                                            old_snapshot)
             # Selector bias
-            bias *= self.selector.probability_ratio(
-                initial_trajectory[shooting_index],
-                initial_trajectory,
-                trial_trajectory,
-                new_snapshot=new_snapshot
-            )
+            try:
+                bias *= self.selector.probability_ratio(
+                    initial_trajectory[shooting_index],
+                    initial_trajectory,
+                    trial_trajectory,
+                    new_snapshot=new_snapshot
+                )
+            except TypeError:
+                bias *= self.selector.probability_ratio(
+                    initial_trajectory[shooting_index],
+                    initial_trajectory,
+                    trial_trajectory)
+                NEW_SNAPSHOT_KWARG_SELECTOR.warn()
+
             # Modifier bias
             bias *= self.modifier.probability_ratio(old_snapshot, new_snapshot)
         else:

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -15,7 +15,6 @@ import pytest
 
 import openpathsampling as paths
 from openpathsampling.collectivevariable import FunctionCV
-from openpathsampling.deprecations import Deprecation
 from openpathsampling.engines.trajectory import Trajectory
 from openpathsampling.ensemble import LengthEnsemble
 from openpathsampling.pathmover import *

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -15,6 +15,7 @@ import pytest
 
 import openpathsampling as paths
 from openpathsampling.collectivevariable import FunctionCV
+from openpathsampling.deprecations import Deprecation
 from openpathsampling.engines.trajectory import Trajectory
 from openpathsampling.ensemble import LengthEnsemble
 from openpathsampling.pathmover import *
@@ -1573,3 +1574,30 @@ class TestAbstract(object):
         with pytest.raises(TypeError,
                            match="Can't instantiate abstract class"):
             abstract_class()
+
+
+class TestDeprecation(TestShootingMover):
+    def test_no_new_snapshot_kwarg_selector(self):
+        class OldSelector(UniformSelector):
+            def __init__(self):
+                super(OldSelector, self).__init__()
+
+            # Override prob_ratio with old signature
+            def probability_ratio(self, snapshot,
+                                  old_trajectory, new_trajectory):
+                prob = super(OldSelector, self).probability_ratio(
+                    snapshot,
+                    old_trajectory,
+                    new_trajectory,
+                    snapshot
+                )
+                return prob
+
+        mover = ForwardShootMover(ensemble=self.tps,
+                                  selector=OldSelector(),
+                                  engine=self.dyn)
+        self.dyn.initialized = True
+        with pytest.warns(DeprecationWarning,
+                          match="'new_snapshot' should be a supported "):
+            a = mover.move(self.init_samp)
+        assert a is not None


### PR DESCRIPTION
Of course merging #1075 let to a downstream CI of mine failing because it broke some API... :facepalm: 
it errors with:
```
  File "/builds/sroet/web_throwing/openpathsampling/openpathsampling/pathmover.py", line 841, in _build_sample
    new_snapshot=new_snapshot
TypeError: probability_ratio() got an unexpected keyword argument 'new_snapshot'
```

This catches the break and raises an appropriate warning instead of failing outright.