### PR TITLE
update tests to use setup_method instead of setup, same for teardown

### DIFF
--- a/openpathsampling/tests/pathsimulators/test_hooks.py
+++ b/openpathsampling/tests/pathsimulators/test_hooks.py
@@ -170,7 +170,7 @@ class TestPathSimulatorHook(object):
 
 
 class TestSelfOrSimProperty(object):
-    def setup(self):
+    def setup_method(self):
         self.attr_name = "test_attr"
         self.simulation = MagicMock(test_attr="sim_attr")
         self.sans_attr_sans_sim = MagicMock(_test_attr=None, _simulation=None)
@@ -226,7 +226,7 @@ class TestSelfOrSimProperty(object):
 
 
 class TestStorageHook(object):
-    def setup(self):
+    def setup_method(self):
         self.storage = MagicMock(spec=["stash", "sync_all"])
         self.old_storage = MagicMock(spec=["save", "sync_all"])
         self.empty_hook = StorageHook()
@@ -267,7 +267,7 @@ class TestStorageHook(object):
 
 
 class TestShootFromSnapshotsOutputHook(object):
-    def setup(self):
+    def setup_method(self):
         if sys.version_info < (3,):
             self.stream = io.BytesIO()
         else:
@@ -295,7 +295,7 @@ class TestShootFromSnapshotsOutputHook(object):
 
 
 class TestSampleSetSanityCheckHook(object):
-    def setup(self):
+    def setup_method(self):
         self.simulation = MagicMock(save_frequency=10)
         self.empty_hook = SampleSetSanityCheckHook()
         self.hook = SampleSetSanityCheckHook(frequency=10)
@@ -319,7 +319,7 @@ class TestSampleSetSanityCheckHook(object):
 
 
 class TestLiveVisualizerHook(object):
-    def setup(self):
+    def setup_method(self):
         self.live_visualizer = MagicMock()
         self.simulation = MagicMock(live_visualizer=self.live_visualizer,
                                     status_update_frequency=2)
@@ -363,7 +363,7 @@ class TestLiveVisualizerHook(object):
 
 
 class TestPathSamplingOutputHook(object):
-    def setup(self):
+    def setup_method(self):
         if sys.version_info < (3,):
             self.stream = io.BytesIO()
         else:
@@ -434,7 +434,7 @@ class TestPathSamplingOutputHook(object):
 
 
 class TestGraciousKillHook(object):
