### PR TITLE
Fix engine props for OpenMM 8.1

### DIFF
--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -287,7 +287,9 @@ class OpenMMEngine(DynamicsEngine):
                 )
             elif platform is None:
                 # as of OpenMM 8.1, we can't give an empty props dict when
-                # platform is None
+                # platform is None. This will still raise the internal
+                # OpenMM error is platform is None and properties are
+                # provided.
                 openmm_props = self.openmm_properties
                 if openmm_props == {}:
                     openmm_props = None

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -286,11 +286,17 @@ class OpenMMEngine(DynamicsEngine):
                     platformProperties=self.openmm_properties
                 )
             elif platform is None:
+                # as of OpenMM 8.1, we can't give an empty props dict when
+                # platform is None
+                openmm_props = self.openmm_properties
+                if openmm_props == {}:
+                    openmm_props = None
+
                 self._simulation = openmm.app.Simulation(
                     topology=self.topology.mdtraj.to_openmm(),
                     system=self.system,
                     integrator=self.integrator,
-                    platformProperties=self.openmm_properties
+                    platformProperties=openmm_props,
                 )
             else:
                 self._simulation = openmm.app.Simulation(


### PR DESCRIPTION
In OpenMM 8.1, it seems that we must pass `None` for engine properties. The empty dict is no longer treated the same.