### PR TITLE
Use MDTraj codecs in SimStore JSON serialization

### DIFF
--- a/openpathsampling/experimental/storage/ops_storage.py
+++ b/openpathsampling/experimental/storage/ops_storage.py
@@ -47,6 +47,9 @@ except ImportError:
     simtk_quantity_codec = None
     SimtkQuantityHandler = None
 
+
+from .mdtraj_json import mdtraj_codecs
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -77,6 +80,7 @@ ops_schema_sql_metadata = {}
 
 # this defines the simulation object serializer for OPS
 EXTRA_CODECS = [simtk_quantity_codec] if simtk_quantity_codec else []
+EXTRA_CODECS += mdtraj_codecs
 EXTRA_HANDLERS = [SimtkQuantityHandler] if SimtkQuantityHandler else []
 CODECS = DEFAULT_CODECS + EXTRA_CODECS
 HANDLERS = DEFAULT_HANDLERS + EXTRA_HANDLERS

--- a/openpathsampling/experimental/storage/test_regressions.py
+++ b/openpathsampling/experimental/storage/test_regressions.py
@@ -1,0 +1,18 @@
+# miscellaneous regression testing
+import pytest
+from openpathsampling.tests.test_helpers import data_filename
+from openpathsampling.netcdfplus import StorableNamedObject
+
+from openpathsampling.experimental.storage.ops_storage import ops_class_info
+
+class TrajWrapper(StorableNamedObject):
+    def __init__(self, traj):
+        super(TrajWrapper, self).__init__()
+        self.traj = traj
+
+
+def test_use_mdtraj_codec():
+    # smoke test to ensure we *can* use the MDTraj codecs
+    md = pytest.importorskip("mdtraj")
+    traj = md.load(data_filename("ala_small_traj.pdb"))
+    serialized = ops_class_info.default_info.serializer(TrajWrapper(traj))


### PR DESCRIPTION
Well this is an embarrassing bugfix to have missed for so long. @sroet, could you spare 30 seconds to review my fix of this facepalm?

I will merge this immediately after review or after it sits open for over 24 hours, merging around Tue 02 Aug 23:00 GMT (18:00 my local).

@ShenWenHuibit: This should fix the current problem you're having. If you can do a developer install using the fork `dwhswenson` and branch `use-mdtraj-codec`, you should be able to try it out immediately.