### PR TITLE
Fix testing against OpenMM RCs

### DIFF
--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -29,6 +29,6 @@ jobs:
 
   test_rc:
     needs: check_rc
-    uses: ./.github/workflow/test-openmm-rc.yml
+    uses: ./.github/workflows/test-openmm-rc.yml
     secrets: inherit
     if: ${{ needs.check_rc.outputs.hasrc == 'True' }}

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -7,8 +7,8 @@ on:
   schedule:
     - cron: "0 9 * * *"
   # use this for debugging
-  pull_request:
-    branch: master
+  #pull_request:
+    #branch: master
 
 jobs:
   check_rc:

--- a/.github/workflows/check-openmm-rc.yml
+++ b/.github/workflows/check-openmm-rc.yml
@@ -7,11 +7,11 @@ on:
   schedule:
     - cron: "0 9 * * *"
   # use this for debugging
-  #pull_request:
-    #branch: master
+  pull_request:
+    branch: master
 
 jobs:
-  check-rc:
+  check_rc:
     if: ${{ github.repository == 'openpathsampling/openpathsampling' }}
     runs-on: ubuntu-latest
     name: "Check for OpenMM RC"
@@ -24,8 +24,11 @@ jobs:
           package: openmm
           ndays: 3
           labels: openmm_rc
-      - uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Test OpenMM Release Candidate
-          token: ${{ secrets.DISPATCH_TOKEN }}
-        if: ${{ steps.checkrc.outputs.hasrc == 'True' }}
+    outputs:
+      hasrc: ${{ steps.checkrc.outputs.hasrc }}
+
+  test_rc:
+    needs: check_rc
+    uses: ./.github/workflow/test-openmm-rc.yml
+    secrets: inherit
+    if: ${{ needs.check_rc.outputs.hasrc == 'True' }}

--- a/.github/workflows/test-openmm-rc.yml
+++ b/.github/workflows/test-openmm-rc.yml
@@ -3,6 +3,7 @@
 name: "Test OpenMM Release Candidate"
 on:
   workflow_dispatch:
+  workflow_call:
   # use this for debugging
   #pull_request:
     #branch: master


### PR DESCRIPTION
Some change has caused the token for workflow dispatch (the mechanism we used to conditionally launch a workflow) to fail. However, in the meantime, GitHub has added a native approach for reusing workflows. So this is intended to switch to using that.

And we're probably going to have some things to change thanks to the OpenMM 8.0 release candidate....