### PR TITLE
Get tests working again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
           - "3.9"
           - "3.8"
           - "3.7"
-          - "2.7"
         MINIMAL: [""]
         include:
           - CONDA_PY: "3.7"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,12 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
+          - "3.11"
+          - "3.10"
           - "3.9"
-          - "3.8"
-          - "3.7"
         MINIMAL: [""]
         include:
-          - CONDA_PY: "3.7"
+          - CONDA_PY: "3.9"
             MINIMAL: "minimal"
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,12 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
-          - "3.11"
-          - "3.10"
           - "3.9"
+          - "3.8"
+          - "3.7"
         MINIMAL: [""]
         include:
-          - CONDA_PY: "3.9"
+          - CONDA_PY: "3.7"
             MINIMAL: "minimal"
 
     steps:

--- a/examples/tests/test_openmm_integration.ipynb
+++ b/examples/tests/test_openmm_integration.ipynb
@@ -44,7 +44,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ignore stderr from openmmtools\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# hide stderr from openmmtools (apparently nbval still gets it)\n",
     "from os import devnull\n",
     "from contextlib import redirect_stderr\n",
     "\n",

--- a/examples/tests/test_openmm_integration.ipynb
+++ b/examples/tests/test_openmm_integration.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -30,10 +32,24 @@
     "except ImportError: # OpenMM < 7.6\n",
     "    import simtk.openmm as omm\n",
     "    import simtk.unit as u\n",
-    "import openmmtools as omt\n",
+    "\n",
     "import mdtraj as md\n",
     "\n",
-    "import openpathsampling.engines.openmm as eng\n"
+    "import openpathsampling.engines.openmm as eng"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ignore stderr from openmmtools\n",
+    "from os import devnull\n",
+    "from contextlib import redirect_stderr\n",
+    "\n",
+    "with open(devnull, 'w') as dvnl, redirect_stderr(dvnl):\n",
+    "    import openmmtools as omt"
    ]
   },
   {
@@ -45,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -73,7 +89,7 @@
        " '_mdtraj_topology': NoneType}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -111,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,35 +228,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[ 0.18766736  0.11599679  0.01245004]\n",
-      " [ 0.19458341  0.22444927  0.00401414]\n",
-      " [ 0.1443672   0.27122689  0.08869714]\n",
-      " [ 0.14886747  0.25747473 -0.08926164]\n",
-      " [ 0.33994537  0.26638274  0.00609843]\n",
-      " [ 0.42709578  0.1897011   0.04380051]\n",
-      " [ 0.36886493  0.38998331 -0.03181562]\n",
-      " [ 0.293367    0.452431   -0.05633815]\n",
-      " [ 0.49859312  0.4565761  -0.02400124]\n",
-      " [ 0.5581438   0.41515287  0.0573552 ]\n",
-      " [ 0.5732535   0.43391328 -0.15561179]\n",
-      " [ 0.5191127   0.48312774 -0.23640657]\n",
-      " [ 0.67427683  0.47320502 -0.14414124]\n",
-      " [ 0.58423056  0.32728151 -0.17536463]\n",
-      " [ 0.4749522   0.60669039 -0.00127668]\n",
-      " [ 0.35958399  0.64924202  0.00474684]\n",
-      " [ 0.5835927   0.68379167  0.00902624]\n",
-      " [ 0.6747424   0.64066121  0.00332412]\n",
-      " [ 0.57127444  0.82897221  0.01853087]\n",
-      " [ 0.46718868  0.86095438  0.02347777]\n",
-      " [ 0.62214258  0.86301533  0.10872177]\n",
-      " [ 0.61715852  0.87434252 -0.06931573]] nm\n"
+      "[[ 0.18766734  0.11599676  0.01245005]\n",
+      " [ 0.19458354  0.22444928  0.00401417]\n",
+      " [ 0.14436737  0.27122667  0.08869709]\n",
+      " [ 0.14886761  0.25747457 -0.08926168]\n",
+      " [ 0.33994532  0.26638275  0.00609838]\n",
+      " [ 0.42709583  0.18970108  0.04380053]\n",
+      " [ 0.36886492  0.38998333 -0.03181563]\n",
+      " [ 0.29336691  0.4524309  -0.05633818]\n",
+      " [ 0.49859303  0.45657605 -0.02400119]\n",
+      " [ 0.55814379  0.41515264  0.05735509]\n",
+      " [ 0.57325351  0.43391326 -0.1556119 ]\n",
+      " [ 0.51911277  0.48312786 -0.23640618]\n",
+      " [ 0.67427617  0.47320503 -0.14414097]\n",
+      " [ 0.58423084  0.32728145 -0.17536484]\n",
+      " [ 0.47495231  0.60669047 -0.00127665]\n",
+      " [ 0.35958403  0.64924204  0.00474683]\n",
+      " [ 0.58359265  0.6837917   0.00902626]\n",
+      " [ 0.67474234  0.64066118  0.00332438]\n",
+      " [ 0.57127434  0.82897246  0.01853088]\n",
+      " [ 0.46718928  0.86095428  0.02347768]\n",
+      " [ 0.62214309  0.86301523  0.1087221 ]\n",
+      " [ 0.61715913  0.8743425  -0.06931649]] nm\n"
      ]
     }
    ],
