### PR TITLE
Updates for SQLAlchemy 2.0

### DIFF
--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -393,7 +393,7 @@ class SQLStorageBackend(StorableNamedObject):
 
         self.metadata.create_all(self.engine)
         sfr_result_types = self.metadata.tables['sfr_result_types']
-        with self.engine.connect() as conn:
+        with self.engine.begin() as conn:
             conn.execute(sfr_result_types.insert(),
                          {'uuid': table_name, 'result_type': result_type})
         self.sfr_result_types[table_name] = result_type
@@ -427,7 +427,7 @@ class SQLStorageBackend(StorableNamedObject):
                    for uuid in unknown_uuids]
         table = self.metadata.tables[table_name]
         if results:
-            with self.engine.connect() as conn:
+            with self.engine.begin() as conn:
                 conn.execute(table.insert(), results)
 
         # update the cache
@@ -483,7 +483,7 @@ class SQLStorageBackend(StorableNamedObject):
     def add_tag(self, table_name, name, content):
         table = self.metadata.tables[table_name]
 
-        with self.engine.connect() as conn:
+        with self.engine.begin() as conn:
             conn.execute(table.insert(), [{'name': name,
                                            'content': content}])
 

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -319,9 +319,6 @@ class SQLStorageBackend(StorableNamedObject):
         with self.engine.connect() as conn:
             for block in grouper(idx_list, self.MAX_SQL_ITEMS):
                 or_stmt = sql.or_(*(table.c.idx == idx for idx in block))
-                # TODO: check correctness that these give the same SQL
-                # statement
-                # sel = table.select(or_stmt)
                 sel = table.select().where(or_stmt)
                 results.extend(list(conn.execute(sel)))
 
@@ -661,8 +658,6 @@ class SQLStorageBackend(StorableNamedObject):
 
     def table_len(self, table_name):
         table = self.metadata.tables[table_name]
-        # TODO: check that we're getting the same SQL here
-        # count_query = sql.select([sql.func.count()]).select_from(table)
         count_query = sql.select(sql.func.count()).select_from(table)
         with self.engine.connect() as conn:
             results = conn.execute(count_query)

--- a/openpathsampling/experimental/simstore/test_attribute_handlers.py
+++ b/openpathsampling/experimental/simstore/test_attribute_handlers.py
@@ -5,7 +5,7 @@ import numpy as np
 from .attribute_handlers import *
 
 class TestStandardHandler(object):
