### PR TITLE
Add FutureWarning for default filesetter external engines

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -211,7 +211,7 @@ NEW_DEFAULT_FILENAME_SETTER =  Deprecation(
     remedy=("If you want to keep the old counting behavior, add "
             '{"filename_setter": '
             "paths.engines.external_engine.FilenameSetter() } to the 'options'"
-            " of this engine. Otherwise, this behaviour will automatically "
+            " of this engine. Otherwise, this behavior will automatically "
             "change to RandomStringFilenames in OPS 2.0."),
     remove_version=(2, 0),
     deprecated_in=(1, 6, 0)

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -204,6 +204,20 @@ NEW_SNAPSHOT_KWARG_SELECTOR = Deprecation(
     deprecated_in=(1, 6, 0)
 )
 
+NEW_DEFAULT_FILENAME_SETTER =  Deprecation(
+    problem=("The default FilenameSetter for external engines is now a counter"
+             ", but will become a random string. This is more robust against "
+             "accidental overwrites."),
+    remedy=("If you want to keep the old counting behavior, add "
+            '{"filename_setter": '
+            "paths.engines.external_engine.FilenameSetter() } to the 'options'"
+            " of this engine. Otherwise, this behaviour will automatically "
+            "change to RandomStringFilenames in OPS 2.0."),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
+
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -7,6 +7,7 @@ from openpathsampling.engines.toy import ToySnapshot
 from openpathsampling.engines.external_engine import *
 
 import numpy as np
+import pytest
 
 import psutil
 
@@ -101,13 +102,15 @@ class TestExternalEngine(object):
             'n_frames_max': 10000,
             'engine_sleep': 100,
             'name_prefix': "test",
-            'engine_directory': engine_dir
+            'engine_directory': engine_dir,
+            'filename_setter': FilenameSetter()
         }
         fast_options = {
             'n_frames_max': 10000,
             'engine_sleep': 0,
             'name_prefix': "test",
-            'engine_directory': engine_dir
+            'engine_directory': engine_dir,
+            'filename_setter': FilenameSetter()
         }
         self.template = peng.toy.Snapshot(coordinates=np.array([[0.0]]),
                                           velocities=np.array([[1.0]]))
@@ -118,6 +121,16 @@ class TestExternalEngine(object):
                                                  self.descriptor,
                                                  self.template)
         self.ensemble = paths.LengthEnsemble(5)
+
+    def test_deprecation(self):
+        slow_options = {'n_frames_max': 10000,
+                        'engine_sleep': 100,
+                        'name_prefix': "test",
+                        'engine_directory': engine_dir}
+        with pytest.warns(FutureWarning, match='filename_setter'):
+            _ = ExampleExternalEngine(slow_options,
+                                      self.descriptor,
+                                      self.template)
 
     def test_start_stop(self):
         eng = self.fast_engine


### PR DESCRIPTION
this adds a `FutureWarning` to let users know that in OPS 2.0 the default `FileSetter` will become random string

This was part of the discussion on #1101 