@@ -251,14 +267,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/sander/miniconda3/envs/python3/lib/python3.9/site-packages/mdtraj/utils/validation.py:115: TypeCastPerformanceWarning: Casting unitcell_vectors dtype=float64 to <class 'numpy.float32'> \n",
+      "/Users/dwhs/mambaforge/envs/dev/lib/python3.9/site-packages/mdtraj/utils/validation.py:115: TypeCastPerformanceWarning: Casting unitcell_vectors dtype=float64 to <class 'numpy.float32'> \n",
       "  warnings.warn(\"Casting %s dtype=%s to %s \" % (name, val.dtype, dtype),\n"
      ]
     }
@@ -271,20 +287,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[ 3.1061454],\n",
-       "       [-3.0958629],\n",
-       "       [ 3.1367555],\n",
-       "       [ 3.1283271],\n",
-       "       [ 3.0931787]], dtype=float32)"
+       "array([[ 3.1061456],\n",
+       "       [-3.0958636],\n",
+       "       [ 3.136756 ],\n",
+       "       [ 3.128327 ],\n",
+       "       [ 3.0931773]], dtype=float32)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -296,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -331,7 +347,7 @@
        "'{\"_cls\":\"OpenMMEngine\",\"_dict\":{\"system_xml\":\"<?xml version=\\\\\"1.0\\\\\" ?>\\\\n<System openmmVersion=\\\\\"7.7\\\\\" type=\\\\\"System\\\\\" version=\\\\\"1\\\\\">\\\\n\\\\t<PeriodicBoxVectors>\\\\n\\\\t\\\\t<A x=\\\\\"2\\\\\" y=\\\\\"0\\\\\" z=\\\\\"0\\\\\"\\\\/>\\\\n\\\\t\\\\t<B x=\\\\\"0\\\\\" y=\\\\\"2\\\\\" z=\\\\\"0\\\\\"\\\\/>\\\\n\\\\t\\\\t<C x=\\\\\"0\\\\\" y=\\\\\"0\\\\\" z=\\\\\"2...'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -343,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -428,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,9 +473,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "dev",
    "language": "python",
-   "name": "python3"
+   "name": "dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -471,7 +487,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.16"
   },
   "toc": {
    "base_numbering": 1,

--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -13,6 +13,8 @@ import signal
 import shlex
 import time
 
+from subprocess import PIPE
+
 import sys
 if sys.version_info > (3, ):
     long = int
@@ -257,9 +259,10 @@ class ExternalEngine(DynamicsEngine):
         self.start_time = time.time()
         try:
             logger.info(self.engine_command())
-            # TODO: add the ability to have handlers for stdin and stdout
             self.proc = psutil.Popen(shlex.split(self.engine_command()),
-                                     preexec_fn=os.setsid)
+                                     preexec_fn=os.setsid,
+                                     stdout=PIPE,
+                                     stderr=PIPE)
         except OSError:  # pragma: no cover
             raise  # TODO: need to handle this, but do what?
         else:
