### PR TITLE
Prevent double monkey-patching experimental storage

### DIFF
--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -120,4 +120,8 @@ def unpatch(paths):
     for module in _UNPATCH_MODULES * 2:
         importlib.reload(module)
 
+    global _IS_PATCHED_SAVING
+    global _IS_PATCHED_LOADING
+    _IS_PATCHED_SAVING = False
+    _IS_PATCHED_LOADING = False
     return paths

--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -64,7 +64,14 @@ _UNPATCH_MODULES = [
     paths
 ]
 
+_IS_PATCHED_SAVING = False
+_IS_PATCHED_LOADING = False
+
 def monkey_patch_saving(paths):
+    global _IS_PATCHED_SAVING
+    if _IS_PATCHED_SAVING:
+        return paths
+
     paths.netcdfplus.FunctionPseudoAttribute.to_dict = \
             function_pseudo_attribute_to_dict
     paths.TPSNetwork.to_dict = tuple_keys_to_dict(
@@ -73,9 +80,14 @@ def monkey_patch_saving(paths):
     paths.MISTISNetwork.to_dict = tuple_keys_to_dict(
         paths.MISTISNetwork.to_dict, 'input_transitions'
     )
+    _IS_PATCHED_SAVING = True
     return paths
 
 def monkey_patch_loading(paths):
+    global _IS_PATCHED_LOADING
+    if _IS_PATCHED_LOADING:
+        return paths
+
     paths.CallableCV.from_dict = classmethod(callable_cv_from_dict)
     paths.netcdfplus.FunctionPseudoAttribute.from_dict = \
             classmethod(from_dict_attr_to_class(
@@ -89,6 +101,7 @@ def monkey_patch_loading(paths):
     paths.MISTISNetwork.from_dict = classmethod(tuple_keys_from_dict(
         paths.MISTISNetwork.from_dict, 'input_transitions'
     ))
+    _IS_PATCHED_LOADING = True
     return paths
 
 def monkey_patch_all(paths):

--- a/openpathsampling/experimental/storage/test_monkey_patches.py
+++ b/openpathsampling/experimental/storage/test_monkey_patches.py
@@ -1,0 +1,43 @@
+import openpathsampling as paths
+import pytest
+
+from openpathsampling.experimental.storage.monkey_patches import *
+from openpathsampling.experimental.storage.collective_variables import \
+    CollectiveVariable
+
+@pytest.fixture
+def patching_tps_network():
+    cv = CollectiveVariable(lambda x: x.xyz[0][0]).named('cv')
+    state_A = paths.CVDefinedVolume(cv, 0, 1)
+    state_B = paths.CVDefinedVolume(cv, 9, 10)
+    tps_network = paths.TPSNetwork(state_A, state_B)
+    yield tps_network
+
+
+def test_double_patch(patching_tps_network):
+    orig_dict = patching_tps_network.to_dict()
+    global paths
+    paths = monkey_patch_all(paths)
+    try:
+        patched_dict = patching_tps_network.to_dict()
+        paths = monkey_patch_all(paths)
+        double_patched_dict = patching_tps_network.to_dict()
+    finally:
+        unpatch(paths)
+
+    assert orig_dict != patched_dict
+    assert patched_dict == double_patched_dict
+
+
+def test_unpatch(patching_tps_network):
+    orig_dict = patching_tps_network.to_dict()
+    global paths
+    paths = monkey_patch_all(paths)
+    try:
+        patched_dict = patching_tps_network.to_dict()
+    finally:
+        paths = unpatch(paths)
+
+    unpatched_dict = patching_tps_network.to_dict()
+    assert unpatched_dict == orig_dict
+    assert unpatched_dict != patched_dict


### PR DESCRIPTION
It was possible to double monkey-patch for the experimental storage. This caused many headaches downstream (e.g., OPS CLI) because that meant that something downstream had to track state of whether OPS had been monkey-patched. It also might be the problem behind #1108. This PR makes it so that monkey-patching is idempotent.

Marked WIP because it still needs tests (which will be slightly a pain), but this is the implementation I'm planning on.