### PR TITLE
[WIP] Fail fast if `prepare` fails in external engines

### DIFF
--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -252,7 +252,11 @@ class ExternalEngine(DynamicsEngine):
         file_prefix = self.filename_setter()
         self.set_filenames(file_prefix)
         self.write_frame_to_file(self.input_file, self.current_snapshot, "w")
-        self.prepare()
+        if not self.prepare():
+            # subclasses SHOULD raise an error if there's a problem here,
+            # but if they don't, we catch it now
+            raise RuntimeError("Something went wrong when preparing to "
+                               "run the trajectory.")
 
         self.start_time = time.time()
         try:

--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -252,7 +252,8 @@ class ExternalEngine(DynamicsEngine):
         file_prefix = self.filename_setter()
         self.set_filenames(file_prefix)
         self.write_frame_to_file(self.input_file, self.current_snapshot, "w")
-        if not self.prepare():
+        error_code = self.prepare()
+        if error_code:
             # subclasses SHOULD raise an error if there's a problem here,
             # but if they don't, we catch it now
             raise RuntimeError("Something went wrong when preparing to "

--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -314,8 +314,13 @@ class ExternalEngine(DynamicsEngine):
     def prepare(self):
         """
         Any preparation between writing snapshot and running command
+
+        Returns
+        -------
+        int :
+            Error code. Return 0 on success, nonzero on any error.
         """
-        pass
+        return 0
 
     def cleanup(self):
         """Any cleanup actions to do after the subprocess dies."""

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -341,6 +341,12 @@ class GromacsEngine(ExternalEngine):
         logger.info(cmd)
         run_cmd = shlex.split(cmd)
         return_code = psutil.Popen(run_cmd, preexec_fn=os.setsid).wait()
+        if return_code:
+            raise RuntimeError("An error occurred while running the "
+                               "command: `" + cmd + "`. Please check "
+                               "output of that command for details.")
+
+
         return return_code
 
     def cleanup(self):  # pragma: no cover


### PR DESCRIPTION
The `prepare` command in external engines can be used to, e.g, create input for a given trajectory. For example, in Gromacs, this runs the grompp command to incorporate snapshot-independent information in the mdp with the specific trr snapshot.

Previously, there was no catch for an error in `prepare`. This meant that the engine would try to run the trajetory, and, not finding required files, would fail with the unhelpful message "engine died unexpectedly." This PR provides a clearer error message in the case that the `prepare` step fails.

It provides a specific error for the Gromacs engine, and a generic error for any engine that returns a non-zero result code from `prepare`, but which hasn't already raised the error.

EDIT: Waiting on some test coverage here, although the actual gmx is outside our normal coverage since we don't install gmx in the test env. That said, I think we need some mechanism for also testing gmx integration in CI. I think there was no official conda-forge package when we first started with gmx integration, but there is now. (We have tests that test the integration, but they skip if there's no `gmx` in the `$PATH`.)