### PR TITLE
Pin nbval != 0.10.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ test =
     pytest
     pytest-cov
     coveralls
-    nbval
+    nbval!=0.10.0
 simstore =
     sqlalchemy>=1.4.1
 


### PR DESCRIPTION
I'm not sure why we're just now picking up nbval 0.10.0 (released in January), but it seems to be causing tests to fail. 