### PR TITLE
Support Python 3.10; Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,11 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
+          - "3.10"
           - "3.9"
-          - "3.8"
-          - "3.7"
         MINIMAL: [""]
         include:
-          - CONDA_PY: "3.7"
+          - CONDA_PY: "3.9"
             MINIMAL: "minimal"
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
       #   CVs) can differ between minor Python versions.
       matrix:
         CONDA_PY:
+          - "3.11"
           - "3.10"
           - "3.9"
         MINIMAL: [""]

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -37,7 +37,6 @@ case $PYTHON_VERSION in
     "3.11")
         mstis="$dropbox_base_url2/c4idtymcaqvtftigce49c/toy_mstis_1k_OPS1_py311.nc?rlkey=soa6ba7okx66439egjyuscc5l&dl=1"
         mistis="$dropbox_base_url2/s0o7br93s60q0vez88phr/toy_mistis_1k_OPS1_py311.nc?rlkey=22vdvjovt25bj4a6gh3m4vrvj&dl=1"
-        unzip="true"
         ;;
     *)
         echo "Unsupported Python version: $PYTHON_VERSION"

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -33,6 +33,10 @@ case $PYTHON_VERSION in
         mstis=$dropbox_base_url/8rr0tt25xlm47cs/toy_mstis_1k_OPS1_py38.nc
         mistis=$dropbox_base_url/r3d5s5txbnpste0/toy_mistis_1k_OPS1_py38.nc
         ;;
+    "3.11")
+        mstis=$dropbox_base_url/8rr0tt25xlm47cs/toy_mstis_1k_OPS1_py38.nc
+        mistis=$dropbox_base_url/r3d5s5txbnpste0/toy_mistis_1k_OPS1_py38.nc
+        ;;
     *)
         echo "Unsupported Python version: $PYTHON_VERSION"
 esac

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -29,6 +29,10 @@ case $PYTHON_VERSION in
         mstis=$dropbox_base_url/8rr0tt25xlm47cs/toy_mstis_1k_OPS1_py38.nc
         mistis=$dropbox_base_url/r3d5s5txbnpste0/toy_mistis_1k_OPS1_py38.nc
         ;;
+    "3.10")
+        mstis=$dropbox_base_url/8rr0tt25xlm47cs/toy_mstis_1k_OPS1_py38.nc
+        mistis=$dropbox_base_url/r3d5s5txbnpste0/toy_mistis_1k_OPS1_py38.nc
+        ;;
     *)
         echo "Unsupported Python version: $PYTHON_VERSION"
 esac