-    def setup(self):
+    def setup_method(self):
         self.obj = {'str': 'foo',
                     'int': 42,
                     'float': 3.14159,
@@ -30,7 +30,7 @@ class TestStandardHandler(object):
 
 
 class TestNDArrayHandler(object):
-    def setup(self):
+    def setup_method(self):
         self.data = np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
         self.ndarray_handler = NDArrayHandler(('float32', (2,3)))
 

--- a/openpathsampling/experimental/simstore/test_callable_codec.py
+++ b/openpathsampling/experimental/simstore/test_callable_codec.py
@@ -14,7 +14,7 @@ def _globals_using_function(self):
     return _global_var
 
 class TestCallableCodec(object):
-    def setup(self):
+    def setup_method(self):
         self.codec = CallableCodec()
         self.functions = {
             'generic': lambda x: x.xyz[0][0],

--- a/openpathsampling/experimental/simstore/test_class_info.py
+++ b/openpathsampling/experimental/simstore/test_class_info.py
@@ -42,7 +42,7 @@ class TestClassInfo(object):
         assert class_info.lookup_result == MockUUIDObject
 
 class SerializationSchemeTester(object):
-    def setup(self):
+    def setup_method(self):
         self.data_obj = all_objects['int']  # doesn't really matter which
         # technically, the next two should behave identically, except
         # name/UUID; but as different types they can be serailized

--- a/openpathsampling/experimental/simstore/test_custom_json.py
+++ b/openpathsampling/experimental/simstore/test_custom_json.py
@@ -54,7 +54,7 @@ class CustomJSONCodingTest(object):
 
 
 class TestNumpyCoding(CustomJSONCodingTest):
-    def setup(self):
+    def setup_method(self):
         self.codec = numpy_codec
         self.objs = [np.array([[1.0, 0.0], [2.0, 3.2]]),
                      np.array([1, 0])]
@@ -89,7 +89,7 @@ class TestNumpyCoding(CustomJSONCodingTest):
 
 
 class TestUUIDCoding(object):
-    def setup(self):
+    def setup_method(self):
         self.codec = uuid_object_codec
         all_objs = test_utils.all_objects
         self.objs = [all_objs['int'], all_objs['str']]

--- a/openpathsampling/experimental/simstore/test_dict_serialization_helpers.py
+++ b/openpathsampling/experimental/simstore/test_dict_serialization_helpers.py
@@ -18,7 +18,7 @@ class TestTupleKeysSerializers(object):
         def from_dict(cls, dct):
             return cls(**dct)
 
-    def setup(self):
+    def setup_method(self):
         self.foo = {('a', 'b'): [1, 2], ('c', 'd'): [3, 4]}
         self.bar = 3
         self.obj = self.ExampleObj(self.foo, self.bar)

--- a/openpathsampling/experimental/simstore/test_serialization.py
+++ b/openpathsampling/experimental/simstore/test_serialization.py
@@ -12,7 +12,7 @@ from .attribute_handlers import DEFAULT_HANDLERS
 
 
 class TestGenericLazyLoader(object):
-    def setup(self):
+    def setup_method(self):
         original_and_class = {
             'normal': (all_objects['int'], MockUUIDObject)
             # TODO: add iterable and mappable classes
@@ -97,7 +97,7 @@ class TestGenericLazyLoader(object):
 
 
 class TestProxyObjectFactory(object):
-    def setup(self):
+    def setup_method(self):
         self.storage = LoadingStorageMock({get_uuid(obj): obj
                                            for obj in all_objects.values()})
 

--- a/openpathsampling/experimental/simstore/test_sql_backend.py
+++ b/openpathsampling/experimental/simstore/test_sql_backend.py
@@ -2,7 +2,7 @@ from .sql_backend import *
 import pytest
 
 class TestSQLStorageBackend(object):
-    def setup(self):
+    def setup_method(self):
         self._delete_tmp_files()
         self.database = self._default_database
         self.database.debug = True
@@ -49,7 +49,7 @@ class TestSQLStorageBackend(object):
         return snap_dicts
 
 
-    def teardown(self):
+    def teardown_method(self):
         self._delete_tmp_files()
 
     @property

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -71,7 +71,7 @@ def test_wrap_numpy():
         assert isinstance(wrap_numpy(inp), np.ndarray)
 
 class TestStorableFunctionConfig(object):
-    def setup(self):
+    def setup_method(self):
         self.config = StorableFunctionConfig(processors=[
             scalarize_singletons,
             wrap_numpy,
@@ -160,7 +160,7 @@ class TestStorableFunctionConfig(object):
 
 
 class TestStorableFunctionResults(object):
-    def setup(self):
+    def setup_method(self):
         self.cv = StorableFunction(lambda x: x)
         self.cv.__uuid__ = "funcUUID"
         self.mapping = {'UUID1': "foo",
@@ -219,7 +219,7 @@ class TestStorableFunctionResults(object):
 @mock.patch(_MODULE + '.get_uuid', lambda x: x)
 @mock.patch(_MODULE + '.has_uuid', lambda x: isinstance(x, str))
 class TestStorableFunction(object):
-    def setup(self):
+    def setup_method(self):
         def get_expected(uuid):
             expected = {'uuid': 'eval', 'uuid1': 'other'}
             return expected[uuid]
@@ -394,7 +394,7 @@ class TestStorableFunction(object):
 
 
 class TestStorageFunctionHandler(object):
-    def setup(self):
+    def setup_method(self):
         self.backend = MockBackend()
         self.storage = mock.NonCallableMock(backend=self.backend)
         self.sf_handler = StorageFunctionHandler(self.storage)

--- a/openpathsampling/experimental/simstore/test_storage.py
+++ b/openpathsampling/experimental/simstore/test_storage.py
@@ -7,7 +7,7 @@ from .test_utils import all_objects, UnnamedUUID, MockUUIDObject, MockStorage
 
 
 class TestStorageTable(object):
-    def setup(self):
+    def setup_method(self):
         self.storage = MockStorage()
         # Override default tables/uuids
         self.storage.backend.table_names = ["all"]
@@ -52,7 +52,7 @@ class TestStorageTable(object):
 
 
 class TestPseudoTable(object):
-    def setup(self):
+    def setup_method(self):
         self.objs = {None: UnnamedUUID(normal_attr=10)}
         self.objs.update(all_objects)
         self.obj_list = list(self.objs.values())

--- a/openpathsampling/experimental/simstore/test_tags_table.py
+++ b/openpathsampling/experimental/simstore/test_tags_table.py
@@ -17,7 +17,7 @@ class IntHolder(StorableObject):
         self.value = value
 
 class TestTagsTable(object):
-    def setup(self):
+    def setup_method(self):
         json_ser = JSONSerializerDeserializer([uuid_object_codec])
         # TODO: add tags to serialization schema
         serialization_schema = SerializationSchema(

--- a/openpathsampling/experimental/simstore/test_tools.py
+++ b/openpathsampling/experimental/simstore/test_tools.py
@@ -10,7 +10,7 @@ def test_compare_sets():
     pytest.skip()
 
 class TestGroupBy(object):
-    def setup(self):
+    def setup_method(self):
         pass
 
 class TestListify(object):
@@ -25,7 +25,7 @@ class TestListify(object):
 
 
 class TestFlatten(object):
-    def setup(self):
+    def setup_method(self):
         self.result = ['a', 'b', 'c', 'd', 'e', 'f']
         self.list = ['a', 'b', [['c'], ['d'], 'e'], [['f']]]
         self.dict = {11: 'a', 12: 'b',

--- a/openpathsampling/experimental/simstore/test_type_ident.py
+++ b/openpathsampling/experimental/simstore/test_type_ident.py
@@ -9,7 +9,7 @@ class TestStandardTyping(object):
     # this tests everything in STANDARD_TYPING; it's a little more
     # integration test than unit, but the individual tests ensure that each
     # unit is tested
-    def setup(self):
+    def setup_method(self):
         self.objects = {
             'int': ('int', 5),
             'float': ('float', 2.3),

--- a/openpathsampling/experimental/simstore/test_utils.py
+++ b/openpathsampling/experimental/simstore/test_utils.py
@@ -198,7 +198,7 @@ all_objects = create_test_objects()
 
 
 class TestMockBackend(object):
-    def setup(self):
+    def setup_method(self):
         self.backend = MockBackend()
 
     @pytest.mark.parametrize(('obj_name', 'table_idx', 'idx'),


### PR DESCRIPTION
SQLAlchemy 2.0 has been released, and SimStore tests are failing now. There were warnings in 1.4 that help migrate to the 2.0 API. This implements those changes.

Still have a couple places where I want to manually check the SQL output to ensure that this is the same, but this PR will fix current errors.