### PR TITLE
SimStore: Fix issue with internalized snapshot box vectors

### DIFF
--- a/openpathsampling/engines/features/box_vectors.py
+++ b/openpathsampling/engines/features/box_vectors.py
@@ -3,6 +3,10 @@ numpy = ['box_vectors']
 
 dimensions = ['n_spatial']
 
+schema_entries = [
+    ('box_vectors', 'ndarray.float32({n_spatial},{n_spatial})')
+]
+
 
 def netcdfplus_init(store):
     store.create_variable(

--- a/openpathsampling/experimental/storage/test_snapshot_integrations.py
+++ b/openpathsampling/experimental/storage/test_snapshot_integrations.py
@@ -7,6 +7,7 @@ import os
 
 import numpy as np
 import openpathsampling as paths
+from openpathsampling.integration_tools import unit
 
 from openpathsampling.tests.test_helpers import data_filename
 
@@ -48,6 +49,10 @@ class TestSnapshotIntegration(object):
         )
         return snap
 
+    def _make_gromacs_int_snap(self):
+        snap = self._make_gromacs_snap()
+        return snap.internalize()
+
     def _make_openmm_snap(self):
         mm = pytest.importorskip('simtk.openmm')
         traj_file = data_filename('ala_small_traj.pdb')
@@ -55,13 +60,30 @@ class TestSnapshotIntegration(object):
         snap = traj[0]
         return snap
 
-    @pytest.mark.parametrize('integration', ['gromacs', 'openmm'])
+    @pytest.mark.parametrize('integration', ['gromacs', 'openmm',
+                                             'gromacs_int'])
     def test_integration(self, integration):
         make_snap = {
             'gromacs': self._make_gromacs_snap,
             'openmm': self._make_openmm_snap,
+            'gromacs_int': self._make_gromacs_int_snap,
         }[integration]
+
         snap = make_snap()
+
+        # already skipping if OpenMM isn't available, so we can use unit
+        nm = unit.nanometer
+        ps = unit.picosecond
+        get_velocities = {
+            'gromacs': lambda snap: snap.velocities,
+            'gromacs_int': lambda snap: snap.velocities,
+            'openmm': lambda snap: snap.velocities.value_in_unit(nm/ps),
+        }[integration]
+        get_box_vectors = {
+            'gromacs': lambda snap: snap.box_vectors,
+            'gromacs_int': lambda snap: snap.box_vectors,
+            'openmm': lambda snap: snap.box_vectors.value_in_unit(nm),
+        }[integration]
 
         storage = self._make_storage(mode='w')
         assert not storage.backend.has_table('snapshot0')
@@ -73,6 +95,9 @@ class TestSnapshotIntegration(object):
         assert storage.backend.has_table('snapshot0')
         snap2 = storage.snapshots.tables['snapshot0'][0]
 
+        assert not snap is snap2
         np.testing.assert_array_equal(snap.xyz, snap2.xyz)
-
-
+        np.testing.assert_array_equal(get_velocities(snap),
+                                      get_velocities(snap2))
+        np.testing.assert_array_equal(get_box_vectors(snap),
+                                      get_box_vectors(snap2))


### PR DESCRIPTION
This fixes a bug when using `engines.features.box_vectors` in SimStore. Previously, these were not saved.

As far as I can tell, this bug only occurs if you are using the internalized Gromacs snapshots, introduced in #933, and storing them with the new SimStore storage system. (However, it could be an issue for engines that aren't included in core OPS.) The OpenMM engine uses a box vectors feature in `engines.features.statics` and the Gromacs engine uses a box vectors feature in `engines.external_snapshots.features.box_vectors`, so neither of these are affected. I only found this bug when I was going to suggest using SimStore + internalized snapshots as part of a [user question](https://mattermodeling.stackexchange.com/questions/6967/) that came up today. It seems that I overlooked this feature when adding SimStore storage support.

New tests fail without the (simple) fix in the feature file and pass with the fix.