### PR TITLE
[WIP] engine_masses feature; use in Gromacs engine

### DIFF
--- a/openpathsampling/engines/external_snapshots/snapshot.py
+++ b/openpathsampling/engines/external_snapshots/snapshot.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
     features.coordinates,
     features.velocities,
     features.box_vectors,
+    features.engine_masses,
     ext_features.file_info
 ])
 class InternalizedMDSnapshot(BaseSnapshot):
@@ -29,6 +30,7 @@ class InternalizedMDSnapshot(BaseSnapshot):
     ext_features.coordinates,
     ext_features.velocities,
     ext_features.box_vectors,
+    features.engine_masses,
     ext_features.file_info
 ])
 class ExternalMDSnapshot(BaseSnapshot):

--- a/openpathsampling/engines/features/__init__.py
+++ b/openpathsampling/engines/features/__init__.py
@@ -5,4 +5,5 @@ from . import kinetics
 from . import box_vectors
 from . import topology
 from . import engine
+from . import engine_masses
 from .base import attach_features

--- a/openpathsampling/engines/features/engine_masses.py
+++ b/openpathsampling/engines/features/engine_masses.py
@@ -1,0 +1,3 @@
+@property
+def masses(snapshot):
+    return snapshot.engine.masses

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -182,6 +182,7 @@ class GromacsEngine(ExternalEngine):
         self.mdout_file = "mdout.mdp"
 
         self._mdtraj_topology = None
+        self._masses = None
 
         super(GromacsEngine, self).__init__(options, descriptor, template,
                                              first_frame_in_file=True)
@@ -219,6 +220,13 @@ class GromacsEngine(ExternalEngine):
     @mdtraj_topology.setter
     def mdtraj_topology(self, value):
         self._mdtraj_topology = value
+
+    @property
+    def masses(self):
+        if self._masses is None:
+            self._masses = [atom.element.mass
+                            for atom in self.mdtraj_topology.atoms]
+        return self._masses
 
     def read_frame_data(self, filename, frame_num):
         """


### PR DESCRIPTION
Apparently Gromacs snapshots didn't have masses associated? See #1117. I was pretty sure we've used masses here before, but can't find an example of it.

Note that the better long-term solution for the needs of #1117 will be an `engine.randomize_velocities` -- we already have the machinery to *use* this, but haven't actually implemented any examples yet.