### PR TITLE
Temporary pin: numpy<1.24

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 install_requires = 
     future
     psutil
-    numpy
+    numpy<1.24
     scipy
     pandas
     netcdf4


### PR DESCRIPTION
Looks like recent failures in CI are because of a numpy/numba incompatibility. See https://github.com/numba/numba/issues/8615. Should be fixed soon, but hopefully this pin will fix for now.

Resolves #1125.