### PR TITLE
SimStore: Fix storable function serialization

### DIFF
--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -346,6 +346,8 @@ class StorableFunction(StorableNamedObject):
             'func': self.func,  # made into JSON by CallableCodec
             'source': self.source,
             'kwargs': self.kwargs,
+            'period_min': self.period_min,
+            'period_max': self.period_max,
         }
 
     @classmethod

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -375,7 +375,7 @@ class TestStorableFunction(object):
             return obj
 
         func = StorableFunction(func=identity, period_min=-2, period_max=2,
-                               store_source=True)
+                                store_source=True)
         dct = func.to_dict()
         assert 'identity' in dct['source']
         assert dct['period_max'] == 2

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -213,7 +213,7 @@ class TestStorableFunctionResults(object):
         assert len(self.sfr) == 2
 
     def test_to_dict_from_dict_cycle(self):
-        pass
+        pytest.skip()
 
 
 @mock.patch(_MODULE + '.get_uuid', lambda x: x)
@@ -246,15 +246,12 @@ class TestStorableFunction(object):
 
     def test_gets_source(self):
         pytest.skip()
-        pass
 
     def test_no_source_warning(self):
         pytest.skip()
-        pass
 
     def test_disk_cache_property(self):
         pytest.skip()
-        pass
 
     @pytest.mark.parametrize('mode', ['no-caching', 'analysis',
                                       'production'])
@@ -374,12 +371,21 @@ class TestStorableFunction(object):
 
 
     def test_to_dict_from_dict_cycle(self):
-        pytest.skip()
-        pass
+        def identity(obj):
+            return obj
+
+        func = StorableFunction(func=identity, period_min=-2, period_max=2,
+                               store_source=True)
+        dct = func.to_dict()
+        assert 'identity' in dct['source']
+        assert dct['period_max'] == 2
+        assert dct['period_min'] == -2
+        obj = StorableFunction.from_dict(dct.copy())
+        reser = obj.to_dict()
+        assert dct == reser
 
     def test_full_serialization_cycle(self):
         pytest.skip()
-        pass
 
     @pytest.mark.parametrize('found_in', ['cache', 'storage', 'eval'])
     def test_analysis_mode_integration(self, found_in):


### PR DESCRIPTION
This fixes a bug in SimStore storable functions serialization. When support for function periodicity was added in #990, it looks like I failed to add the periodicity information to the `StorableFunction.to_dict`. This fixes that, and includes a test to prevent regression.

Currently, function periodicity is only used by the (as yet unreleased) command line tools for setting up a simulation, where it is only used at object creation time to determine whether a volume should be periodic or not. This means that the only use case where this bug could be a problem would be if the user is using the unreleased CLI `wizard` to create *new* volumes for periodic CVs *after* loading that CV from a file. This is an unlikely use case, so I don't think this is a critical concern, but it does push for an OPS release before the CLI wizard is released.