### PR TITLE
update copyright to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2019 the contributors to OpenPathSampling
+Copyright (c) 2014-2022 the contributors to OpenPathSampling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'OpenPathSampling'
-copyright = u'2014-2021, David W.H. Swenson, Jan-Hendrik Prinz, John Chodera, Peter Bolhuis'
+copyright = u'2014-2022, David W.H. Swenson, Jan-Hendrik Prinz, John Chodera, Peter Bolhuis'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Happy new year!

This updates the copyright I found with `grep -rl "2021" ./ --exclude=*.{pdb}`