-    def setup(self):
+    def setup_method(self):
         self.final_call = MagicMock()
         self.nocall_final_call = MagicMock()
         self.simulation = MagicMock(storage=MagicMock(close=MagicMock(),

--- a/openpathsampling/tests/test_attribute.py
+++ b/openpathsampling/tests/test_attribute.py
@@ -15,7 +15,7 @@ import os
 
 
 class TestFunctionPseudoAttribute(object):
-    def setup(self):
+    def setup_method(self):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.mdtraj = md.load(data_filename("ala_small_traj.pdb"))
@@ -30,7 +30,7 @@ class TestFunctionPseudoAttribute(object):
         if os.path.isfile("myfile.nc"):
             os.remove("myfile.nc")
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile("myfile.nc"):
             os.remove("myfile.nc")
 

--- a/openpathsampling/tests/test_bias_function.py
+++ b/openpathsampling/tests/test_bias_function.py
@@ -24,13 +24,13 @@ for logger in quiet_loggers:
 
 
 class TestBiasEnsembleTable(object):
-    def setup(self):
+    def setup_method(self):
         # create the network
         paths.InterfaceSet._reset()
         xval = paths.FunctionCV(name="xA", f=lambda s : s.xyz[0][0])
         self.stateA = paths.CVDefinedVolume(xval, -1.0, -0.5).named("A")
         self.stateB = paths.CVDefinedVolume(xval, 0.5, float("inf")).named("B")
-        ifacesA = paths.VolumeInterfaceSet(xval, float(-1.0), 
+        ifacesA = paths.VolumeInterfaceSet(xval, float(-1.0),
                                            [-0.5, -0.4, -0.3, -0.2])
         self.network = paths.MISTISNetwork([
             (self.stateA, ifacesA, self.stateB)
@@ -76,7 +76,7 @@ class TestBiasEnsembleTable(object):
 
         # for old_to_new, the probability of moving outerward depends on the
         # ratio of the probabilities of the two ensembles
-        change_vals = { 
+        change_vals = {
             self.change_01 : 0.5,
             self.change_02 : 0.2,
             self.change_12 : old_div(0.2, 0.5),
@@ -233,13 +233,13 @@ class TestBiasEnsembleTable(object):
         bias_ABC = bias_A + bias_B + bias_C
 
 class TestSRTISBiasFromNetwork(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         xval = paths.CoordinateFunctionCV(name="xA",
                                           f=lambda s : s.xyz[0][0])
         self.stateA = paths.CVDefinedVolume(xval, -1.0, -0.5).named("A")
         self.stateB = paths.CVDefinedVolume(xval, 0.5, float("inf")).named("B")
-        self.ifacesA = paths.VolumeInterfaceSet(xval, -1.0, 
+        self.ifacesA = paths.VolumeInterfaceSet(xval, -1.0,
                                                 [-0.5, -0.4, -0.3, -0.2])
         self.ifacesB = paths.VolumeInterfaceSet(xval, [0.5, 0.4, 0.3, 0.2],
                                                 1.0)

--- a/openpathsampling/tests/test_channel_analysis.py
+++ b/openpathsampling/tests/test_channel_analysis.py
@@ -18,7 +18,7 @@ logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestChannelAnalysis(object):
-    def setup(self):
+    def setup_method(self):
         cv = paths.FunctionCV("Id", lambda snap: snap.xyz[0][0])
         self.state_A = paths.CVDefinedVolume(cv, -0.1, 0.1)
         self.state_B = ~paths.CVDefinedVolume(cv, -1.0, 1.0)

--- a/openpathsampling/tests/test_collectivevariable.py
+++ b/openpathsampling/tests/test_collectivevariable.py
@@ -29,7 +29,7 @@ import os
 
 
 class TestFunctionCV(object):
-    def setup(self):
+    def setup_method(self):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.mdtraj = md.load(data_filename("ala_small_traj.pdb"))
@@ -44,7 +44,7 @@ class TestFunctionCV(object):
         if os.path.isfile("myfile.nc"):
             os.remove("myfile.nc")
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile("myfile.nc"):
             os.remove("myfile.nc")
 

--- a/openpathsampling/tests/test_deprecations.py
+++ b/openpathsampling/tests/test_deprecations.py
@@ -51,7 +51,7 @@ def test_version_tuple_to_string(version_tup, version_str):
     assert version_tuple_to_string(version_tup) == version_str
 
 class TestDeprecation(object):
-    def setup(self):
+    def setup_method(self):
         self.foo, self.bar = make_foo_bar_baz()[0:2]
 
     def test_message(self):
@@ -78,7 +78,7 @@ class TestDeprecation(object):
 
 
 class TestDeprecationDecorators(object):
-    def setup(self):
+    def setup_method(self):
         self.foo, self.bar, self.baz = make_foo_bar_baz()
 
         @deprecate(self.foo)

--- a/openpathsampling/tests/test_dynamicsengine.py
+++ b/openpathsampling/tests/test_dynamicsengine.py
@@ -41,7 +41,7 @@ class StupidEngine(paths.engines.DynamicsEngine):
 
 
 class TestDynamicsEngine(object):
-    def setup(self):
+    def setup_method(self):
         options = {'n_frames_max' : 100, 'random_option' : True}
 
         snapshot_dimensions = {

--- a/openpathsampling/tests/test_ensemble.py
+++ b/openpathsampling/tests/test_ensemble.py
@@ -195,7 +195,7 @@ class EnsembleTest(object):
 
 
 class TestPartOutXEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.leaveX = PartOutXEnsemble(vol1)
 
     def test_leaveX(self):
@@ -238,11 +238,11 @@ class TestPartOutXEnsemble(EnsembleTest):
 
     def test_leaveX_str(self):
         volstr = "{x|Id(x) in [0.1, 0.5]}"
-        assert_equal(self.leaveX.__str__(), 
+        assert_equal(self.leaveX.__str__(),
                      "exists t such that x[t] in (not "+volstr+")")
 
 class TestAllInXEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.inX = AllInXEnsemble(vol1)
 
     def test_inX(self):
@@ -306,7 +306,7 @@ class TestAllInXEnsemble(EnsembleTest):
                      "x[t] in "+volstr+" for all t")
 
 class TestAllOutXEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.outX = AllOutXEnsemble(vol1)
 
     def test_outX(self):
@@ -369,7 +369,7 @@ class TestAllOutXEnsemble(EnsembleTest):
                      "x[t] in (not "+volstr+") for all t")
 
 class TestPartInXEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.hitX = PartInXEnsemble(vol1)
 
     def test_hitX(self):
@@ -407,7 +407,7 @@ class TestPartInXEnsemble(EnsembleTest):
 
 
 class TestSequentialEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.inX = AllInXEnsemble(vol1)
         self.outX = AllOutXEnsemble(vol1)
         self.hitX = PartInXEnsemble(vol1)
@@ -533,10 +533,10 @@ class TestSequentialEnsemble(EnsembleTest):
                         'lower_in_out_in_in' : False,
                         'upper_in_out_in_out_in' : False,
                         'lower_in_out_in_out_in' : False
-                    }   
+                    }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_tis.can_append, 
+            self._single_test(self.pseudo_tis.can_append,
                                 ttraj[test], results[test], failmsg)
 
     def test_strict_can_append_tis(self):
@@ -559,10 +559,10 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_in_out_in_in' : False,
             'upper_in_out_in_out_in' : False,
             'lower_in_out_in_out_in' : False
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_tis.strict_can_append, 
+            self._single_test(self.pseudo_tis.strict_can_append,
                                 ttraj[test], results[test], failmsg)
 
     def test_can_append_pseudominus(self):
@@ -604,10 +604,10 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_cross_in_cross_in' : False,
             'upper_in_cross_in_cross_in' : False,
             'lower_in_cross_in_cross_in' : False
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_minus.can_append, 
+            self._single_test(self.pseudo_minus.can_append,
                                 ttraj[test], results[test], failmsg)
 
     def test_strict_can_append_pseudominus(self):
@@ -648,10 +648,10 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_cross_in_cross_in' : False,
             'upper_in_cross_in_cross_in' : False,
             'lower_in_cross_in_cross_in' : False
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_minus.strict_can_append, 
+            self._single_test(self.pseudo_minus.strict_can_append,
                                 ttraj[test], results[test], failmsg)
 
     def test_can_prepend_pseudo_tis(self):
@@ -675,10 +675,10 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_in_out_in_in' : False,
             'upper_in_out_in_out_in' : False,
             'lower_in_out_in_out_in' : False
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_tis.can_prepend, 
+            self._single_test(self.pseudo_tis.can_prepend,
                                 ttraj[test], results[test], failmsg)
 
     def test_strict_can_prepend_pseudo_tis(self):
@@ -701,10 +701,10 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_in_out_in_in' : False,
             'upper_in_out_in_out_in' : False,
             'lower_in_out_in_out_in' : False
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_tis.strict_can_prepend, 
+            self._single_test(self.pseudo_tis.strict_can_prepend,
                                 ttraj[test], results[test], failmsg)
 
     def test_can_prepend_pseudo_minus(self):
@@ -738,10 +738,10 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_out_in_out_in': True,
             'upper_out_in_in_out_in' : True,
             'lower_out_in_in_out_in' : True
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_minus.can_prepend, 
+            self._single_test(self.pseudo_minus.can_prepend,
                                 ttraj[test], results[test], failmsg)
 
     def test_strict_can_prepend_pseudo_minus(self):
@@ -775,14 +775,14 @@ class TestSequentialEnsemble(EnsembleTest):
             'lower_out_in_out_in': True,
             'upper_out_in_in_out_in' : True,
             'lower_out_in_in_out_in' : True
-        }   
+        }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(self.pseudo_minus.strict_can_prepend, 
+            self._single_test(self.pseudo_minus.strict_can_prepend,
                                 ttraj[test], results[test], failmsg)
 
 
-    
+
     def test_sequential_transition_frames(self):
         """SequentialEnsemble identifies transitions frames correctly"""
         ensemble = SequentialEnsemble([self.inX, self.outX])
@@ -793,7 +793,7 @@ class TestSequentialEnsemble(EnsembleTest):
                   }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(ensemble.transition_frames, 
+            self._single_test(ensemble.transition_frames,
                                 ttraj[test], results[test], failmsg)
 
     def test_sequential_simple_in_out_call(self):
@@ -806,7 +806,7 @@ class TestSequentialEnsemble(EnsembleTest):
                   }
         for test in list(results.keys()):
             failmsg = "Failure in "+test+"("+str(ttraj[test])+"): "
-            self._single_test(ensemble, 
+            self._single_test(ensemble,
                                 ttraj[test], results[test], failmsg)
 
 
@@ -898,7 +898,7 @@ class TestSequentialEnsemble(EnsembleTest):
             logging.getLogger('openpathsampling.ensemble').info(
                 "Testing: "+str(test)
             )
-            self._single_test(ensemble, ttraj[test], 
+            self._single_test(ensemble, ttraj[test],
                               match_results[test], failmsg)
 
         append_results = {
@@ -916,7 +916,7 @@ class TestSequentialEnsemble(EnsembleTest):
             logging.getLogger('opentis.ensemble').info(
                 "Testing: "+str(test)
             )
-            self._single_test(ensemble.can_append, ttraj[test], 
+            self._single_test(ensemble.can_append, ttraj[test],
                               append_results[test], failmsg)
 
     def test_sequential_enter_exit(self):
@@ -951,7 +951,7 @@ class TestSequentialEnsembleCombination(EnsembleTest):
     # useful to making sure that the ensemble combination of strict_can_*
     # works correctly, since this is where strict and normal have a
     # distinction
-    def setup(self):
+    def setup_method(self):
         self.ens1 = SequentialEnsemble([
             AllInXEnsemble(vol1) & LengthEnsemble(1),
             AllOutXEnsemble(vol1) & PartOutXEnsemble(vol2),
@@ -1185,7 +1185,7 @@ class TestSequentialEnsembleCombination(EnsembleTest):
         self._test_everything(self.combo_and.strict_can_prepend, and_true, False)
 
 class TestTISEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.tis = TISEnsemble(vol1, vol3, vol2, op)
         self.traj = ttraj['upper_in_out_cross_out_in']
         self.minl = min(op(self.traj))
@@ -1269,7 +1269,7 @@ class EnsembleCacheTest(EnsembleTest):
         return cache.contents == { }
 
 class TestEnsembleCache(EnsembleCacheTest):
-    def setup(self):
+    def setup_method(self):
         self.fwd = EnsembleCache(direction=+1)
         self.rev = EnsembleCache(direction=-1)
         self.traj = ttraj['lower_in_out_in_in_out_in']
@@ -1366,7 +1366,7 @@ class TestEnsembleCache(EnsembleCacheTest):
 
 
 class TestSequentialEnsembleCache(EnsembleCacheTest):
-    def setup(self):
+    def setup_method(self):
         self.inX = AllInXEnsemble(vol1)
         self.outX = AllOutXEnsemble(vol1)
         self.length1 = LengthEnsemble(1)
@@ -1499,7 +1499,7 @@ class TestSlicedTrajectoryEnsemble(EnsembleTest):
             failmsg = "Failure in "+test+"("+tstr(ttraj[test])+"): "
             self._single_test(real_tis, ttraj[test],
                               sequential_tis(ttraj[test]), failmsg)
-            self._single_test(sliced_tis, ttraj[test], 
+            self._single_test(sliced_tis, ttraj[test],
                               sequential_tis(ttraj[test]), failmsg)
 
     def test_slice_outside_trajectory_range(self):
@@ -1601,7 +1601,7 @@ class TestSlicedTrajectoryEnsemble(EnsembleTest):
                      "("+inXstr+" in {1:-1})")
 
 class TestOptionalEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.start_opt = SequentialEnsemble([
             OptionalEnsemble(AllOutXEnsemble(vol1)),
             AllInXEnsemble(vol1),
@@ -1857,7 +1857,7 @@ class TestOptionalEnsemble(EnsembleTest):
         assert_equal(opt_inX.__str__(), "{"+inX.__str__()+"} (OPTIONAL)")
 
 class TestPrefixTrajectoryEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.inX = AllInXEnsemble(vol1)
 
     def test_bad_start_traj(self):
@@ -1907,7 +1907,7 @@ class TestPrefixTrajectoryEnsemble(EnsembleTest):
             outX,
             inX,
             outX,
-            inX & length1 
+            inX & length1
         ])
         traj = ttraj['upper_in_out_in_in_out_in']
         ens = PrefixTrajectoryEnsemble(pseudo_minus, traj[0:2])
@@ -1929,7 +1929,7 @@ class TestPrefixTrajectoryEnsemble(EnsembleTest):
 
 
 class TestSuffixTrajectoryEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         xval = paths.FunctionCV("x", lambda s : s.xyz[0][0])
         vol = paths.CVDefinedVolume(xval, 0.1, 0.5)
         self.inX = AllInXEnsemble(vol)
@@ -1983,7 +1983,7 @@ class TestSuffixTrajectoryEnsemble(EnsembleTest):
             self.outX,
             self.inX,
             self.outX,
-            self.inX & length1 
+            self.inX & length1
         ])
         traj = ttraj['upper_in_out_in_in_out_in']
 
@@ -2009,7 +2009,7 @@ class TestSuffixTrajectoryEnsemble(EnsembleTest):
         assert_equal(ens._cache_can_prepend.trusted, True)
 
 class TestMinusInterfaceEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         # Mostly we use minus ensembles where the state matches the first
         # interface. We also test the case where that isn't in, in which
         # case there's an interstitial zone. (Only test it for nl=2 to keep
@@ -2338,7 +2338,7 @@ class TestMinusInterfaceEnsemble(EnsembleTest):
 
 # TODO: this whole class should become a single test in SeqEns
 class TestSingleEnsembleSequentialEnsemble(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         #self.inner_ens = AllInXEnsemble(vol1 | vol2)
         self.inner_ens = LengthEnsemble(3) & AllInXEnsemble( vol1 | vol2 )
         self.ens = SequentialEnsemble([self.inner_ens])
@@ -2355,7 +2355,7 @@ class TestSingleEnsembleSequentialEnsemble(EnsembleTest):
 
 
 class TestEnsembleSplit(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.inA = AllInXEnsemble(vol1)
         self.outA = AllOutXEnsemble(vol1)
 
@@ -2453,7 +2453,7 @@ class TestEnsembleSplit(EnsembleTest):
         assert(traj3.subtrajectory_indices(sub_traj) == [2,3,4])
 
 class TestVolumeCombinations(EnsembleTest):
-    def setup(self):
+    def setup_method(self):
         self.outA = paths.AllOutXEnsemble(vol1)
         self.outB = paths.AllOutXEnsemble(~vol2)
         self.outA.special_debug = True
@@ -2475,7 +2475,7 @@ class TestVolumeCombinations(EnsembleTest):
     def _test_trusted(self, trajectory, function, results,
                       cache_results=None, direction=+1, start_traj_len=1):
         # Tests `trajectory` frame by frame in a forward direction for the
-        # `function`, expecting `results`. Additionally, can take the 
+        # `function`, expecting `results`. Additionally, can take the
 
         if cache_results is None:
             cache_results = {}
@@ -2577,8 +2577,8 @@ class TestVolumeCombinations(EnsembleTest):
     def test_can_append_outA_or_outB(self):
         self._test_trusted(
             trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
-            function=self.outA_or_outB.can_append, 
-            results=[True, True, True, True, False], 
+            function=self.outA_or_outB.can_append,
+            results=[True, True, True, True, False],
             cache_results={
                 self.outA._cache_can_append : [True, False, False, False, False],
                 self.outB._cache_can_append : [None, True, True, True, False]

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -92,7 +92,7 @@ def teardown_module():
 
 
 class TestExternalEngine(object):
-    def setup(self):
+    def setup_method(self):
         self.descriptor = SnapshotDescriptor.construct(
             snapshot_class=ToySnapshot,
             snapshot_dimensions={'n_spatial': 1,

--- a/openpathsampling/tests/test_external_snapshots.py
+++ b/openpathsampling/tests/test_external_snapshots.py
@@ -45,7 +45,7 @@ class ErrorMockEngine(MockEngine):
 
 
 class TestExternalMDSnapshot(object):
-    def setup(self):
+    def setup_method(self):
         self.box = np.array([[1.0, 0.0], [0.0, 1.0]])
         self.vel = np.array([[1.0, 0.0]])
 

--- a/openpathsampling/tests/test_gromacs_engine.py
+++ b/openpathsampling/tests/test_gromacs_engine.py
@@ -44,7 +44,7 @@ finally:
 
 
 class TestGroFileEngine(object):
-    def setup(self):
+    def setup_method(self):
         if not HAS_MDTRAJ:
             pytest.skip("MDTraj not installed.")
         self.gro = os.path.join(data_filename("gromacs_engine"), "conf.gro")
@@ -83,7 +83,7 @@ class TestGromacsEngine(object):
     # conf.gro, md.mdp, topol.top : standard Gromacs input files
     # project_trr/0000000.trr : working file, 4 frames
     # project_trr/0000099.trr : 49 working frames, final frame partial
-    def setup(self):
+    def setup_method(self):
         if not HAS_MDTRAJ:
             pytest.skip("MDTraj not installed.")
         self.test_dir = data_filename("gromacs_engine")
@@ -94,7 +94,7 @@ class TestGromacsEngine(object):
                              base_dir=self.test_dir,
                              prefix="project")
 
-    def teardown(self):
+    def teardown_method(self):
         files = ['topol.tpr', 'mdout.mdp', 'initial_frame.trr', 'state.cpt',
                  'state_prev.cpt', 'traj_comp.xtc',
                  self.engine.trajectory_filename(1)]
@@ -316,7 +316,7 @@ class TestGromacsEngine(object):
 
 
 class TestGromacsExternalMDSnapshot(object):
-    def setup(self):
+    def setup_method(self):
         if not HAS_MDTRAJ:
             pytest.skip("MDTraj not installed.")
 
@@ -336,7 +336,7 @@ class TestGromacsExternalMDSnapshot(object):
         self.snapshot_shape = (1651, 3)
         self.storage_filename = "gmx_snap.nc"
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.storage_filename):
             os.remove(self.storage_filename)
 

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -45,7 +45,7 @@ class TestFunctions(object):
 
 
 class TestHistogram(object):
-    def setup(self):
+    def setup_method(self):
         self.data = [1.0, 1.1, 1.2, 1.3, 2.0, 1.4, 2.3, 2.5, 3.1, 3.5]
         self.nbins = 5
         self.bins = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5]
@@ -189,7 +189,7 @@ class TestHistogram(object):
 
 
 class TestSparseHistogram(object):
-    def setup(self):
+    def setup_method(self):
         data = [(0.0, 0.1), (0.2, 0.7), (0.3, 0.6), (0.6, 0.9)]
         self.histo = SparseHistogram(bin_widths=(0.5, 0.3),
                                      left_bin_edges=(0.0, -0.1))
@@ -232,7 +232,7 @@ class TestSparseHistogram(object):
 
 
 class TestHistogramPlotter2D(object):
-    def setup(self):
+    def setup_method(self):
         data = [(0.0, 0.1), (0.2, 0.7), (0.3, 0.6), (0.6, 0.9)]
         histo = SparseHistogram(bin_widths=(0.5, 0.3),
                                 left_bin_edges=(0.0, -0.1))

--- a/openpathsampling/tests/test_interface_set.py
+++ b/openpathsampling/tests/test_interface_set.py
@@ -20,7 +20,7 @@ logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestInterfaceSet(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         self.cv = paths.FunctionCV(name="x", f=lambda s: s.xyz[0][0])
         self.lambdas = [0.0, 0.1, 0.2, 0.3]
@@ -104,7 +104,7 @@ class TestGenericVolumeInterfaceSet(object):
 
 
 class TestVolumeInterfaceSet(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         self.cv = paths.FunctionCV(name="x", f=lambda s: s.xyz[0][0])
         self.increasing_set = paths.VolumeInterfaceSet(cv=self.cv,
@@ -171,7 +171,7 @@ class TestVolumeInterfaceSet(object):
 
 
 class TestPeriodicVolumeInterfaceSet(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         self.cv = paths.FunctionCV(name="x", f=lambda s: s.xyz[0][0])
         self.increasing_set = paths.PeriodicVolumeInterfaceSet(

--- a/openpathsampling/tests/test_lookup_function.py
+++ b/openpathsampling/tests/test_lookup_function.py
@@ -14,7 +14,7 @@ from openpathsampling.numerics import (
 )
 
 class TestLookupFunctionGroup(object):
-    def setup(self):
+    def setup_method(self):
         x1 = [0.0, 1.0, 2.0, 3.0, 4.0]
         y1 = [0.1, 1.3, 1.8, 3.3, 4.2]
         luf1 = LookupFunction(x1, y1)
@@ -75,7 +75,7 @@ class TestLookupFunctionGroup(object):
 
 
 class TestVoxelLookupFunction(object):
-    def setup(self):
+    def setup_method(self):
         counter = collections.Counter({(0,0): 1.0, (0,2): 2.0, (1,4): 4.0,
                                        (-1,-1): 5.0})
         self.lookup = VoxelLookupFunction(left_bin_edges=(-1.0, 1.0),

--- a/openpathsampling/tests/test_mdtraj_support.py
+++ b/openpathsampling/tests/test_mdtraj_support.py
@@ -27,7 +27,7 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 # add tests for topology conversions as well
 
 class TestMDTrajSupport(object):
-    def setup(self):
+    def setup_method(self):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.md_trajectory = md.load(data_filename("ala_small_traj.pdb"))

--- a/openpathsampling/tests/test_movescheme.py
+++ b/openpathsampling/tests/test_movescheme.py
@@ -92,7 +92,7 @@ def _make_null_mover_step(mccycle, path_sim_mover, null_mover):
 
 
 class TestMoveAcceptanceAnalysis(object):
-    def setup(self):
+    def setup_method(self):
         self.HAS_TQDM = paths.progress.HAS_TQDM
         paths.progress.HAS_TQDM = False
         paths.InterfaceSet._reset()
@@ -146,7 +146,7 @@ class TestMoveAcceptanceAnalysis(object):
                          'normal': acceptance,
                          'with_null': acceptance_null}
 
-    def teardown(self):
+    def teardown_method(self):
         paths.progress.HAS_TQDM = self.HAS_TQDM
 
     @pytest.mark.parametrize('step_num', [0, 1, 2, 3, 4])
@@ -391,7 +391,7 @@ class TestMoveAcceptanceAnalysis(object):
 
 
 class TestMoveScheme(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         cvA = paths.FunctionCV(name="xA", f=lambda s : s.xyz[0][0])
         cvB = paths.FunctionCV(name="xB", f=lambda s : -s.xyz[0][0])
@@ -421,7 +421,7 @@ class TestMoveScheme(object):
 
         strats = self.scheme.strategies
         assert_equal(len(list(strats.keys())), 3)
-        pairs = [(levels.MOVER, shootstrat), (levels.SIGNATURE, repexstrat), 
+        pairs = [(levels.MOVER, shootstrat), (levels.SIGNATURE, repexstrat),
                  (levels.GLOBAL, defaultstrat)]
         for (k, v) in pairs:
             assert_in(v, strats[k])
@@ -435,7 +435,7 @@ class TestMoveScheme(object):
 
         strats = self.scheme.strategies
         assert_equal(len(list(strats.keys())), 3)
-        pairs = [(levels.MOVER, shootstrat), (levels.SIGNATURE, repexstrat), 
+        pairs = [(levels.MOVER, shootstrat), (levels.SIGNATURE, repexstrat),
                  (levels.GLOBAL, defaultstrat)]
         for (k, v) in pairs:
             assert_in(v, strats[k])
@@ -470,7 +470,7 @@ class TestMoveScheme(object):
         repexstrat = NearestNeighborRepExStrategy()
         defaultstrat = OrganizeByMoveGroupStrategy()
         assert_equal(len(list(self.scheme.strategies.keys())), 0)
-        self.scheme.append([shootstrat, repexstrat, defaultstrat], 
+        self.scheme.append([shootstrat, repexstrat, defaultstrat],
                            [45, 55, 65])
 
         strats = self.scheme.strategies
@@ -659,7 +659,7 @@ class TestMoveScheme(object):
 
     def test_select_movers(self):
         self.scheme.append([
-            OneWayShootingStrategy(), 
+            OneWayShootingStrategy(),
             NearestNeighborRepExStrategy(),
             OrganizeByMoveGroupStrategy()
         ])
@@ -677,7 +677,7 @@ class TestMoveScheme(object):
 
     def test_n_trials_for_steps(self):
         self.scheme.append([
-            OneWayShootingStrategy(), 
+            OneWayShootingStrategy(),
             NearestNeighborRepExStrategy(),
             OrganizeByMoveGroupStrategy()
         ])
@@ -728,15 +728,15 @@ class TestMoveScheme(object):
 
 
 class TestDefaultScheme(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         cvA = paths.FunctionCV(name="xA", f=lambda s : s.xyz[0][0])
         cvB = paths.FunctionCV(name="xB", f=lambda s : -s.xyz[0][0])
         self.stateA = paths.CVDefinedVolume(cvA, float("-inf"), -0.5)
         self.stateB = paths.CVDefinedVolume(cvB, float("-inf"), -0.5)
-        interfacesA = paths.VolumeInterfaceSet(cvA, float("-inf"), 
+        interfacesA = paths.VolumeInterfaceSet(cvA, float("-inf"),
                                                [-0.5, -0.3, -0.1])
-        interfacesB = paths.VolumeInterfaceSet(cvB, float("-inf"), 
+        interfacesB = paths.VolumeInterfaceSet(cvB, float("-inf"),
                                                [-0.5, -0.3, -0.1])
         self.network = paths.MSTISNetwork(
             [(self.stateA, interfacesA),
@@ -862,7 +862,7 @@ class TestDefaultScheme(object):
 
         assert_almost_equal(sum(scheme.choice_probability.values()), 1.0)
 
-        tot_norm = sum([default_group_weights[group] 
+        tot_norm = sum([default_group_weights[group]
                         for group in scheme.movers])
 
         prob_shoot0 = scheme.choice_probability[scheme.movers['shooting'][0]]
@@ -1112,15 +1112,15 @@ class TestDefaultScheme(object):
 
 
 class TestLockedMoveScheme(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         cvA = paths.FunctionCV(name="xA", f=lambda s : s.xyz[0][0])
         cvB = paths.FunctionCV(name="xB", f=lambda s : -s.xyz[0][0])
         self.stateA = paths.CVDefinedVolume(cvA, float("-inf"), -0.5)
         self.stateB = paths.CVDefinedVolume(cvB, float("-inf"), -0.5)
-        interfacesA = paths.VolumeInterfaceSet(cvA, float("-inf"), 
+        interfacesA = paths.VolumeInterfaceSet(cvA, float("-inf"),
                                                [-0.5, -0.3, -0.1])
-        interfacesB = paths.VolumeInterfaceSet(cvB, float("-inf"), 
+        interfacesB = paths.VolumeInterfaceSet(cvB, float("-inf"),
                                                [-0.5, -0.3, -0.1])
         self.network = paths.MSTISNetwork(
             [(self.stateA, interfacesA),
@@ -1175,15 +1175,15 @@ class TestLockedMoveScheme(object):
 
 
 class TestOneWayShootingMoveScheme(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         cvA = paths.FunctionCV(name="xA", f=lambda s : s.xyz[0][0])
         cvB = paths.FunctionCV(name="xB", f=lambda s : -s.xyz[0][0])
         self.stateA = paths.CVDefinedVolume(cvA, float("-inf"), -0.5)
         self.stateB = paths.CVDefinedVolume(cvB, float("-inf"), -0.5)
-        interfacesA = paths.VolumeInterfaceSet(cvA, float("-inf"), 
+        interfacesA = paths.VolumeInterfaceSet(cvA, float("-inf"),
                                                [-0.5, -0.3, -0.1])
-        interfacesB = paths.VolumeInterfaceSet(cvB, float("-inf"), 
+        interfacesB = paths.VolumeInterfaceSet(cvB, float("-inf"),
                                                [-0.5, -0.3, -0.1])
         self.network = paths.MSTISNetwork(
             [(self.stateA, interfacesA),
@@ -1209,7 +1209,7 @@ class TestOneWayShootingMoveScheme(object):
         root = scheme.move_decision_tree()
         unused = scheme.find_unused_ensembles()
         specials = self.network.special_ensembles
-        expected_unused = sum([list(specials[special_type].keys()) 
+        expected_unused = sum([list(specials[special_type].keys())
                                for special_type in specials], [])
         assert_equal(set(expected_unused), set(unused))
 

--- a/openpathsampling/tests/test_movestrategy.py
+++ b/openpathsampling/tests/test_movestrategy.py
@@ -56,7 +56,7 @@ class TestStrategyLevels(object):
 
 
 class MoveStrategyTestSetup(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         cvA = paths.FunctionCV(name="xA", f=lambda s: s.xyz[0][0])
         cvB = paths.FunctionCV(name="xB", f=lambda s: -s.xyz[0][0])
@@ -126,8 +126,8 @@ class TestMoveStrategy(MoveStrategyTestSetup):
 
 
 class TestSingleEnsembleMoveStrategy(MoveStrategyTestSetup):
-    def setup(self):
-        super(TestSingleEnsembleMoveStrategy, self).setup()
+    def setup_method(self):
+        super(TestSingleEnsembleMoveStrategy, self).setup_method()
         self.strategy = MockSingleEnsembleMoveStrategy(
             ensembles=None,
             group='test_group',
@@ -356,7 +356,7 @@ class TestEnsembleHopStrategy(MoveStrategyTestSetup):
         # set up the swap pairs
         swap_pairs = []
         for trans in self.network.sampling_transitions:
-            swap_pairs.extend([[trans.ensembles[i], trans.ensembles[i+1]] 
+            swap_pairs.extend([[trans.ensembles[i], trans.ensembles[i+1]]
                                for i in range(len(trans.ensembles)-1)])
         assert_equal(len(swap_pairs), 4)
 
@@ -415,7 +415,7 @@ class TestEnsembleHopStrategy(MoveStrategyTestSetup):
             input_ensembles=[ens0, ens1],
             output_ensembles=[ens1, ens2]
         )
-        assert_equal(weird_mover.ensemble_signature, 
+        assert_equal(weird_mover.ensemble_signature,
                      ((ens0,ens1),(ens1,ens2)))
         scheme = MoveScheme(self.network)
         scheme.movers['weird'] = [weird_mover]
@@ -436,7 +436,7 @@ class TestEnsembleHopStrategy(MoveStrategyTestSetup):
         # groups: both the new and the old.
         scheme = DefaultScheme(self.network)
         scheme.movers ={}
-        scheme.append(EnsembleHopStrategy(replace=False, 
+        scheme.append(EnsembleHopStrategy(replace=False,
                                           group='hop',
                                           from_group='repex'))
         scheme.build_move_decision_tree()
@@ -448,7 +448,7 @@ class TestEnsembleHopStrategy(MoveStrategyTestSetup):
         # remove the old from_group from existence
         scheme = DefaultScheme(self.network)
         scheme.movers ={}
-        scheme.append(EnsembleHopStrategy(replace=True, 
+        scheme.append(EnsembleHopStrategy(replace=True,
                                           group='hop',
                                           from_group='repex'))
         scheme.build_move_decision_tree()
@@ -717,7 +717,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         for groupname in list(scheme.movers.keys()):
             for mover in scheme.movers[groupname]:
                 mover_weights[(groupname, mover.ensemble_signature)] = 1.0
-    
+
         m_sig = {}
         for g in scheme.movers:
             for m in scheme.movers[g]:
@@ -756,9 +756,9 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
 
         strategy = OrganizeByMoveGroupStrategy()
         root = strategy.make_movers(scheme)
-        
+
         assert_equal(len(root.movers), 4)
-        names = ['ShootingChooser', 'RepexChooser', 'PathreversalChooser', 
+        names = ['ShootingChooser', 'RepexChooser', 'PathreversalChooser',
                  'MinusChooser']
         name_dict = {root.movers[i].name : i for i in range(len(root.movers))}
         for name in names:
@@ -830,7 +830,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         root = strategy.make_movers(scheme)
 
         name_dict = {root.movers[i].name : i for i in range(len(root.movers))}
-        
+
         name = 'BlahblahblahChooser'
         weight = root.weights[name_dict[name]]
         chooser = root.movers[name_dict[name]]
@@ -862,7 +862,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         # check that the number of sigs in a each group matches the number
         # of movers in that group
         for group in list(group_weights.keys()):
-            mover_sigs = [sig for sig in list(mover_weights.keys()) 
+            mover_sigs = [sig for sig in list(mover_weights.keys())
                           if sig[0]==group]
             assert_equal(len(mover_sigs), len(scheme.movers[group]))
 
@@ -883,7 +883,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         assert_equal(group_weights, {'shooting' : 1.0})
         for sig in mover_weights:
             assert_equal(mover_weights[sig], 1.0)
-            assert_in(sig[1], [m.ensemble_signature 
+            assert_in(sig[1], [m.ensemble_signature
                                for m in scheme2.movers[sig[0]]])
 
         for group in list(scheme2.movers.keys()):
@@ -897,18 +897,18 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         ensA_sig = ((ensA,),(ensA,))
 
         scheme = MoveScheme(self.network)
-        scheme.append([NearestNeighborRepExStrategy(), 
-                       OneWayShootingStrategy(), 
+        scheme.append([NearestNeighborRepExStrategy(),
+                       OneWayShootingStrategy(),
                        strategy])
         root = scheme.move_decision_tree()
         old_choice_probability = scheme.choice_probability
-        old_shooter_ensA = [m for m in scheme.movers['shooting'] 
+        old_shooter_ensA = [m for m in scheme.movers['shooting']
                             if m.ensemble_signature == ensA_sig][0]
 
         strategy.group_weights['repex'] = 3.0
         strategy.mover_weights[('shooting',ensA_sig)]= 2.0
         scheme.choice_probability = {} # this is unset here
- 
+
         (group_weights, mover_weights) = strategy.get_weights(
             scheme=scheme,
             sorted_movers=scheme.movers,
@@ -938,7 +938,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
                      3.0*len(new_repex_chooser.movers))
 
         new_shoot_chooser = [m for m in root if m.name=="ShootingChooser"][0]
-        new_shooter_ensA = [m for m in scheme.movers['shooting'] 
+        new_shooter_ensA = [m for m in scheme.movers['shooting']
                             if m.ensemble_signature == ensA_sig][0]
         shooter_ensA_idx = new_shoot_chooser.movers.index(new_shooter_ensA)
         assert_equal(new_shoot_chooser.weights[shooter_ensA_idx], 2.0)
@@ -948,8 +948,8 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
     def test_get_weights_group_weights_set(self):
         strategy = OrganizeByMoveGroupStrategy()
         scheme = MoveScheme(self.network)
-        scheme.append([NearestNeighborRepExStrategy(), 
-                       OneWayShootingStrategy(), 
+        scheme.append([NearestNeighborRepExStrategy(),
+                       OneWayShootingStrategy(),
                        strategy])
         root = scheme.move_decision_tree()
 
@@ -986,12 +986,12 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
             assert_almost_equal(choice_prob[mover], old_div(1.0,7.0))
         for mover in scheme.movers['repex']:
             assert_almost_equal(choice_prob[mover], old_div(1.0,28.0))
-        
+
 
     def test_get_weights_mover_weights_set(self):
         strategy = OrganizeByMoveGroupStrategy()
         scheme = MoveScheme(self.network)
-        scheme.append([NearestNeighborRepExStrategy(), 
+        scheme.append([NearestNeighborRepExStrategy(),
                        OneWayShootingStrategy(),
                        strategy])
         # build it so there's an old version
@@ -1005,7 +1005,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         assert_equal(group_weights, {'shooting' : 1.0, 'repex' : 3.0})
 
         ensA = self.network.sampling_transitions[0].ensembles[0]
-        ensA_sig = ((ensA,),(ensA,)) 
+        ensA_sig = ((ensA,),(ensA,))
         strategy.group_weights = {}
         strategy.mover_weights[('shooting',ensA_sig)] = 2.0
 
@@ -1028,7 +1028,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
     def test_get_weights_internal_unset_choice_prob_set(self):
         strategy = OrganizeByMoveGroupStrategy()
         scheme = MoveScheme(self.network)
-        scheme.append([NearestNeighborRepExStrategy(), 
+        scheme.append([NearestNeighborRepExStrategy(),
                        OneWayShootingStrategy(),
                        strategy])
         ensA = self.network.sampling_transitions[0].ensembles[0]
@@ -1066,10 +1066,10 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         for group in scheme.movers:
             for mover in scheme.movers[group]:
                 old_mover = [
-                    old for old in old_movers[group] 
+                    old for old in old_movers[group]
                     if mover.ensemble_signature==old.ensemble_signature
                 ][0]
-                assert_almost_equal(new_choice_prob[mover], 
+                assert_almost_equal(new_choice_prob[mover],
                                     old_choice_prob[old_mover])
 
         #print new_choice_prob
@@ -1087,7 +1087,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         # with path reversal
         strategy = OrganizeByMoveGroupStrategy()
         scheme = MoveScheme(self.network)
-        scheme.append([NearestNeighborRepExStrategy(), 
+        scheme.append([NearestNeighborRepExStrategy(),
                        PathReversalStrategy(),
                        strategy])
         strategy.group_weights['repex'] = 3.0
@@ -1100,7 +1100,7 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
         )
         assert_equal(group_weights, {'pathreversal' : 1.0, 'repex' : 3.0})
         ensA = self.network.sampling_transitions[0].ensembles[0]
-        ensA_sig = ((ensA,),(ensA,)) 
+        ensA_sig = ((ensA,),(ensA,))
         strategy.group_weights = {}
         strategy.mover_weights[('pathreversal',ensA_sig)] = 2.0
 
@@ -1124,8 +1124,8 @@ class TestOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
 
 class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
     StrategyClass = OrganizeByEnsembleStrategy
-    def setup(self):
-        super(TestOrganizeByEnsembleStrategy, self).setup()
+    def setup_method(self):
+        super(TestOrganizeByEnsembleStrategy, self).setup_method()
         scheme = MoveScheme(self.network)
         ens0 = self.network.sampling_transitions[0].ensembles[0]
         ens1 = self.network.sampling_transitions[0].ensembles[1]
@@ -1142,7 +1142,7 @@ class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
             paths.ReplicaExchangeMover(ens1, ens2)
         ]
         scheme.movers['pathreversal'] = [
-            paths.PathReversalMover(ensemble=ens) 
+            paths.PathReversalMover(ensemble=ens)
             for ens in [ens0, ens1, ens2]
         ]
         scheme.movers['minus'] = [paths.MinusMover(
@@ -1184,8 +1184,8 @@ class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
         # minus: 1/9
 
         # ens0 moves: shooting (2.0), repex01 (1.0), minus (1.0), rev (1.0)
-        # ens1 moves: shooting (1.0), repex01 (1.0), repex12 (1.0), rev (1.0) 
-        # ens2 moves: shooting (1.0), repex12 (1.0), rev (1.0) 
+        # ens1 moves: shooting (1.0), repex01 (1.0), repex12 (1.0), rev (1.0)
+        # ens2 moves: shooting (1.0), repex12 (1.0), rev (1.0)
         # minus moves: minus (1.0)
 
         # ens0 norm: 5.0
@@ -1197,7 +1197,7 @@ class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
         #   shooting0 = 4/9 * 2.0/5.0 = 8.0/45.0
         #   shooting1 = 2/9 * 1.0/4.0 = 1.0/18.0
         #   shooting2 = 2/9 * 1.0/3.0 = 2.0/27.0
-        #   repex01 = 4/9 * 1.0/5.0 + 2/9 * 1.0/4.0 = 13.0/90.0 
+        #   repex01 = 4/9 * 1.0/5.0 + 2/9 * 1.0/4.0 = 13.0/90.0
         #   repex12 = 2/9 * 1.0/4.0 + 2/9 * 1.0/3.0 = 7.0/54.0
         #   minus = 1/9*1.0 + 4/9*1.0/5.0 = 1.8/9.0
         #   rev0 = 4/9 * 1.0/5.0 = 4.0/45.0
@@ -1242,7 +1242,7 @@ class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
         (ensemble_weights, mover_weights) = strategy.default_weights(scheme)
 
         for ens in [ens0, ens1, ens2, minus]:
-            chooser_mweights = strategy.chooser_mover_weights(scheme, ens, 
+            chooser_mweights = strategy.chooser_mover_weights(scheme, ens,
                                                               mover_weights)
             for mover in chooser_mweights:
                 assert_in(ens, mover.ensemble_signature[0])
@@ -1265,12 +1265,12 @@ class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
 
         (ensemble_weights, mover_weights)= strategy.default_weights(scheme)
 
-        assert_equal(ensemble_weights, 
+        assert_equal(ensemble_weights,
                      {e : 1.0 for e in [ens0, ens1, ens2, minus]})
 
         # get the correct order on repex and minus signatures for testing
-        double_sigs = [m.ensemble_signature 
-                       for m in sum([scheme.movers[g] 
+        double_sigs = [m.ensemble_signature
+                       for m in sum([scheme.movers[g]
                                      for g in ['repex', 'minus']], [])
                       ]
         repex01_sig = reorder_ensemble_signature(((ens0,ens1),(ens0,ens1)),
@@ -1297,7 +1297,7 @@ class TestOrganizeByEnsembleStrategy(MoveStrategyTestSetup):
 
         assert_equal(len(mover_ens_sigs), len(list(mover_weights.keys())))
         assert_equal(set(mover_weights.keys()), set(mover_ens_sigs))
-        
+
         expected = {s : 1.0 for s in mover_ens_sigs}
         assert_equal(expected, mover_weights)
 
@@ -1406,10 +1406,10 @@ class TestPoorSingleReplicaStrategy(TestOrganizeByEnsembleStrategy):
         (ens_w, mov_w) = strategy.get_weights(scheme, scheme.movers,
                                               strategy.ensemble_weights,
                                               strategy.mover_weights)
-        scheme.choice_probability = strategy.choice_probability(scheme, 
+        scheme.choice_probability = strategy.choice_probability(scheme,
                                                                 ens_w, mov_w)
         for ens in [ens0, ens1, ens2, minus]:
-            chooser_mweights = strategy.chooser_mover_weights(scheme, ens, 
+            chooser_mweights = strategy.chooser_mover_weights(scheme, ens,
                                                               mover_weights)
             if ens in [ens0, ens1]:
                 assert_equal(len(chooser_mweights), 5)
@@ -1418,7 +1418,7 @@ class TestPoorSingleReplicaStrategy(TestOrganizeByEnsembleStrategy):
             elif ens is ens2:
                 assert_equal(len(chooser_mweights), 4)
 
-            real_movers = [m for m in list(chooser_mweights.keys()) 
+            real_movers = [m for m in list(chooser_mweights.keys())
                            if m != strategy.null_mover]
             for m in real_movers:
                 assert_equal(scheme.choice_probability[m], chooser_mweights[m])

--- a/openpathsampling/tests/test_ms_outer_interface.py
+++ b/openpathsampling/tests/test_ms_outer_interface.py
@@ -18,10 +18,10 @@ logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestMSOuterTISInterface(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         self.cv_inc = paths.FunctionCV(name="inc", f=lambda s: s.xyz[0][0])
-        self.cv_dec = paths.FunctionCV(name="dec", 
+        self.cv_dec = paths.FunctionCV(name="dec",
                                         f=lambda s: 1.0-s.xyz[0][0])
         self.lambdas = [0.0, 0.1, 0.2, 0.3]
         self.interfaces_inc = paths.VolumeInterfaceSet(cv=self.cv_inc,

--- a/openpathsampling/tests/test_netcdfplus_base.py
+++ b/openpathsampling/tests/test_netcdfplus_base.py
@@ -3,7 +3,7 @@ import pytest
 from openpathsampling.netcdfplus.base import *
 
 class TestStorableNamedObject(object):
-    def setup(self):
+    def setup_method(self):
         self.obj = StorableNamedObject()
 
     def test_named(self):

--- a/openpathsampling/tests/test_network.py
+++ b/openpathsampling/tests/test_network.py
@@ -25,7 +25,7 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestMultipleStateTIS(object):
     # generic class to set up states and ifaces
-    def setup(self):
+    def setup_method(self):
         # need to clear this before each run, otherwise it saves the
         # previous setup
         paths.InterfaceSet._reset()
@@ -91,8 +91,8 @@ class TestMultipleStateTIS(object):
 
 
 class TestMSTISNetwork(TestMultipleStateTIS):
-    def setup(self):
-        super(TestMSTISNetwork, self).setup()
+    def setup_method(self):
+        super(TestMSTISNetwork, self).setup_method()
 
         ifacesA = self.ifacesA[:-1]
         ifacesB = self.ifacesB[:-1]
@@ -241,8 +241,8 @@ class TestMSTISNetwork(TestMultipleStateTIS):
 
 
 class TestMISTISNetwork(TestMultipleStateTIS):
-    def setup(self):
-        super(TestMISTISNetwork, self).setup()
+    def setup_method(self):
+        super(TestMISTISNetwork, self).setup_method()
 
         ifacesA = self.ifacesA[:-1]
         ifacesB = self.ifacesB[:-1]
@@ -411,7 +411,7 @@ class TestTPSNetwork(object):
     NetworkType = TPSNetwork
     std_kwargs = {}
 
-    def setup(self):
+    def setup_method(self):
         from .test_helpers import CallIdentity
         xval = paths.FunctionCV("xval", lambda snap: snap.xyz[0][0])
         self.stateA = paths.CVDefinedVolume(xval, float("-inf"), -0.5)

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -73,7 +73,7 @@ def setup_module():
 
 
 class TestOpenMMEngine(object):
-    def setup(self):
+    def setup_method(self):
 
         # OpenMM Integrator
         integrator = mm.LangevinIntegrator(
@@ -102,7 +102,7 @@ class TestOpenMMEngine(object):
         context.setPositions(template.coordinates)
         context.setVelocities(u.Quantity(zero_array, old_div(u.nanometers, u.picoseconds)))
 
-    def teardown(self):
+    def teardown_method(self):
         pass
 
     def test_sanity(self):
@@ -126,7 +126,7 @@ class TestOpenMMEngine(object):
         testvel = []
         testpos = []
         for i in range(len(pdb_pos)):
-            testpos.append(list(np.array(pdb_pos[i]) + 
+            testpos.append(list(np.array(pdb_pos[i]) +
                                 np.array([1.0, 1.0, 1.0]))
                           )
             testvel.append([0.1*i, 0.1*i, 0.1*i])

--- a/openpathsampling/tests/test_openmm_snapshot.py
+++ b/openpathsampling/tests/test_openmm_snapshot.py
@@ -26,7 +26,7 @@ logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestOpenMMSnapshot(object):
-    def setup(self):
+    def setup_method(self):
         if not openmm:
             raise SkipTest("OpenMM not installed")
         if not omt:

--- a/openpathsampling/tests/test_path_histogram.py
+++ b/openpathsampling/tests/test_path_histogram.py
@@ -26,14 +26,14 @@ from openpathsampling.analysis.path_histogram import *
 from collections import Counter
 
 class PathHistogramTester(object):
-    def setup(self):
+    def setup_method(self):
         self.HAS_TQDM = paths.progress.HAS_TQDM
         paths.progress.HAS_TQDM = False
         self.trajectory = [(0.1, 0.3), (2.1, 3.1), (1.7, 1.4),
                            (1.6, 0.6), (0.1, 1.4), (2.2, 3.3)]
         self.diag = [(0.25, 0.25), (2.25, 2.25)]
 
-    def teardown(self):
+    def teardown_method(self):
         paths.progress.HAS_TQDM = self.HAS_TQDM
 
     def test_nopertraj(self):
@@ -74,8 +74,8 @@ class PathHistogramTester(object):
 
 class TestPathHistogramNoInterpolate(PathHistogramTester):
     Interpolator = NoInterpolation
-    def setup(self):
-        super(TestPathHistogramNoInterpolate, self).setup()
+    def setup_method(self):
+        super(TestPathHistogramNoInterpolate, self).setup_method()
         self.expected_bins = [(0, 0), (4, 6), (3, 2),
                               (3, 1), (0, 2), (4, 6)]
 
@@ -89,8 +89,8 @@ class TestPathHistogramNoInterpolate(PathHistogramTester):
 
 class TestPathHistogramSubdivideInterpolate(PathHistogramTester):
     Interpolator = SubdivideInterpolation
-    def setup(self):
-        super(TestPathHistogramSubdivideInterpolate, self).setup()
+    def setup_method(self):
+        super(TestPathHistogramSubdivideInterpolate, self).setup_method()
         self.expected_bins = [
             (0, 0),  # initial
             (0, 1), (1, 1), (1, 2), (1, 3), (2, 3), (2, 4), (3, 4),
@@ -105,8 +105,8 @@ class TestPathHistogramSubdivideInterpolate(PathHistogramTester):
 
 class TestPathHistogramBesenhamLikeInterpolate(PathHistogramTester):
     Interpolator = BresenhamLikeInterpolation
-    def setup(self):
-        super(TestPathHistogramBesenhamLikeInterpolate, self).setup()
+    def setup_method(self):
+        super(TestPathHistogramBesenhamLikeInterpolate, self).setup_method()
         # NOTE: the (4, 5) in the 1->2 transition is exactly on bin edge;
         # left bin edge is inclusive
         self.expected_bins = [
@@ -121,8 +121,8 @@ class TestPathHistogramBesenhamLikeInterpolate(PathHistogramTester):
 
 class TestPathHistogramBesenhamInterpolate(PathHistogramTester):
     Interpolator = BresenhamInterpolation
-    def setup(self):
-        super(TestPathHistogramBesenhamInterpolate, self).setup()
+    def setup_method(self):
+        super(TestPathHistogramBesenhamInterpolate, self).setup_method()
         self.expected_bins = [
             (0, 0),  # initial
             (1, 1), (1, 2), (2, 3), (3, 4), (3, 5), (4, 6),  # 0->1
@@ -134,14 +134,14 @@ class TestPathHistogramBesenhamInterpolate(PathHistogramTester):
 
 class TestPathHistogram(object):
     # tests of fundamental things in PathHistogram, not interpolators
-    def setup(self):
+    def setup_method(self):
         self.HAS_TQDM = paths.progress.HAS_TQDM
         paths.progress.HAS_TQDM = False
         self.trajectory = [(0.1, 0.3), (2.1, 3.1), (1.7, 1.4),
                            (1.6, 0.6), (0.1, 1.4), (2.2, 3.3)]
         self.diag = [(0.25, 0.25), (2.25, 2.25)]
 
-    def teardown(self):
+    def teardown_method(self):
         paths.progress.HAS_TQDM = self.HAS_TQDM
 
     def test_add_with_weight(self):
@@ -199,7 +199,7 @@ class TestPathHistogram(object):
 
 
 class TestPathDensityHistogram(object):
-    def setup(self):
+    def setup_method(self):
         self.HAS_TQDM = paths.progress.HAS_TQDM
         paths.progress.HAS_TQDM = False
         id_cv = paths.FunctionCV("Id",
@@ -218,7 +218,7 @@ class TestPathDensityHistogram(object):
         self.traj2 = make_1d_traj([0.6, 0.7])
         # [(2, 1, 0), (2, 1, 1)]
 
-    def teardown(self):
+    def teardown_method(self):
         paths.progress.HAS_TQDM = self.HAS_TQDM
 
     def test_histogram_no_weights(self):
@@ -235,7 +235,7 @@ class TestPathDensityHistogram(object):
     def test_histogram_with_weights(self):
         hist = PathDensityHistogram(self.cvs, self.left_bin_edges,
                                     self.bin_widths)
-        counter = hist.histogram([self.traj1, self.traj2], 
+        counter = hist.histogram([self.traj1, self.traj2],
                                  weights=[1.0, 2.0])
         assert_equal(len(counter), 5)
         for bin_label in [(0,0,0), (2,0,0), (1,0,0)]:

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -38,7 +38,7 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 # logging.getLogger('openpathsampling.initialization').propagate = False
 
 class TestMakeListOfPairs(object):
-    def setup(self):
+    def setup_method(self):
         self.correct = [[0, 1], [2, 3], [4, 5]]
 
     def test_not_iterable_type_error(self):
@@ -85,7 +85,7 @@ def assert_choice_of(result, choices):
 
 
 class TestPathMover(object):
-    def setup(self):
+    def setup_method(self):
         self.l1 = LengthEnsemble(1)
         self.l2 = LengthEnsemble(2)
         self.l3 = LengthEnsemble(3)
@@ -125,7 +125,7 @@ class TestPathMover(object):
 
 
 class TestShootingMover(object):
-    def setup(self):
+    def setup_method(self):
         self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7,
                                       -0.1, 0.2, 0.4, 0.6, 0.8])
         op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
@@ -508,7 +508,7 @@ class TestTwoWayShootingMover(TestShootingMover):
 
 
 class TestPathReversalMover(object):
-    def setup(self):
+    def setup_method(self):
         op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
 
         volA = CVDefinedVolume(op, -100, 0.0)
@@ -564,7 +564,7 @@ class TestPathReversalMover(object):
 
 
 class TestReplicaIDChangeMover(object):
-    def setup(self):
+    def setup_method(self):
         pass
 
     def test_replica_in_sample_set(self):
@@ -575,7 +575,7 @@ class TestReplicaIDChangeMover(object):
 
 
 class TestReplicaExchangeMover(object):
-    def setup(self):
+    def setup_method(self):
         op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
 
         state1 = CVDefinedVolume(op, -100, 0.0)
@@ -658,7 +658,7 @@ class TestReplicaExchangeMover(object):
 
 
 class TestRandomChoiceMover(object):
-    def setup(self):
+    def setup_method(self):
         traj = Trajectory([-0.5, 0.7, 1.1])
         op = CallIdentity()
         volA = CVDefinedVolume(op, -100, 0.0)
@@ -718,7 +718,7 @@ class TestRandomChoiceMover(object):
 
 
 class TestRandomAllowedChoiceMover(object):
-    def setup(self):
+    def setup_method(self):
         self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7,
                                       -0.1, 0.2, 0.4, 0.6, 0.8,
                                       ])
@@ -820,7 +820,7 @@ class TestRandomAllowedChoiceMover(object):
 
 
 class TestSequentialMover(object):
-    def setup(self):
+    def setup_method(self):
         traj = Trajectory([-0.5, 0.7, 1.1])
         op = CallIdentity()
         volA = CVDefinedVolume(op, -100, 0.0)
@@ -1033,7 +1033,7 @@ class TestConditionalSequentialMover(TestSequentialMover):
 
 
 class SubtrajectorySelectTester(object):
-    def setup(self):
+    def setup_method(self):
         op = CallIdentity()
         vol = paths.CVDefinedVolume(op, -0.5, 0.5)
         inX = paths.AllInXEnsemble(vol)
@@ -1175,7 +1175,7 @@ class TestFinalSubtrajectorySelectMover(SubtrajectorySelectTester):
 
 
 class TestMinusMover(object):
-    def setup(self):
+    def setup_method(self):
         op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
         volA = CVDefinedVolume(op, -100, 0.0)
         volB = CVDefinedVolume(op, 1.0, 100)
@@ -1409,7 +1409,7 @@ class TestMinusMover(object):
 
 
 class TestSingleReplicaMinusMover(object):
-    def setup(self):
+    def setup_method(self):
         op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
         volA = CVDefinedVolume(op, -100, 0.0)
         volB = CVDefinedVolume(op, 1.0, 100)

--- a/openpathsampling/tests/test_pathsimulator.py
+++ b/openpathsampling/tests/test_pathsimulator.py
@@ -32,7 +32,7 @@ class TestAbstract(object):
 
 
 class TestFullBootstrapping(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         self.cv = paths.FunctionCV("Id", lambda snap: snap.xyz[0][0])
         cv_neg = paths.FunctionCV("Neg", lambda snap: -snap.xyz[0][0])
@@ -169,7 +169,7 @@ class TestShootFromSnapshotsSimulation(object):
     # for CommittorSimulation. This is just an additional test to show that
     # using different ensembles from the ones used for the committor will
     # also work.
-    def setup(self):
+    def setup_method(self):
         # As a test system, let's use 1D motion on a flat potential. If the
         # velocity is positive, you right the state on the right. If it is
         # negative, you hit the state on the left.
@@ -204,7 +204,7 @@ class TestShootFromSnapshotsSimulation(object):
         )
         self.simulation.output_stream = open(os.devnull, "w")
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None
@@ -232,7 +232,7 @@ class TestShootFromSnapshotsSimulation(object):
 
 
 class TestCommittorSimulation(object):
-    def setup(self):
+    def setup_method(self):
         # As a test system, let's use 1D motion on a flat potential. If the
         # velocity is positive, you right the state on the right. If it is
         # negative, you hit the state on the left.
@@ -268,7 +268,7 @@ class TestCommittorSimulation(object):
                                               initial_snapshots=self.snap0)
         self.simulation.output_stream = open(os.devnull, 'w')
 
-    def teardown(self):
+    def teardown_method(self):
         self.storage.close()
         if os.path.isfile(self.filename):
             os.remove(self.filename)
@@ -425,7 +425,7 @@ class TestCommittorSimulation(object):
 
 
 class TestReactiveFluxSimulation(object):
-    def setup(self):
+    def setup_method(self):
         # PES is one-dimensional linear slope (y(x) = x)
         pes = toys.LinearSlope(m=[-1.0], c=[0.0])
         # one particle with mass 1.0
@@ -484,7 +484,7 @@ class TestReactiveFluxSimulation(object):
                               rc=rc)
         self.simulation.output_stream = open(os.devnull, 'w')
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None
@@ -546,7 +546,7 @@ class TestReactiveFluxSimulation(object):
 
 
 class TestDirectSimulation(object):
-    def setup(self):
+    def setup_method(self):
         pes = toys.HarmonicOscillator(A=[1.0], omega=[1.0], x0=[0.0])
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
         integrator = toys.LeapfrogVerletIntegrator(0.1)
@@ -780,7 +780,7 @@ class TestDirectSimulation(object):
 
 
 class TestPathSampling(object):
-    def setup(self):
+    def setup_method(self):
         paths.InterfaceSet._reset()
         self.cv = paths.FunctionCV("x", lambda x: x.xyz[0][0])
         self.state_A = paths.CVDefinedVolume(self.cv, float("-inf"), 0.0)

--- a/openpathsampling/tests/test_plumed_wrapper.py
+++ b/openpathsampling/tests/test_plumed_wrapper.py
@@ -35,7 +35,7 @@ import copy
 
 
 class TestPLUMED(object):
-    def setup(self):
+    def setup_method(self):
         if not HAS_PLUMED:
             pytest.skip("PLUMED module not installed.")
         if not HAS_OPENMM:
@@ -55,7 +55,7 @@ class TestPLUMED(object):
         if os.path.isfile("test.nc"):
             os.remove("test.nc")
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile("test.nc"):
             os.remove("test.nc")
         root = os.listdir(".")

--- a/openpathsampling/tests/test_progress.py
+++ b/openpathsampling/tests/test_progress.py
@@ -14,7 +14,7 @@ def test_silent_progress(capsys):
 
 
 class TestTqdmPartial(object):
-    def setup(self):
+    def setup_method(self):
         _ = pytest.importorskip('tqdm')
         self.tqdm_partial = TqdmPartial(desc="foo")
 
@@ -40,7 +40,7 @@ class TestTqdmPartial(object):
 
 
 class TestSimpleProgress(object):
-    def setup(self):
+    def setup_method(self):
         self.progress = SimpleProgress()
 
     def test_progress_getter(self):

--- a/openpathsampling/tests/test_pyemma_cv.py
+++ b/openpathsampling/tests/test_pyemma_cv.py
@@ -10,7 +10,7 @@ mdtraj = pytest.importorskip("mdtraj")
 
 
 class TestPyEMMAFeaturizerCV(object):
-    def setup(self):
+    def setup_method(self):
         self.md_trajectory = mdtraj.load(data_filename("ala_small_traj.pdb"))
         self.ops_trajectory = trajectory_from_mdtraj(self.md_trajectory)
         # output of f.pairs(f.select_Backbone()) in the pyemma_generator
@@ -27,7 +27,7 @@ class TestPyEMMAFeaturizerCV(object):
         self.storage = paths.Storage('delete.nc', 'w')
         self.fname = self.storage.filename
 
-    def teardown(self):
+    def teardown_method(self):
         fname = self.fname
         if self.storage.isopen():
             self.storage.close()

--- a/openpathsampling/tests/test_reactive_flux_analysis.py
+++ b/openpathsampling/tests/test_reactive_flux_analysis.py
@@ -30,7 +30,7 @@ logging.getLogger('openpathsampling.sample').setLevel(logging.CRITICAL)
 
 
 class TestReactiveFluxAnalysis(object):
-    def setup(self):
+    def setup_method(self):
         import openpathsampling.engines.toy as toys
         # PES is one-dimensional linear slope (y(x) = -x)
         pes = toys.LinearSlope(m=[-1.0], c=[0.0])
@@ -131,7 +131,7 @@ class TestReactiveFluxAnalysis(object):
         self.simulation.run(n_per_snapshot=1)
         self.analysis = None
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.filename):
             self.storage.close()
             os.remove(self.filename)

--- a/openpathsampling/tests/test_resampling_statistics.py
+++ b/openpathsampling/tests/test_resampling_statistics.py
@@ -13,7 +13,7 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestResamplingStatistics(object):
     # NOTE: we test the mean_df and std_df functions within this
-    def setup(self):
+    def setup_method(self):
         # order of the column/index labels should not matter
         self.list_AB = ['A', 'B']
         self.list_BA = ['B', 'A']
@@ -86,7 +86,7 @@ class TestResamplingStatistics(object):
 
 
 class TestBlockResampling(object):
-    def setup(self):
+    def setup_method(self):
         self.samples = list(range(100))
 
     def test_default_initialization(self):

--- a/openpathsampling/tests/test_sample.py
+++ b/openpathsampling/tests/test_sample.py
@@ -15,7 +15,7 @@ from openpathsampling.sample import Sample
 
 
 class TestSampleSet(object):
-    def setup(self):
+    def setup_method(self):
         self.ensA = LengthEnsemble(1)
         self.ensB = LengthEnsemble(2)
         traj0A = Trajectory([0.5])
@@ -103,7 +103,7 @@ class TestSampleSet(object):
         testset2 = SampleSet([self.s0A, self.s1A, self.s2B])
         # if we accidentally hit the statistical code, repeating 100 times
         # reduces odds of getting the same replacement each time
-        for i in range(100): 
+        for i in range(100):
             self.testset[self.ensA] = self.s0A
             self.testset.consistency_check()
             assert_equal(len(self.testset), 3)

--- a/openpathsampling/tests/test_shared.py
+++ b/openpathsampling/tests/test_shared.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 class TestStaticContainerStore(object):
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile("test.nc"):
             os.remove("test.nc")
 

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -14,7 +14,7 @@ import numpy as np
 
 
 class SelectorTest(object):
-    def setup(self):
+    def setup_method(self):
         self.mytraj = make_1d_traj(coordinates=[-0.5, 0.1, 0.2, 0.3, 0.5],
                                    velocities=[1.0, 1.0, 1.0, 1.0, 1.0])
         self.dyn = CalvinistDynamics([-0.5, -0.4, -0.3, -0.2, -0.1,
@@ -69,8 +69,8 @@ class TestShootingPointSelector(SelectorTest):
 
 
 class TestGaussianBiasSelector(SelectorTest):
-    def setup(self):
-        super(TestGaussianBiasSelector, self).setup()
+    def setup_method(self):
+        super(TestGaussianBiasSelector, self).setup_method()
         self.cv = paths.FunctionCV("Id", lambda x: x.xyz[0][0])
         self.sel = GaussianBiasSelector(self.cv, alpha=2.0, l_0=0.25)
         self.f = [
@@ -102,8 +102,8 @@ class TestGaussianBiasSelector(SelectorTest):
 
 
 class TestBiasedSelector(SelectorTest):
-    def setup(self):
-        super(TestBiasedSelector, self).setup()
+    def setup_method(self):
+        super(TestBiasedSelector, self).setup_method()
         self.f = {
             'gaussian': [
                 0.32465246735834974,  # = exp(-2.0*(-0.5-0.25)**2)
@@ -202,7 +202,7 @@ class TestFinalFrameSelector(SelectorTest):
 
 
 class TestConstrainedSelector(SelectorTest):
-    def setup(self):
+    def setup_method(self):
         cvx = paths.FunctionCV('ID', lambda snap: snap.xyz[0][0])
         vol = paths.CVDefinedVolume(cvx, float('-inf'), 0)
         self.sel = InterfaceConstrainedSelector(vol)

--- a/openpathsampling/tests/test_shooting_point_analysis.py
+++ b/openpathsampling/tests/test_shooting_point_analysis.py
@@ -26,7 +26,7 @@ logging.getLogger('openpathsampling.sample').setLevel(logging.CRITICAL)
 
 
 class TestTransformedDict(object):
-    def setup(self):
+    def setup_method(self):
         self.untransformed = {(0, 1): "a", (1, 2): "b", (2, 3): "c"}
         self.transformed = {0: "a", 1: "b", 2: "c"}
         self.hash_function = lambda x: x[0]
@@ -72,7 +72,7 @@ class TestTransformedDict(object):
 
 
 class TestSnapshotByCoordinateDict(object):
-    def setup(self):
+    def setup_method(self):
         self.empty_dict = SnapshotByCoordinateDict()
         coords_A = np.array([[0.0, 0.0]])
         coords_B = np.array([[1.0, 1.0]])
@@ -96,7 +96,7 @@ class TestSnapshotByCoordinateDict(object):
 
 
 class TestShootingPointAnalysis(object):
-    def setup(self):
+    def setup_method(self):
         self.HAS_TQDM = paths.progress.HAS_TQDM
         paths.progress.HAS_TQDM = False
         # taken from the TestCommittorSimulation
@@ -145,7 +145,7 @@ class TestShootingPointAnalysis(object):
         self.analyzer = ShootingPointAnalysis(self.storage.steps,
                                               [self.left, self.right])
 
-    def teardown(self):
+    def teardown_method(self):
         import os
         paths.progress.HAS_TQDM = self.HAS_TQDM
         self.storage.close()

--- a/openpathsampling/tests/test_snapshot_modifier.py
+++ b/openpathsampling/tests/test_snapshot_modifier.py
@@ -31,7 +31,7 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 
 class TestSnapshotModifier(object):
-    def setup(self):
+    def setup_method(self):
         # TODO OPS 2.0: This subclass is only here for python 2.7 should be
         # replaced with SnapshotModifier
         class DummyMod(SnapshotModifier):
@@ -100,8 +100,8 @@ class TestSnapshotModifier(object):
 
 
 class TestNoModification(TestSnapshotModifier):
-    def setup(self):
-        super(TestNoModification, self).setup()
+    def setup_method(self):
+        super(TestNoModification, self).setup_method()
         self.modifier = NoModification()
 
     def test_call(self):
@@ -133,7 +133,7 @@ class TestNoModification(TestSnapshotModifier):
 
 
 class TestRandomizeVelocities(object):
-    def setup(self):
+    def setup_method(self):
         # TODO: check against several possibilities, including various
         # combinations of shapes of velocities and masses.
         topology_2x3D = paths.engines.toy.Topology(
@@ -271,7 +271,7 @@ class TestRandomizeVelocities(object):
 
 
 class TestGeneralizedDirectionModifier(object):
-    def setup(self):
+    def setup_method(self):
         import openpathsampling.engines.toy as toys
         # applies one delta_v to all atoms
         self.toy_modifier_all = GeneralizedDirectionModifier(1.5)
@@ -462,7 +462,7 @@ class TestGeneralizedDirectionModifier(object):
 
 
 class TestVelocityDirectionModifier(object):
-    def setup(self):
+    def setup_method(self):
         import openpathsampling.engines.toy as toys
         self.toy_modifier = VelocityDirectionModifier(
             delta_v=[1.0, 2.0],
@@ -573,7 +573,7 @@ class TestVelocityDirectionModifier(object):
 
 
 class TestSingleAtomVelocityDirectionModifier(object):
-    def setup(self):
+    def setup_method(self):
         import openpathsampling.engines.toy as toys
         self.toy_modifier = SingleAtomVelocityDirectionModifier(
             delta_v=[1.0, 2.0],

--- a/openpathsampling/tests/test_spring_shooting.py
+++ b/openpathsampling/tests/test_spring_shooting.py
@@ -23,7 +23,7 @@ class FakeStep(object):
 
 
 class SelectorTest(object):
-    def setup(self):
+    def setup_method(self):
         self.mytraj = make_1d_traj(coordinates=[-0.5, 0.1, 0.2, 0.3, 0.5],
                                    velocities=[1.0, 1.0, 1.0, 1.0, 1.0])
         self.dyn = CalvinistDynamics([-0.5, -0.4, -0.3, -0.2, -0.1,
@@ -308,8 +308,8 @@ class TestSpringShootingSelector(SelectorTest):
 
 
 class MoverTest(SelectorTest):
-    def setup(self):
-        super(MoverTest, self).setup()
+    def setup_method(self):
+        super(MoverTest, self).setup_method()
         sel = SpringShootingSelector(delta_max=1, k_spring=0)
         sel._fw_prob_list = [1.0, 0.0, 0.0]
         sel._bw_prob_list = [0.0, 0.0, 1.0]

--- a/openpathsampling/tests/test_sshooting_analysis.py
+++ b/openpathsampling/tests/test_sshooting_analysis.py
@@ -19,7 +19,7 @@ logging.getLogger('openpathsampling.sample').setLevel(logging.CRITICAL)
 
 
 class TestSShootingAnalysis(object):
-    def setup(self):
+    def setup_method(self):
         # PES is one-dimensional negative slope (y(x) = -x)
         pes = toys.LinearSlope(m=[-1.0], c=[0.0])
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
@@ -83,7 +83,7 @@ class TestSShootingAnalysis(object):
                                                   self.state_B,
                                                   self.state_S])
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None

--- a/openpathsampling/tests/test_sshooting_simulator.py
+++ b/openpathsampling/tests/test_sshooting_simulator.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 
 class TestSShootingSimulation(object):
-    def setup(self):
+    def setup_method(self):
         # PES is one-dimensional zero function (y(x) = 0)
         pes = toys.LinearSlope(m=[0.0], c=[0.0])
         topology = toys.Topology(n_spatial=1, masses=[1.0], pes=pes)
@@ -57,7 +57,7 @@ class TestSShootingSimulation(object):
         )
         self.simulation.output_stream = open(os.devnull, 'w')
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.filename):
             os.remove(self.filename)
         paths.EngineMover.default_engine = None

--- a/openpathsampling/tests/test_storage.py
+++ b/openpathsampling/tests/test_storage.py
@@ -26,7 +26,7 @@ from nose.plugins.skip import SkipTest
 
 
 class TestStorage(object):
-    def setup(self):
+    def setup_method(self):
         if not md:
             raise SkipTest("mdtraj not installed")
         self.mdtraj = md.load(data_filename("ala_small_traj.pdb"))
@@ -55,7 +55,7 @@ class TestStorage(object):
             engine=self.engine
         )
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile(self.filename):
             os.remove(self.filename)
 

--- a/openpathsampling/tests/test_tis_analysis.py
+++ b/openpathsampling/tests/test_tis_analysis.py
@@ -100,7 +100,7 @@ class TISAnalysisTester(object):
         sampling_AB = network.analysis_to_sampling[analysis_AB][0]
         return sampling_AB.ensembles
 
-    def setup(self):
+    def setup_method(self):
         # set up the trajectories, ensembles, etc. for this test
         self.HAS_TQDM = paths.progress.HAS_TQDM
         paths.progress.HAS_TQDM = False  # turn of progress bars
@@ -161,7 +161,7 @@ class TISAnalysisTester(object):
         )
 
 
-    def teardown(self):
+    def teardown_method(self):
         paths.progress.HAS_TQDM = self.HAS_TQDM
 
 
@@ -205,8 +205,8 @@ class TestWeightedTrajectories(TISAnalysisTester):
 class TestFluxToPandas(TISAnalysisTester):
     # includes tests for default_flux_sort and flux_matrix_pd
     # as a class to simplify setup of flux objects
-    def setup(self):
-        super(TestFluxToPandas, self).setup()
+    def setup_method(self):
+        super(TestFluxToPandas, self).setup_method()
         interfaces_A = self.mstis.from_state[self.state_A].interfaces
         interfaces_B = self.mstis.from_state[self.state_B].interfaces
         pairs_A = list(itertools.product([self.state_A], interfaces_A))
@@ -255,8 +255,8 @@ class TestFluxToPandas(TISAnalysisTester):
 
 
 class TestDictFlux(TISAnalysisTester):
-    def setup(self):
-        super(TestDictFlux, self).setup()
+    def setup_method(self):
+        super(TestDictFlux, self).setup_method()
         self.innermost_interface_A = \
             self.sampling_ensembles_for_transition(self.mistis,
                                                    self.state_A,
@@ -308,8 +308,8 @@ class TestDictFlux(TISAnalysisTester):
 
 
 class TestMinusMoveFlux(TISAnalysisTester):
-    def setup(self):
-        super(TestMinusMoveFlux, self).setup()
+    def setup_method(self):
+        super(TestMinusMoveFlux, self).setup_method()
 
         a = 0.1  # just a number to simplify the trajectory-making
         minus_move_descriptions = [
@@ -674,8 +674,8 @@ class TestStandardTransitionProbability(TISAnalysisTester):
 
 
 class TestTransitionDictResults(TISAnalysisTester):
-    def setup(self):
-        super(TestTransitionDictResults, self).setup()
+    def setup_method(self):
+        super(TestTransitionDictResults, self).setup_method()
         results_dict = {(self.state_A, self.state_B): 1,
                         (self.state_B, self.state_A): 2}
         self.mistis_transition_dict = TransitionDictResults(
@@ -775,8 +775,8 @@ class TestTISAnalysis(TISAnalysisTester):
         )
         return tis_analysis
 
-    def setup(self):
-        super(TestTISAnalysis, self).setup()
+    def setup_method(self):
+        super(TestTISAnalysis, self).setup_method()
         self.mistis_analysis = self._make_tis_analysis(self.mistis)
         self.mistis_analysis.calculate(self.mistis_steps)
         self.mstis_analysis = self._make_tis_analysis(self.mstis)

--- a/openpathsampling/tests/test_toy_dynamics.py
+++ b/openpathsampling/tests/test_toy_dynamics.py
@@ -43,7 +43,7 @@ def setup_module():
 # === TESTS FOR TOY POTENTIAL ENERGY SURFACES =============================
 
 class TestHarmonicOscillator(object):
-    def setup(self):
+    def setup_method(self):
         self.positions = init_pos
         self.velocities = init_vel
         self.mass = sys_mass
@@ -65,7 +65,7 @@ class TestHarmonicOscillator(object):
 
 
 class TestGaussian(object):
-    def setup(self):
+    def setup_method(self):
         self.positions = init_pos
         self.velocities = init_vel
         self.mass = sys_mass
@@ -82,7 +82,7 @@ class TestGaussian(object):
 
 
 class TestOuterWalls(object):
-    def setup(self):
+    def setup_method(self):
         self.positions = init_pos
         self.velocities = init_vel
         self.mass = sys_mass
@@ -99,7 +99,7 @@ class TestOuterWalls(object):
 
 
 class TestLinearSlope(object):
-    def setup(self):
+    def setup_method(self):
         self.positions = init_pos
         self.velocities = init_vel
         self.mass = sys_mass
@@ -112,7 +112,7 @@ class TestLinearSlope(object):
 
 
 class TestDoubleWell(object):
-    def setup(self):
+    def setup_method(self):
         self.positions = init_pos
         self.velocities = init_vel
         self.mass = sys_mass
@@ -133,7 +133,7 @@ class TestDoubleWell(object):
 
 
 class TestCombinations(object):
-    def setup(self):
+    def setup_method(self):
         self.positions = init_pos
         self.velocities = init_vel
         self.mass = sys_mass
@@ -142,7 +142,7 @@ class TestCombinations(object):
 
     def test_V(self):
         assert_almost_equal(self.simpletest.V(self), 2*2.37918851445)
-        assert_almost_equal(self.fullertest.V(self), 
+        assert_almost_equal(self.fullertest.V(self),
                             2.37918851445 + 1.080382 - 2.0375)
 
     def test_dVdx(self):
@@ -171,7 +171,7 @@ class Test_convert_fcn(object):
                                  np.array([[1.0, 2.0, 3.0], [4.0, 0.0, 0.0]]))
 
 class TestToyEngine(object):
-    def setup(self):
+    def setup_method(self):
         pes = linear
         integ = toy.LeapfrogVerletIntegrator(dt=0.002)
         topology = toy.Topology(
@@ -196,7 +196,7 @@ class TestToyEngine(object):
         sim.n_steps_per_frame = 10
         self.sim = sim
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.isfile('toy_tmp.nc'):
             os.remove('toy_tmp.nc')
 
@@ -253,7 +253,7 @@ class TestToyEngine(object):
         assert_equal(len(traj1), len(traj2))
         for (s1, s2) in zip(traj1, traj2):
             # snapshots are not the same object
-            assert_not_equal(s1, s2) 
+            assert_not_equal(s1, s2)
             # however, they have the same values stored in them
             assert_equal(len(s1.coordinates), 1)
             assert_equal(len(s1.coordinates[0]), 2)
@@ -273,7 +273,7 @@ class TestToyEngine(object):
 # === TESTS FOR TOY INTEGRATORS ===========================================
 
 class TestLeapfrogVerletIntegrator(object):
-    def setup(self):
+    def setup_method(self):
         pes = linear
         integ = toy.LeapfrogVerletIntegrator(dt=0.002)
         topology = toy.Topology(
@@ -326,7 +326,7 @@ class TestLangevinBAOABIntegrator(object):
     '''Testing for correctness is hard, since this is a stochastic
     calculation. However, we can at least run tests to make sure nothing
     crashes.'''
-    def setup(self):
+    def setup_method(self):
         pes = linear
         integ = toy.LangevinBAOABIntegrator(dt=0.002, temperature=0.5,
                                             gamma=1.0)
@@ -373,7 +373,7 @@ class TestLangevinBAOABIntegrator(object):
 class TestOverdampedLangevinIntegrator(object):
     '''This is only a test if the integrator runs. Because of its stochastic
     nature we can not actually test its correctness easily.'''
-    def setup(self):
+    def setup_method(self):
         pes = linear
         integ = toy.OverdampedLangevinIntegrator(dt=0.001, temperature=4.0,
                                                  D=1.0)

--- a/openpathsampling/tests/test_toy_features.py
+++ b/openpathsampling/tests/test_toy_features.py
@@ -12,7 +12,7 @@ logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestToySnapshotFeatures(object):
-    def setup(self):
+    def setup_method(self):
         integ = toys.LangevinBAOABIntegrator(dt=0.002,
                                              temperature=1.0,
                                              gamma=2.5)

--- a/openpathsampling/tests/test_trajectory.py
+++ b/openpathsampling/tests/test_trajectory.py
@@ -18,7 +18,7 @@ logging.getLogger('opentis.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 
 class TestSummarizeTrajectoryVolumes(object):
-    def setup(self):
+    def setup_method(self):
         op = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
         vol1 = paths.CVDefinedVolume(op, 0.1, 0.5)
         vol2 = paths.CVDefinedVolume(op, -0.1, 0.7)
@@ -55,7 +55,7 @@ class TestSummarizeTrajectoryVolumes(object):
             "A-B-I-X"
         )
         assert_items_equal(
-            self._make_traj("abix").summarize_by_volumes_str(voldict, " blah "), 
+            self._make_traj("abix").summarize_by_volumes_str(voldict, " blah "),
             "A blah B blah I blah X"
         )
 
@@ -84,7 +84,7 @@ class TestSummarizeTrajectoryVolumes(object):
         )
 
 class TestSubtrajectoryIndices(object):
-    def setup(self):
+    def setup_method(self):
         op = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
         vol1 = paths.CVDefinedVolume(op, 0.1, 0.5)
         vol2 = paths.CVDefinedVolume(op, -0.1, 0.7)

--- a/openpathsampling/tests/test_trajectory_transition_analysis.py
+++ b/openpathsampling/tests/test_trajectory_transition_analysis.py
@@ -20,7 +20,7 @@ logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestTrajectorySegmentContainer(object):
-    def setup(self):
+    def setup_method(self):
         op = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
         self.vol1 = paths.CVDefinedVolume(op, 0.1, 0.5)
         self.vol3 = paths.CVDefinedVolume(op, 2.0, 2.5)
@@ -103,7 +103,7 @@ class TestTrajectorySegmentContainer(object):
 
 
 class TestTrajectoryTransitionAnalysis(object):
-    def setup(self):
+    def setup_method(self):
         op = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
         vol1 = paths.CVDefinedVolume(op, 0.1, 0.5)
         vol2 = paths.CVDefinedVolume(op, -0.1, 0.7)
@@ -139,7 +139,7 @@ class TestTrajectoryTransitionAnalysis(object):
                             velocities=[1.0]*len(sequence))
 
     def test_analyze_continuous_time(self):
-        resultA = self.analyzer.analyze_continuous_time(self.trajectory, 
+        resultA = self.analyzer.analyze_continuous_time(self.trajectory,
                                                         self.stateA)
         assert_equal(resultA.n_frames.tolist(), [3, 1, 1, 1, 1, 1, 1])
         resultB = self.analyzer.analyze_continuous_time(self.trajectory,

--- a/openpathsampling/tests/test_transitions.py
+++ b/openpathsampling/tests/test_transitions.py
@@ -18,7 +18,7 @@ logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class TestTISTransition(object):
-    def setup(self):
+    def setup_method(self):
         pass
 
     def test_initialization(self):
@@ -28,7 +28,7 @@ class TestTISTransition(object):
         pass
 
 class TestFixedLengthTPSTransition(object):
-    def setup(self):
+    def setup_method(self):
         op = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
         self.stateA = paths.CVDefinedVolume(op, 0.1, 0.5)
         self.stateB = paths.CVDefinedVolume(op, 2.0, 2.5)
@@ -75,7 +75,7 @@ class TestFixedLengthTPSTransition(object):
             os.remove(filename)
 
 class TestMinusSidesSummary(object):
-    def setup(self):
+    def setup_method(self):
         op = paths.FunctionCV("Id", lambda snap : snap.coordinates[0][0])
         vol1 = paths.CVDefinedVolume(op, 0.1, 0.5)
         vol2 = paths.CVDefinedVolume(op, -0.1, 0.7)
@@ -110,18 +110,18 @@ class TestMinusSidesSummary(object):
                      {"in" : [5], "out" : [4]})
         assert_not_equal(minus_sides_summary(self.traj_axaxa, minus),
                          {"in" : [5], "out" : [3]})
-        assert_equal(minus_sides_summary(self.traj_aixiaixia, minus), 
+        assert_equal(minus_sides_summary(self.traj_aixiaixia, minus),
                      {"in" : [5], "out" : [6] })
-        assert_equal(minus_sides_summary(self.traj_aixixiaxia, minus), 
+        assert_equal(minus_sides_summary(self.traj_aixixiaxia, minus),
                      {"in" : [5], "out" : [10] })
 
     def test_minus_with_interstitial(self):
         minus = paths.MinusInterfaceEnsemble(self.stateA, self.innermost)
         assert_equal(minus_sides_summary(self.traj_axaxa, minus),
                      {"in" : [5], "out" : [4]})
-        assert_equal(minus_sides_summary(self.traj_aixiaixia, minus), 
+        assert_equal(minus_sides_summary(self.traj_aixiaixia, minus),
                      {"in" : [6], "out" : [4] })
-        assert_equal(minus_sides_summary(self.traj_aixixiaxia, minus), 
+        assert_equal(minus_sides_summary(self.traj_aixixiaxia, minus),
                      {"in" : [5], "out" : [8] })
 
     def test_minus_with_multiple_excursion(self):

--- a/openpathsampling/tests/test_visit_all_states.py
+++ b/openpathsampling/tests/test_visit_all_states.py
@@ -56,7 +56,7 @@ def test_extract_info_from_default_report():
 
 
 class TestVisitAllStatesEnsemble(object):
-    def setup(self):
+    def setup_method(self):
         self.cv = paths.FunctionCV("x", lambda x: x.xyz[0][0])
         vol_A = paths.CVDefinedVolume(self.cv, 0.0, 1.0).named("A")
         vol_B = paths.CVDefinedVolume(self.cv, 2.0, 3.0).named("B")

--- a/openpathsampling/tests/test_volume.py
+++ b/openpathsampling/tests/test_volume.py
@@ -226,7 +226,7 @@ class TestCVDefinedVolume(object):
 
 
 class TestCVRangeVolumePeriodic(object):
-    def setup(self):
+    def setup_method(self):
         self.pvolA = volume.PeriodicCVDefinedVolume(op_id, -100, 75)
         self.pvolA_ = volume.PeriodicCVDefinedVolume(op_id, 75, -100)
         self.pvolB = volume.PeriodicCVDefinedVolume(op_id, 50, 100)

--- a/openpathsampling/tests/test_wham.py
+++ b/openpathsampling/tests/test_wham.py
@@ -19,7 +19,7 @@ logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 
 class TestWHAM(object):
-    def setup(self):
+    def setup_method(self):
         self.exact = [1.0, 0.5, 0.25, 0.125, 0.0625, 0.03125, 0.015625]
         self.iface1 = [2.0, 1.0, 0.5, 0.25, 0.125, 0.0625, 0.0]
         self.iface2 = [1.0, 1.0, 1.0, 0.5, 0.25, 0.125, 0.0625]
@@ -114,7 +114,7 @@ class TestWHAM(object):
     def test_generate_lnZ(self):
         guess = [1.0, 1.0, 1.0]
         expected_lnZ = np.log([1.0, old_div(1.0,4.0), old_div(7.0,120.0)])
-        # TODO: I'm not sure the last is log(7/120) 
+        # TODO: I'm not sure the last is log(7/120)
         # however, I got the same result out of the old version, too, and
         # this does combine into the correct result in the end (see
         # test_output_histogram)


### PR DESCRIPTION
I noticed today that a bunch of 
```
openpathsampling/tests/test_pathmover.py::TestTwoWayShootingMover::test_to_dict_from_dict
  /usr/share/miniconda3/envs/test/lib/python3.7/site-packages/_pytest/fixtures.py:900: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  openpathsampling/tests/test_pathmover.py::TestTwoWayShootingMover::test_to_dict_from_dict is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    fixture_result = next(generator)
```
came form our test suite. This solves them (together with a similar warning for `teardown`)