### PR TITLE
DOCS: Add GitHub support to `copyfiles`, remove online notebook downloads

### DIFF
--- a/docs/copyfiles/copyfiles.py
+++ b/docs/copyfiles/copyfiles.py
@@ -33,9 +33,20 @@ def copy_gitlab(source, dest, files):
         print(url)
         urllib.request.urlretrieve(url, dest / f)
 
+def copy_github(source, dest, files):
+    domain = "http://raw.githubusercontent.com/"
+    if not source.endswith("/"):
+        source = source + "/"
+    dest = pathlib.Path(dest)
+    for f in files:
+        url = domain + source + f
+        print(url)
+        urllib.request.urlretrieve(url, dest / f)
+
 DISPATCH = {
     'local': copy_local,
-    'gitlab': copy_gitlab
+    'gitlab': copy_gitlab,
+    'github': copy_github,
 }
 
 def make_copies(fileset):

--- a/docs/copyfiles/notebooks.yml
+++ b/docs/copyfiles/notebooks.yml
@@ -11,13 +11,13 @@ copyfiles:
       - toy_model_mstis/toy_mstis_1_setup.ipynb
       - toy_model_mstis/toy_mstis_2_run.ipynb
       - toy_model_mstis/toy_mstis_3_analysis.ipynb
-  - gitlab: http://gitlab.e-cam2020.eu/dwhswenson/ops_tutorial
-    target: examples/ops_tutorial
-    mkdirs:
-      - examples/ops_tutorial
-    files:
-      - 1_tps_sampling_tutorial.ipynb
-      - 2_tps_analysis_tutorial.ipynb
-      - 3_committor_analysis_tutorial.ipynb
-      - 4_mstis_sampling_tutorial.ipynb
-      - 5_advanced_customize_shooting.ipynb
+  #- github: openpathsampling/ops_tutorial/main
+    #target: examples/ops_tutorial
+    #mkdirs:
+      #- examples/ops_tutorial
+    #files:
+      #- 1_tps_sampling_tutorial.ipynb
+      #- 2_tps_analysis_tutorial.ipynb
+      #- 3_committor_analysis_tutorial.ipynb
+      #- 4_mstis_sampling_tutorial.ipynb
+      #- 5_advanced_customize_shooting.ipynb


### PR DESCRIPTION
In order to move notebooks into the right locations, a while ago I added a `copyfiles` script to our docs directory. This is specifically used to bring our docs from examples into the docs, where Sphinx can find them.

Today, I discovered that it was using GitLab to download (very outdated) copies of our tutorial notebooks. So I updated the script to allow us to use GitHub instead.

Then I realized that I we're not even *using* those downloaded notebooks in our docs. 🤷‍♂️ It definitely makes more sense to just *link* to the repositories, especially given the option of launching the tutorial with Binder.

In any case, I left the addition of support for GitHub, and removed the downloads of the tutorial notebooks from online (this also would have been an annoyance to anyone trying to build our docs without internet connectivity). I left previous usage commented as an example for any future users.

This should be immediately ready for review.