### PR TITLE
Move check-openmm-rc off of main branch

### DIFF
--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -6,6 +6,9 @@ name: "Check for OpenMM RC"
 on:
   schedule:
     - cron: "0 9 * * *"
+  # use this for debugging
+  pull_request:
+    branch: master
 
 jobs:
   check-rc:
@@ -14,7 +17,7 @@ jobs:
     name: "Check for OpenMM RC"
     steps:
       - uses: actions/checkout@v2
-      - uses: dwhswenson/conda-rc-check@main
+      - uses: dwhswenson/conda-rc-check@v1
         id: checkrc
         with:
           channel: conda-forge

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -7,8 +7,8 @@ on:
   schedule:
     - cron: "0 9 * * *"
   # use this for debugging
-  pull_request:
-    branch: master
+  #pull_request:
+    #branch: master
 
 jobs:
   check-rc:


### PR DESCRIPTION
We're currently using the `@main` branch of the `check-openmm-rc` GitHub action. This is not a best practice, because (1) it does not guarantee a stable API, and (2) a bad actor could change that action and potentially abuse our resources.

I'm not actually terribly worried about either (since I maintain the action, I would update here if I broke the API). However, @mikemhenry came across what seems to be a broken `@v1` tag on that, so I thought I'd try to figure out how to fix it here.

My goal is to get this to work with a "stable API" approach, where the `@v1` tag will work. The most secure approach is to pin to a specific commit (usually the commit associated with a specific tag). We probably won't worry about that here, because GH actions is well compartmentalized and it shouldn't be possible to steal secrets from within the `check-openmm-rc` action.