--- a/examples/ipynbtests.sh
+++ b/examples/ipynbtests.sh
@@ -7,6 +7,7 @@ PYTHON_VERSION=`python -V 2>&1 | awk '{print $2}' | awk 'BEGIN { FS="." } { prin
 echo "Running tests for Python version: $PYTHON_VERSION"
 
 dropbox_base_url="https://www.dropbox.com/s"
+dropbox_base_url2="https://www.dropbox.com/scl/fi"
 
 case $PYTHON_VERSION in
     "2.7")
@@ -34,8 +35,9 @@ case $PYTHON_VERSION in
         mistis=$dropbox_base_url/r3d5s5txbnpste0/toy_mistis_1k_OPS1_py38.nc
         ;;
     "3.11")
-        mstis=$dropbox_base_url/8rr0tt25xlm47cs/toy_mstis_1k_OPS1_py38.nc
-        mistis=$dropbox_base_url/r3d5s5txbnpste0/toy_mistis_1k_OPS1_py38.nc
+        mstis="$dropbox_base_url2/c4idtymcaqvtftigce49c/toy_mstis_1k_OPS1_py311.nc?rlkey=soa6ba7okx66439egjyuscc5l&dl=1"
+        mistis="$dropbox_base_url2/s0o7br93s60q0vez88phr/toy_mistis_1k_OPS1_py311.nc?rlkey=22vdvjovt25bj4a6gh3m4vrvj&dl=1"
+        unzip="true"
         ;;
     *)
         echo "Unsupported Python version: $PYTHON_VERSION"

--- a/openpathsampling/deprecations.py
+++ b/openpathsampling/deprecations.py
@@ -217,7 +217,15 @@ NEW_DEFAULT_FILENAME_SETTER =  Deprecation(
     deprecated_in=(1, 6, 0)
 )
 
-
+SIMSTORE_CALLABLE_CODEC_STRING_NOT_BYTES = Deprecation(
+    problem=("The storage representation of callables stored by SimStore "
+             "has changed. Some functions stored in this file may not "
+             "work starting in {OPS} {version}"),
+    remedy=("Re-saving the data from this file into another file will "
+            "create something that can be loaded in that version."),
+    remove_version=(2, 0),
+    deprecated_in=(1, 6, 0)
+)
 
 # has_deprecations and deprecate hacks to change docstrings inspired by:
 # https://stackoverflow.com/a/47441572/4205735

--- a/openpathsampling/experimental/simstore/callable_codec.py
+++ b/openpathsampling/experimental/simstore/callable_codec.py
@@ -3,6 +3,8 @@ import dis
 import dill
 import codecs
 from .serialization_helpers import has_uuid, do_import
+from openpathsampling.deprecations \
+        import SIMSTORE_CALLABLE_CODEC_STRING_NOT_BYTES
 
 GLOBALS_ERROR_MESSAGE="""
 The function you tried to save uses information from global scope, which
@@ -145,7 +147,10 @@ class CallableCodec(object):
                 # TODO: this is to support older SimStore storages; should
                 # add a deprecation warning on this
                 if isinstance(dilled, bytes):
-                    dilled = codecs.encode(dilled, 'base64')
+                    SIMSTORE_CALLABLE_CODEC_STRING_NOT_BYTES.warn(
+                        category=FutureWarning
+                    )
+                    dilled = str(codecs.encode(dilled, 'base64'), 'utf-8')
 
                 dilledbytes = bytes(dilled, 'utf-8')  # or ascii
                 func =  dill.loads(codecs.decode(dilledbytes, 'base64'))

--- a/openpathsampling/experimental/simstore/callable_codec.py
+++ b/openpathsampling/experimental/simstore/callable_codec.py
@@ -144,8 +144,6 @@ class CallableCodec(object):
             elif '_dilled' in dct:
                 dilled = dct['_dilled']
 
-                # TODO: this is to support older SimStore storages; should
-                # add a deprecation warning on this
                 if isinstance(dilled, bytes):
                     SIMSTORE_CALLABLE_CODEC_STRING_NOT_BYTES.warn(
                         category=FutureWarning

--- a/openpathsampling/experimental/simstore/test_callable_codec.py
+++ b/openpathsampling/experimental/simstore/test_callable_codec.py
@@ -1,6 +1,7 @@
 import pytest
 from .callable_codec import *
 import dill
+import codecs
 
 import numpy as np
 
@@ -26,8 +27,10 @@ class TestCallableCodec(object):
         for func in ['generic', 'use_known_module', 'use_globals']:
             self.functions[func].__module__ = "__main__"
 
-        dilled = {key: dill.dumps(func, recurse=True)
-                  for key, func in self.functions.items()}
+        dilledbytes = {key: dill.dumps(func, recurse=True)
+                       for key, func in self.functions.items()}
+        dilled = {key: str(codecs.encode(val, 'base64'), 'utf-8')
+                  for key, val in dilledbytes.items()}
         self.dcts = {
             'generic': {
                 '__callable_name__': '<lambda>',

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -13,7 +13,6 @@ import ujson
 import marshal
 import types
 import opcode
-import warnings
 
 from .base import StorableObject
 

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -381,15 +381,6 @@ class ObjectJSON(object):
         # if the easy way did not work, try saving it using bytecode
         if ObjectJSON.allow_marshal and callable(c):
             if sys.version_info > (3, 11):
-                # TODO: maybe move the warning to storage creation? makes
-                # more sense than screaming when they save things
-                warnings.warn(
-                    "netcdfplus is deprecated for Python 3.11+. "
-                    "Using SimStore is recommended. "
-                    "See https://github.com/dwhswenson/ops-storage-"
-                    "notebooks/blob/master/examples/01_simple_usage.ipynb "
-                    "for usage."
-                )
                 codec = make_callable_codec(safemode=False)
                 return codec.default(c)
 

--- a/openpathsampling/netcdfplus/dictify.py
+++ b/openpathsampling/netcdfplus/dictify.py
@@ -13,6 +13,7 @@ import ujson
 import marshal
 import types
 import opcode
+import warnings
 
 from .base import StorableObject
 
@@ -40,6 +41,18 @@ else:
     get_callable_name = lambda c: c.func_name
     import builtins
 
+def make_callable_codec(safemode):
+    # starting in Python 3.11, we use SimStore to serialize callables
+    from openpathsampling.experimental.simstore.callable_codec \
+            import CallableCodec
+    only_req = ObjectJSON.prevent_unsafe_modules
+    codec = CallableCodec(settings={
+        'only_allow_required_modules': only_req,
+        'required_modules': ObjectJSON.safe_modules,
+        'safemode': safemode,
+    })
+    return codec
+
 # in Python 3.6 the opcodes have changed width
 if sys.version_info > (3, 6):
     opcode_arg_width = 1
@@ -52,6 +65,7 @@ if int(ujson.__version__.split(".")[0]) <= 2:
     ujson_kwargs = dict()
 else:
     ujson_kwargs = {"reject_bytes": False}
+
 
 class ObjectJSON(object):
     """
@@ -294,7 +308,7 @@ class ObjectJSON(object):
                 else:
                     return None
 
-            elif '_marshal' in obj or '_module' in obj:
+            elif '_marshal' in obj or '_module' in obj or '_dilled' in obj:
                 if self.safemode:
                     return None
 
@@ -366,6 +380,20 @@ class ObjectJSON(object):
 
         # if the easy way did not work, try saving it using bytecode
         if ObjectJSON.allow_marshal and callable(c):
+            if sys.version_info > (3, 11):
+                # TODO: maybe move the warning to storage creation? makes
+                # more sense than screaming when they save things
+                warnings.warn(
+                    "netcdfplus is deprecated for Python 3.11+. "
+                    "Using SimStore is recommended. "
+                    "See https://github.com/dwhswenson/ops-storage-"
+                    "notebooks/blob/master/examples/01_simple_usage.ipynb "
+                    "for usage."
+                )
+                codec = make_callable_codec(safemode=False)
+                return codec.default(c)
+
+            # back to normal for older Python versions
             # use marshal
             global_vars = ObjectJSON._find_var(c, opcode.opmap['LOAD_GLOBAL'])
             import_vars = ObjectJSON._find_var(c, opcode.opmap['IMPORT_NAME'])
@@ -480,6 +508,12 @@ class ObjectJSON(object):
                 if packages[0] in ObjectJSON.safe_modules:
                     imp = importlib.import_module(module)
                     c = getattr(imp, c_dict['_name'])
+
+            elif '_dilled' in c_dict:
+                # safemode has to get handled by original netcdfplus, since
+                # this is a staticmethod
+                codec = make_callable_codec(safemode=False)
+                c = codec.object_hook(c_dict)
 
         return c
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,9 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Bio-Informatics
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
@@ -27,6 +26,7 @@ classifiers =
 
 [options]
 include_package_data = True
+python_requires = ">3.7"  # only testing against 3.9+; but 3.7 should work
 install_requires = 
     future
     psutil
@@ -38,9 +38,12 @@ install_requires =
     networkx
     matplotlib
     ujson!=2.*,!=3.*,!=4.0.0,!=4.0.1
+    dill
     mdtraj
 # mdtraj is not technically required, but we co-package it because it is
 # required for many integrations with other packages
+# dill is technically only required for Python 3.11+, but we'll include it
+# for all Python versions
 packages = find:
 
 [options.extras_require]
@@ -52,7 +55,6 @@ test =
     nbval
 simstore =
     sqlalchemy!=1.4.0
-    dill
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 include_package_data = True
-python_requires = ">3.7"  # only testing against 3.9+; but 3.7 should work
+python_requires = >3.7
 install_requires = 
     future
     psutil


### PR DESCRIPTION
This is a follow-up on #1132, and should only be merged after that one.

This PR will bring OPS tests in line with the [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) guidance on Python version support: namely, we will drop anything before 3.9, and support everything after 3.9 that is also supported by released versions of our major dependencies (typically involved waiting on support in the OpenMM ecosystem to filter through).

To-do:

- [x] Test on Python 3.10
- [x] Test on Python 3.11

Due to major changes in opcodes in Python 3.11, we're using SimStore's `CallableCodec` to serialize callables in Python 3.11, even in netcdfplus storage. This has the side effect that we needed to change the `CallableCodec`'s output to be base64-encoded so that it was serializable by `ujson` (SimStore's JSON codec ecosystem knows how to store raw bytes; `ujson` does not.) This means that SimStore storages will change, although we should still be able to load the old objects. It also means that `dill` is now a strict requirement for OPS (technically only on Python 3.11, but we'll include it in packaging everywhere).

A few extra to-do's as a result:

* ~Add warning that on Python 3.11 you should probably switch to SimStore~ [I decided against this. It has always been the case that you could use different code paths for serialization in different Python versions. This is just a *much* different code path. I'll probably add `FutureWarning` on `Storage` after the next release.]
- [x] Add warning when loading old SimStore storages that the serialization has changed
- [x] Add test to ensure we can load old SimStore storages