### PR TITLE
(Possible temporary) Fix dill in testing

### DIFF
--- a/openpathsampling/experimental/simstore/callable_codec.py
+++ b/openpathsampling/experimental/simstore/callable_codec.py
@@ -127,7 +127,7 @@ class CallableCodec(object):
 
             return {
                 '__callable_name__': obj.__name__,
-                '_dilled': dill.dumps(obj)
+                '_dilled': dill.dumps(obj, recurse=True)
             }
         return obj
 

--- a/openpathsampling/experimental/simstore/test_callable_codec.py
+++ b/openpathsampling/experimental/simstore/test_callable_codec.py
@@ -26,7 +26,7 @@ class TestCallableCodec(object):
         for func in ['generic', 'use_known_module', 'use_globals']:
             self.functions[func].__module__ = "__main__"
 
-        dilled = {key: dill.dumps(func)
+        dilled = {key: dill.dumps(func, recurse=True)
                   for key, func in self.functions.items()}
         self.dcts = {
             'generic': {


### PR DESCRIPTION
Resolves #1112.

This should at least get tests working. I'm keeping an eye on https://github.com/uqfoundation/dill/issues/482 / https://github.com/uqfoundation/dill/pull/486 for possible better long-term fixes, although it might make sense to just leave this as-is. Serialization of callables shouldn't be a performance bottleneck for us, so as long as this works, I'm not worried if this might be a little slower.