### PR TITLE
revert openmmtools import guard from test notebook

### DIFF
--- a/examples/tests/test_openmm_integration.ipynb
+++ b/examples/tests/test_openmm_integration.ipynb
@@ -30,20 +30,10 @@
     "except ImportError: # OpenMM < 7.6\n",
     "    import simtk.openmm as omm\n",
     "    import simtk.unit as u\n",
+    "import openmmtools as omt\n",
     "import mdtraj as md\n",
     "\n",
-    "import openpathsampling.engines.openmm as eng"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "# Ignore until next OpenMMTools release (> 0.20.3), see openpathsampling/openpathsampling#1091\n",
-    "import openmmtools as omt"
+    "import openpathsampling.engines.openmm as eng\n"
    ]
   },
   {
@@ -55,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -83,7 +73,7 @@
        " '_mdtraj_topology': NoneType}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -121,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,35 +212,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[ 0.18766724  0.11599682  0.01245003]\n",
-      " [ 0.19458355  0.22444932  0.00401419]\n",
-      " [ 0.1443672   0.27122667  0.08869705]\n",
-      " [ 0.14886743  0.2574746  -0.08926158]\n",
-      " [ 0.33994532  0.26638272  0.0060984 ]\n",
-      " [ 0.42709577  0.18970107  0.04380053]\n",
-      " [ 0.36886498  0.38998336 -0.03181566]\n",
-      " [ 0.29336688  0.45243084 -0.05633819]\n",
-      " [ 0.49859306  0.45657611 -0.02400118]\n",
-      " [ 0.55814379  0.41515264  0.0573551 ]\n",
-      " [ 0.57325351  0.43391329 -0.15561192]\n",
-      " [ 0.51911271  0.48312774 -0.23640621]\n",
-      " [ 0.67427629  0.47320485 -0.14414111]\n",
-      " [ 0.58423072  0.32728142 -0.17536469]\n",
-      " [ 0.47495225  0.60669041 -0.00127666]\n",
-      " [ 0.359584    0.64924204  0.00474686]\n",
-      " [ 0.58359265  0.68379164  0.00902625]\n",
-      " [ 0.67474234  0.64066118  0.00332434]\n",
-      " [ 0.57127434  0.82897234  0.01853087]\n",
-      " [ 0.46718949  0.86095488  0.02347777]\n",
-      " [ 0.62214309  0.86301541  0.108722  ]\n",
-      " [ 0.61715913  0.87434274 -0.06931632]] nm\n"
+      "[[ 0.18766736  0.11599679  0.01245004]\n",
+      " [ 0.19458341  0.22444927  0.00401414]\n",
+      " [ 0.1443672   0.27122689  0.08869714]\n",
+      " [ 0.14886747  0.25747473 -0.08926164]\n",
+      " [ 0.33994537  0.26638274  0.00609843]\n",
+      " [ 0.42709578  0.1897011   0.04380051]\n",
+      " [ 0.36886493  0.38998331 -0.03181562]\n",
+      " [ 0.293367    0.452431   -0.05633815]\n",
+      " [ 0.49859312  0.4565761  -0.02400124]\n",
+      " [ 0.5581438   0.41515287  0.0573552 ]\n",
+      " [ 0.5732535   0.43391328 -0.15561179]\n",
+      " [ 0.5191127   0.48312774 -0.23640657]\n",
+      " [ 0.67427683  0.47320502 -0.14414124]\n",
+      " [ 0.58423056  0.32728151 -0.17536463]\n",
+      " [ 0.4749522   0.60669039 -0.00127668]\n",
+      " [ 0.35958399  0.64924202  0.00474684]\n",
+      " [ 0.5835927   0.68379167  0.00902624]\n",
+      " [ 0.6747424   0.64066121  0.00332412]\n",
+      " [ 0.57127444  0.82897221  0.01853087]\n",
+      " [ 0.46718868  0.86095438  0.02347777]\n",
+      " [ 0.62214258  0.86301533  0.10872177]\n",
+      " [ 0.61715852  0.87434252 -0.06931573]] nm\n"
      ]
     }
    ],
@@ -261,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -281,20 +271,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[ 3.1061459],\n",
-       "       [-3.0958638],\n",
-       "       [ 3.1367562],\n",
-       "       [ 3.1283274],\n",
-       "       [ 3.0931776]], dtype=float32)"
+       "array([[ 3.1061454],\n",
+       "       [-3.0958629],\n",
+       "       [ 3.1367555],\n",
+       "       [ 3.1283271],\n",
+       "       [ 3.0931787]], dtype=float32)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -306,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,16 +322,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'{\"_cls\":\"OpenMMEngine\",\"_dict\":{\"system_xml\":\"<?xml version=\\\\\"1.0\\\\\" ?>\\\\n<System openmmVersion=\\\\\"7.6\\\\\" type=\\\\\"System\\\\\" version=\\\\\"1\\\\\">\\\\n\\\\t<PeriodicBoxVectors>\\\\n\\\\t\\\\t<A x=\\\\\"2\\\\\" y=\\\\\"0\\\\\" z=\\\\\"0\\\\\"\\\\/>\\\\n\\\\t\\\\t<B x=\\\\\"0\\\\\" y=\\\\\"2\\\\\" z=\\\\\"0\\\\\"\\\\/>\\\\n\\\\t\\\\t<C x=\\\\\"0\\\\\" y=\\\\\"0\\\\\" z=\\\\\"2...'"
+       "'{\"_cls\":\"OpenMMEngine\",\"_dict\":{\"system_xml\":\"<?xml version=\\\\\"1.0\\\\\" ?>\\\\n<System openmmVersion=\\\\\"7.7\\\\\" type=\\\\\"System\\\\\" version=\\\\\"1\\\\\">\\\\n\\\\t<PeriodicBoxVectors>\\\\n\\\\t\\\\t<A x=\\\\\"2\\\\\" y=\\\\\"0\\\\\" z=\\\\\"0\\\\\"\\\\/>\\\\n\\\\t\\\\t<B x=\\\\\"0\\\\\" y=\\\\\"2\\\\\" z=\\\\\"0\\\\\"\\\\/>\\\\n\\\\t\\\\t<C x=\\\\\"0\\\\\" y=\\\\\"0\\\\\" z=\\\\\"2...'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -353,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -438,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,13 +452,6 @@
     "st.save(traj)\n",
     "st.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -488,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
with openmmtools `0.21.0` released this guard against the import warning introduced in #1091 is not needed anymore