### PR TITLE
Improved implementation of shooting point selector pick (avoid model that might introduce index error in subclasses)

### DIFF
--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -85,7 +85,7 @@ class ShootingPointSelector(StorableNamedObject):
         rand = self._rng.random() * sum_bias
         idx = 0
         prob = prob_list[0]
-        while prob <= rand and idx < len(prob_list):
+        while prob <= rand and idx < len(prob_list) - 1:
             idx += 1
             prob += prob_list[idx]
 

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -50,6 +50,23 @@ class TestShootingPointSelector(SelectorTest):
             assert sel.probability(frame, self.mytraj) == \
                     uniform.probability(frame, self.mytraj)
 
+    def test_pick(self):
+        sel = ShootingPointSelector()
+        test_traj_len = 22  # must be a multiple of 2 for this test
+        test_traj = [1 for _ in range(test_traj_len)]
+        # overwrite _biases to make sure we can only pick the last frame
+        sel._biases = lambda traj: [0 for _ in traj[:-1]] + [1]
+        assert sel.pick(test_traj) == test_traj_len - 1
+        # test pick first frame
+        sel._biases = lambda traj: [1] + [0 for _ in traj[1:]]
+        assert sel.pick(test_traj) == 0
+        # and test middle frame (only works if test_traj_len is a multiple of 2)
+        sel._biases = lambda traj: ([0 for _ in traj[:test_traj_len // 2]]
+                                    + [1]
+                                    + [0 for _ in traj[test_traj_len // 2 + 1:]]
+                                    )
+        assert sel.pick(test_traj) == test_traj_len // 2
+
 
 class TestGaussianBiasSelector(SelectorTest):
     def setup(self):


### PR DESCRIPTION
After 5 years of using ops it bit me today, for the old implementation it was possible to have `idx == len(prob_list)` in the last iteration which would then raise an `IndexError` when trying to get the associated probability from prob_list. 

Or in other words in 5 years of ops I never tried to select the last frame of a trajectory as new shooting point, which is a good thing I would say :)

EDIT: typo