### PR TITLE
Update standard filenamesetter for OPS 2.0

### DIFF
--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import sys
 import warnings
-from collections import namedtuple
 from functools import wraps
 from inspect import isclass
 
@@ -166,21 +165,6 @@ NEW_SNAPSHOT_KWARG_SELECTOR = Deprecation(
     remove_version=(2, 0),
     deprecated_in=(1, 6, 0)
 )
-
-NEW_DEFAULT_FILENAME_SETTER =  Deprecation(
-    problem=("The default FilenameSetter for external engines is now a counter"
-             ", but will become a random string. This is more robust against "
-             "accidental overwrites."),
-    remedy=("If you want to keep the old counting behavior, add "
-            '{"filename_setter": '
-            "paths.engines.external_engine.FilenameSetter() } to the 'options'"
-            " of this engine. Otherwise, this behaviour will automatically "
-            "change to RandomStringFilenames in OPS 2.0."),
-    remove_version=(2, 0),
-    deprecated_in=(1, 6, 0)
-)
-
-
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -125,12 +125,63 @@ SIMSTORE_NO_SFR_TYPES = Deprecation(
 )
 
 OPENMM_MDTRAJTOPOLOGY = Deprecation(
-                                    problem=("openpathsampling.engines.openmm.topology.MDTrajTopology "
-                                             "has been moved."),
-                                    remedy=("Import MDTrajTopology from openpathsampling.engines instead."),
-                                    remove_version=(2, 0),
-                                    deprecated_in=(1, 5, 0)
-                                    )
+    problem=("openpathsampling.engines.openmm.topology.MDTrajTopology "
+             "has been moved."),
+    remedy=("Import MDTrajTopology from openpathsampling.engines instead."),
+    remove_version=(2, 0),
+    deprecated_in=(1, 5, 0)
+)
+
+SNAPSHOTMODIFIER_PROB_RAT = Deprecation(
+    problem=("This function will raise a NotImplementedError in "
+             "{OPS} {version}."),
+    remedy=("All SnapshotModifier subclasses should override the "
+            "probability_ratio function."),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
+NEW_SNAPSHOT_SELECTOR = Deprecation(
+    problem=("new_snapshot=None; If snapshot has been copied or modified we "
+             "can't find it in trial_trajectory. This call signature will "
+             "update to "
+             "(old_snapshot, old_trajectory, new_snapshot, new_trajectory) "
+             "in {OPS} {version}. "),
+    remedy=("Call with kwargs and use new_snapshot=old_snapshot if "
+            " old_snapshot is not copied or modified in new_traj"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
+NEW_SNAPSHOT_KWARG_SELECTOR = Deprecation(
+    problem=("'new_snapshot' should be a supported keyword in "
+             "selector.probability_ratio(); If snapshot has been copied or "
+             "modified we can't reliably find it in trial_trajectory. This "
+             "keyword must be supported in the expected signature: "
+             "(old_snapshot, old_trajectory, new_snapshot, new_trajectory) "
+             "in {OPS} {version}. "),
+    remedy=("kwarg 'new_snapshot' must to be supported, implement it as "
+            "new_snapshot=old_snapshot if new_traj is not used to calculate "
+            "the weight of old_snapshot"),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
+NEW_DEFAULT_FILENAME_SETTER =  Deprecation(
+    problem=("The default FilenameSetter for external engines is now a counter"
+             ", but will become a random string. This is more robust against "
+             "accidental overwrites."),
+    remedy=("If you want to keep the old counting behavior, add "
+            '{"filename_setter": '
+            "paths.engines.external_engine.FilenameSetter() } to the 'options'"
+            " of this engine. Otherwise, this behaviour will automatically "
+            "change to RandomStringFilenames in OPS 2.0."),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
+
+
+
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735
 def has_deprecations(cls):

--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -55,29 +55,7 @@ def _debug_snapshot_loading(snapshot):
     snapshot.clear_cache()
 
 
-class FilenameSetter(StorableNamedObject):
-    """Just use numbers, as we did previously.
-
-    This is the default for compatibility reasons, but it not recommended.
-    Generally, we recommend using :class:`.RandomString`.
-    """
-    # the weird use of this as the base class is because engine options has
-    # some weird type testing that requires replace object to be instances
-    # of the default
-    def __init__(self, count=0):
-        super(FilenameSetter, self).__init__()
-        self.count = count
-
-    def __call__(self):
-        retval = self.count
-        self.count += 1
-        return retval
-
-    def reset(self, count=0):
-        self.count = count
-
-
-class RandomStringFilenames(FilenameSetter):
+class RandomStringFilenames(StorableNamedObject):
     """Use a random string for filename prefixes.
 
     This is recommended, and will become the default in future versions of
@@ -100,6 +78,30 @@ class RandomStringFilenames(FilenameSetter):
 
     def __call__(self):
         return "".join(np.random.choice(self.allowed, self.length))
+
+
+class FilenameSetter(RandomStringFilenames):
+    """Just use numbers, as we did previously.
+
+    This is the default for compatibility reasons, but it not recommended.
+    Generally, we recommend using :class:`.RandomString`.
+    """
+    # the weird use of this as the base class is because engine options has
+    # some weird type testing that requires replace object to be instances
+    # of the default
+    def __init__(self, count=0, length=1):
+        super(FilenameSetter, self).__init__(length=length)
+        self.count = count
+
+    def __call__(self):
+        retval = self.count
+        self.count += 1
+        # This invocation returns a string padded to at least self.length with
+        # zeros
+        return f"{retval:0{self.length}d}"
+
+    def reset(self, count=0):
+        self.count = count
 
 
 class _InternalizedEngineProxy(DynamicsEngine):

--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -1,7 +1,6 @@
 from openpathsampling.netcdfplus import StorableNamedObject
 from openpathsampling.engines.dynamics_engine import DynamicsEngine
 from openpathsampling.engines.snapshot import BaseSnapshot, SnapshotDescriptor
-from openpathsampling.deprecations import NEW_DEFAULT_FILENAME_SETTER
 
 import numpy as np
 import os
@@ -147,7 +146,7 @@ class ExternalEngine(DynamicsEngine):
         'n_spatial': 1,
         'n_atoms': 1,
         'n_poll_per_step': 1,
-        'filename_setter': FilenameSetter(),
+        'filename_setter': RandomStringFilenames()
     }
 
     killsig = signal.SIGTERM
@@ -165,11 +164,6 @@ class ExternalEngine(DynamicsEngine):
         self._current_snapshot = template
         self.n_frames_since_start = None
         self.internalized_engine = _InternalizedEngineProxy(self)
-        if 'filename_setter' not in options:
-            # Level 6 is needed to raise it to the initialization of a
-            # gromacs engine. This is a FutureWarning to also warn
-            # users, not only developers.
-            NEW_DEFAULT_FILENAME_SETTER.warn(6, category=FutureWarning)
 
     def to_dict(self):
         dct = super(ExternalEngine, self).to_dict()

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -309,7 +309,8 @@ class GromacsEngine(ExternalEngine):
             num_str = '{:07d}'.format(number + 1)
             self.output_file = self.trajectory_filename(number + 1)
             init_filename = "initial_frame.trr"
-            self.filename_setter.reset(number + 1)
+            if hasattr(self.filename_setter, 'reset'):
+                self.filename_setter.reset(number + 1)
         else:
             num_str = number
             self.output_file = self.trajectory_filename(num_str)

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -7,6 +7,7 @@ from openpathsampling.engines.toy import ToySnapshot
 from openpathsampling.engines.external_engine import *
 
 import numpy as np
+import pytest
 
 import psutil
 
@@ -101,13 +102,15 @@ class TestExternalEngine(object):
             'n_frames_max': 10000,
             'engine_sleep': 100,
             'name_prefix': "test",
-            'engine_directory': engine_dir
+            'engine_directory': engine_dir,
+            'filename_setter': FilenameSetter()
         }
         fast_options = {
             'n_frames_max': 10000,
             'engine_sleep': 0,
             'name_prefix': "test",
-            'engine_directory': engine_dir
+            'engine_directory': engine_dir,
+            'filename_setter': FilenameSetter()
         }
         self.template = peng.toy.Snapshot(coordinates=np.array([[0.0]]),
                                           velocities=np.array([[1.0]]))
@@ -118,6 +121,16 @@ class TestExternalEngine(object):
                                                  self.descriptor,
                                                  self.template)
         self.ensemble = paths.LengthEnsemble(5)
+
+    def test_deprecation(self):
+        slow_options = {'n_frames_max': 10000,
+                        'engine_sleep': 100,
+                        'name_prefix': "test",
+                        'engine_directory': engine_dir}
+        with pytest.warns(FutureWarning, match='filename_setter'):
+            _ = ExampleExternalEngine(slow_options,
+                                      self.descriptor,
+                                      self.template)
 
     def test_start_stop(self):
         eng = self.fast_engine

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -228,13 +228,22 @@ class TestExternalEngine(object):
 class TestFilenameSetter(object):
     def test_default_setter(self):
         setter = FilenameSetter()
-        assert setter() == 0
-        assert setter() == 1
+        assert setter() == "0"
+        assert setter() == "1"
 
     def test_specific_number_setter(self):
         setter = FilenameSetter(100)
-        assert setter() == 100
-        assert setter() == 101
+        assert setter() == "100"
+        assert setter() == "101"
+
+    def test_specific_length(self):
+        setter = FilenameSetter(length=3)
+        assert setter() == "000"
+        assert setter() == "001"
+
+    def test_length_overrun(self):
+        setter = FilenameSetter(1000, length=3)
+        assert setter() == "1000"
 
 
 class TestRandomStringFilenames(object):

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -7,7 +7,6 @@ from openpathsampling.engines.toy import ToySnapshot
 from openpathsampling.engines.external_engine import *
 
 import numpy as np
-import pytest
 
 import psutil
 
@@ -121,16 +120,6 @@ class TestExternalEngine(object):
                                                  self.descriptor,
                                                  self.template)
         self.ensemble = paths.LengthEnsemble(5)
-
-    def test_deprecation(self):
-        slow_options = {'n_frames_max': 10000,
-                        'engine_sleep': 100,
-                        'name_prefix': "test",
-                        'engine_directory': engine_dir}
-        with pytest.warns(FutureWarning, match='filename_setter'):
-            _ = ExampleExternalEngine(slow_options,
-                                      self.descriptor,
-                                      self.template)
 
     def test_start_stop(self):
         eng = self.fast_engine

--- a/openpathsampling/tests/test_gromacs_engine.py
+++ b/openpathsampling/tests/test_gromacs_engine.py
@@ -222,11 +222,11 @@ class TestGromacsEngine(object):
         assert len(beauty) == len(truth)
         assert beauty == truth
 
-    @pytest.mark.skipif(not has_gmx,
-                        reason="Gromacs 5 (gmx) not found. Skipping test.")
-    @pytest.mark.skipif(not HAS_MDTRAJ,
-                        reason="MDTraj not found. Skipping test.")
     def test_generate(self):
+        if not has_gmx:
+            pytest.skip("Gromacs 5 (gmx) not found. Skipping test.")
+        if not HAS_MDTRAJ:
+            pytest.skip("MDTraj not found. Skipping test.")
         traj_0 = self.engine.trajectory_filename(0)
         snap = self.engine.read_frame_from_file(traj_0, 0)
 

--- a/openpathsampling/tests/test_gromacs_engine.py
+++ b/openpathsampling/tests/test_gromacs_engine.py
@@ -227,13 +227,12 @@ class TestGromacsEngine(object):
 
         traj_0 = self.engine.trajectory_filename(0)
         snap = self.engine.read_frame_from_file(traj_0, 0)
-        self.engine.filename_setter.reset(0)
 
         ens = paths.LengthEnsemble(5)
         traj = self.engine.generate(snap, running=[ens.can_append])
         assert_equal(self.engine.proc.is_running(), False)
         assert_equal(len(traj), 5)
-        ttraj = md.load(self.engine.trajectory_filename(1),
+        ttraj = md.load(self.engine.output_file,
                         top=self.engine.gro)
         # the mdp suggests a max length of 100 frames
         assert_true(len(ttraj) < 100)


### PR DESCRIPTION
This does a couple things:
- cherry-picks in #1102
- the default `filename_setter` for `ExternalEngines` are now `RandomStringFilenames` instead of `FilenameSetter`
- `FilenameSetter` is now a subclass of `RandomStringFilenames` (instead of the other way around) (this was needed to still be able to use Filename setter after changing the default options)
- `FilenameSetter now returns a string that is padded up to `self.length` with zeroes
- `GromacsEngine.set_filenames` only resets the `filename_setter` if the `filename_setter` has a `reset` attribute
- updated the tests for this behaviout
- solved pep8 complaints on all touched files
- dropped `nose` from all touched tests