### PR TITLE
make a missed string into a rawstring

### DIFF
--- a/openpathsampling/engines/toy/pes.py
+++ b/openpathsampling/engines/toy/pes.py
@@ -371,7 +371,7 @@ class LinearSlope(PES):
 
 
 class DoubleWell(PES):
-    """Simple double-well potential. Independent in each degree of freedom.
+    r"""Simple double-well potential. Independent in each degree of freedom.
 
     V(x) = \sum_i A_i * (x_i**2 - x0_i**2)**2
 


### PR DESCRIPTION
This fixes a DeprecationWarning that popped up in the running tests after merging #787 
```
openpathsampling/engines/toy/pes.py:374
/home/sroet/github_files/openpathsampling/openpathsampling/engines/toy/pes.py:374: DeprecationWarning: invalid escape sequence \s
"""Simple double-well potential. Independent in each degree of freedom.
```