### PR TITLE
Bump to Autorelease 0.3.2

### DIFF
--- a/.github/workflows/autorelease-default-env.sh
+++ b/.github/workflows/autorelease-default-env.sh
@@ -1,4 +1,6 @@
-INSTALL_AUTORELEASE="python -m pip install autorelease==0.3.0"
+# Vendored from Autorelease 0.3.2
+# Update by updating Autorelease and running `autorelease vendor actions`
+INSTALL_AUTORELEASE="python -m pip install autorelease==0.3.2"
 if [ -f autorelease-env.sh ]; then
     source autorelease-env.sh
 fi

--- a/.github/workflows/autorelease-deploy.yml
+++ b/.github/workflows/autorelease-deploy.yml
@@ -1,10 +1,13 @@
-name: Autorelease
+# Vendored from Autorelease 0.3.2
+# Update by updating Autorelease and running `autorelease vendor actions`
+name: "Autorelease Deploy"
 on:
   release:
     types: [published]
 
 jobs:
   deploy_pypi:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Deploy to PyPI"
     steps:

--- a/.github/workflows/autorelease-gh-rel.yml
+++ b/.github/workflows/autorelease-gh-rel.yml
@@ -1,11 +1,15 @@
-name: Autorelease
+# Vendored from Autorelease 0.3.2
+# Update by updating Autorelease and running `autorelease vendor actions`
+name: "Autorelease Release"
 on:
   push:
     branches:
+      # TODO: this should come from yaml conf
       - stable
 
 jobs:
   release-gh:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Cut release"
     steps:
@@ -31,3 +35,4 @@ jobs:
           autorelease-release --project $PROJECT --version $VERSION --token $AUTORELEASE_TOKEN
         env:
           AUTORELEASE_TOKEN: ${{ secrets.AUTORELEASE_TOKEN }}
+        name: "Cut release"

--- a/.github/workflows/autorelease-prep.yml
+++ b/.github/workflows/autorelease-prep.yml
@@ -1,9 +1,10 @@
-# File vencdored from Autorelease; specific version information should be in
-# the INSTALL_AUTORELEASE variable in autorelease-default-env.sh
-name: "Autorelease"
+# Vendored from Autorelease 0.3.2
+# Update by updating Autorelease and running `autorelease vendor actions`
+name: "Autorelease testpypi"
 on:
   pull_request:
     branches:
+      # TODO: this should come from yaml conf
       - stable
 
 defaults:
@@ -12,6 +13,7 @@ defaults:
 
 jobs:
   deploy_testpypi:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Deployment test"
     steps:
@@ -47,6 +49,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
         name: "Deploy to testpypi"
   test_testpypi:
+    if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Test deployed"
     needs: deploy_testpypi


### PR DESCRIPTION
Autorelease 0.3.2 was released back in August. The main improvements are in blocking Autorelease workflows from running on forks (see #1061, #1062) and in better information on the vendored files (to ensure that the status as vendored from Autorelease is more clear).