@@ -267,6 +270,10 @@ class ExternalEngine(DynamicsEngine):
 
         if self.first_frame_in_file:
             _ = self.generate_next_frame()  # throw away repeat first frame
+
+    def _communicate(self):
+        # this is primarily for debug purposes
+        self.proc.communicate()
 
     def stop(self, trajectory):
         super(ExternalEngine, self).stop(trajectory)

--- a/openpathsampling/engines/external_engine.py
+++ b/openpathsampling/engines/external_engine.py
@@ -273,7 +273,7 @@ class ExternalEngine(DynamicsEngine):
 
     def _communicate(self):
         # this is primarily for debug purposes
-        self.proc.communicate()
+        return self.proc.communicate()
 
     def stop(self, trajectory):
         super(ExternalEngine, self).stop(trajectory)

--- a/openpathsampling/tests/test_gromacs_engine.py
+++ b/openpathsampling/tests/test_gromacs_engine.py
@@ -90,7 +90,10 @@ class TestGromacsEngine(object):
         self.engine = Engine(gro="conf.gro",
                              mdp="md.mdp",
                              top="topol.top",
-                             options={'mdrun_args': '-nt 1'},
+                             options={
+                                 'mdrun_args': '-nt 1',
+                                 'grompp_args': '-maxwarn 2',  # Berendsen
+                             },
                              base_dir=self.test_dir,
                              prefix="project")
 
@@ -220,7 +223,7 @@ class TestGromacsEngine(object):
 
     def test_generate(self):
         if not has_gmx:
-            raise SkipTest("Gromacs 5 (gmx) not found. Skipping test.")
+            pytest.skip("Gromacs 5 (gmx) not found. Skipping test.")
 
         if not HAS_MDTRAJ:
             pytest.skip("MDTraj not found. Skipping test.")

--- a/openpathsampling/tests/test_gromacs_engine.py
+++ b/openpathsampling/tests/test_gromacs_engine.py
@@ -223,7 +223,7 @@ class TestGromacsEngine(object):
 
     def test_generate(self):
         if not has_gmx:
-            pytest.skip("Gromacs 5 (gmx) not found. Skipping test.")
+            pytest.skip("gmx not found. Skipping test.")
 
         if not HAS_MDTRAJ:
             pytest.skip("MDTraj not found. Skipping test.")
@@ -243,7 +243,7 @@ class TestGromacsEngine(object):
 
     def test_prepare(self):
         if not has_gmx:
-            raise SkipTest("Gromacs 5 (gmx) not found. Skipping test.")
+            pytest.skip("gmx not found. Skipping test.")
         self.engine.set_filenames(0)
         traj_0 = self.engine.trajectory_filename(0)
         snap = self.engine.read_frame_from_file(traj_0, 0)
@@ -273,7 +273,7 @@ class TestGromacsEngine(object):
         # snapshot should contain data -- the others should have their cache
         # cleared
         if not has_gmx:
-            pytest.skip("Gromacs (gmx) not found. Skipping test.")
+            pytest.skip("gmx not found. Skipping test.")
         if not HAS_MDTRAJ:
             pytest.skip("MDTraj not found. Skipping test.")
 


### PR DESCRIPTION
Taking a few days to do some OPS upkeep; after far too much neglect. This PR will get our tests back in working order.

Importantly, as of this PR (and the next release), we're (finally) dropping Python 2.7 support. It is too much of a maintenance burden, and everyone else dropped it over 3 years ago. There should be no active projects going with Python 2.7.

- [x] Drop Python 2 support (finally)
- [x] Fix up Gromacs tests for newer grompp warnings