### PR TITLE
Fix a few more setup -> setup_method tests

### DIFF
--- a/examples/tests/test_netcdfplus.ipynb
+++ b/examples/tests/test_netcdfplus.ipynb
@@ -235,6 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "st.nodes.save(Node(10));"
    ]
   },
@@ -370,7 +371,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['bool', 'float', 'index', 'int', 'json', 'jsonobj', 'lazyobj', u'lazyobj.attributes', u'lazyobj.dict', u'lazyobj.dictimmutable', u'lazyobj.nodes', u'lazyobj.nodesnamed', u'lazyobj.nodesunique', 'lazyobj.stores', u'lazyobj.varstore', u'lazyuuid.attributes', u'lazyuuid.dict', u'lazyuuid.dictimmutable', u'lazyuuid.nodes', u'lazyuuid.nodesnamed', u'lazyuuid.nodesunique', 'lazyuuid.stores', u'lazyuuid.varstore', 'length', 'long', 'numpy.float32', 'numpy.float64', 'numpy.int16', 'numpy.int32', 'numpy.int64', 'numpy.int8', 'numpy.uint16', 'numpy.uint32', 'numpy.uint64', 'numpy.uint8', 'obj', u'obj.attributes', u'obj.dict', u'obj.dictimmutable', u'obj.nodes', u'obj.nodesnamed', u'obj.nodesunique', 'obj.stores', u'obj.varstore', 'store', 'str', 'uuid', u'uuid.attributes', u'uuid.dict', u'uuid.dictimmutable', u'uuid.nodes', u'uuid.nodesnamed', u'uuid.nodesunique', 'uuid.stores', u'uuid.varstore']\n"
+      "['bool', 'float', 'index', 'int', 'json', 'jsonobj', 'lazyobj', 'lazyobj.attributes', 'lazyobj.dict', 'lazyobj.dictimmutable', 'lazyobj.nodes', 'lazyobj.nodesnamed', 'lazyobj.nodesunique', 'lazyobj.stores', 'lazyobj.varstore', 'lazyuuid.attributes', 'lazyuuid.dict', 'lazyuuid.dictimmutable', 'lazyuuid.nodes', 'lazyuuid.nodesnamed', 'lazyuuid.nodesunique', 'lazyuuid.stores', 'lazyuuid.varstore', 'length', 'long', 'numpy.float32', 'numpy.float64', 'numpy.int16', 'numpy.int32', 'numpy.int64', 'numpy.int8', 'numpy.uint16', 'numpy.uint32', 'numpy.uint64', 'numpy.uint8', 'obj', 'obj.attributes', 'obj.dict', 'obj.dictimmutable', 'obj.nodes', 'obj.nodesnamed', 'obj.nodesunique', 'obj.stores', 'obj.varstore', 'store', 'str', 'uuid', 'uuid.attributes', 'uuid.dict', 'uuid.dictimmutable', 'uuid.nodes', 'uuid.nodesnamed', 'uuid.nodesunique', 'uuid.stores', 'uuid.varstore']\n"
      ]
     }
    ],
@@ -430,84 +431,84 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "attributes_cache (u'attributes',)\n",
-      "attributes_json (u'attributes',)\n",
-      "attributes_name (u'attributes',)\n",
-      "attributes_uuid (u'attributes',)\n",
-      "bool (u'pair', u'pair', u'pair')\n",
-      "dict_json (u'dict',)\n",
-      "dict_name (u'dict',)\n",
-      "dict_uuid (u'dict',)\n",
-      "dictimmutable_json (u'dictimmutable',)\n",
-      "dictimmutable_name (u'dictimmutable',)\n",
-      "dictimmutable_uuid (u'dictimmutable',)\n",
-      "float (u'pair', u'pair', u'pair')\n",
-      "index (u'pair', u'pair', u'pair')\n",
-      "int (u'pair', u'pair', u'pair')\n",
-      "json (u'pair', u'pair', u'pair')\n",
-      "jsonobj (u'pair', u'pair', u'pair')\n",
-      "lazyobj (u'pair', u'pair', u'pair', u'pair')\n",
-      "lazyobj.attributes (u'pair', u'pair', u'pair')\n",
-      "lazyobj.dict (u'pair', u'pair', u'pair')\n",
-      "lazyobj.dictimmutable (u'pair', u'pair', u'pair')\n",
-      "lazyobj.nodes (u'pair', u'pair', u'pair')\n",
-      "lazyobj.nodesnamed (u'pair', u'pair', u'pair')\n",
-      "lazyobj.nodesunique (u'pair', u'pair', u'pair')\n",
-      "lazyobj.stores (u'pair', u'pair', u'pair')\n",
-      "lazyobj.varstore (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.attributes (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.dict (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.dictimmutable (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.nodes (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.nodesnamed (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.nodesunique (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.stores (u'pair', u'pair', u'pair')\n",
-      "lazyuuid.varstore (u'pair', u'pair', u'pair')\n",
-      "length (u'pair', u'pair', u'pair')\n",
-      "long (u'pair', u'pair', u'pair')\n",
-      "nodes_json (u'nodes',)\n",
-      "nodes_uuid (u'nodes',)\n",
-      "nodesnamed_json (u'nodesnamed',)\n",
-      "nodesnamed_name (u'nodesnamed',)\n",
-      "nodesnamed_uuid (u'nodesnamed',)\n",
-      "nodesunique_json (u'nodesunique',)\n",
-      "nodesunique_name (u'nodesunique',)\n",
-      "nodesunique_uuid (u'nodesunique',)\n",
-      "numpy.float32 (u'pair', u'pair', u'pair')\n",
-      "numpy.float64 (u'pair', u'pair', u'pair')\n",
-      "numpy.int16 (u'pair', u'pair', u'pair')\n",
-      "numpy.int32 (u'pair', u'pair', u'pair')\n",
-      "numpy.int64 (u'pair', u'pair', u'pair')\n",
-      "numpy.int8 (u'pair', u'pair', u'pair')\n",
-      "numpy.uint16 (u'pair', u'pair', u'pair')\n",
-      "numpy.uint32 (u'pair', u'pair', u'pair')\n",
-      "numpy.uint64 (u'pair', u'pair', u'pair')\n",
-      "numpy.uint8 (u'pair', u'pair', u'pair')\n",
-      "obj (u'pair', u'pair', u'pair', u'pair')\n",
-      "obj.attributes (u'pair', u'pair', u'pair')\n",
-      "obj.dict (u'pair', u'pair', u'pair')\n",
-      "obj.dictimmutable (u'pair', u'pair', u'pair')\n",
-      "obj.nodes (u'pair', u'pair', u'pair')\n",
-      "obj.nodesnamed (u'pair', u'pair', u'pair')\n",
-      "obj.nodesunique (u'pair', u'pair', u'pair')\n",
-      "obj.stores (u'pair', u'pair', u'pair')\n",
-      "obj.varstore (u'pair', u'pair', u'pair')\n",
-      "store (u'pair', u'pair', u'pair')\n",
-      "stores_json (u'stores',)\n",
-      "stores_name (u'stores',)\n",
-      "stores_uuid (u'stores',)\n",
-      "str (u'pair', u'pair', u'pair')\n",
-      "uuid (u'pair', u'pair', u'pair')\n",
-      "uuid.attributes (u'pair', u'pair', u'pair')\n",
-      "uuid.dict (u'pair', u'pair', u'pair')\n",
-      "uuid.dictimmutable (u'pair', u'pair', u'pair')\n",
-      "uuid.nodes (u'pair', u'pair', u'pair')\n",
-      "uuid.nodesnamed (u'pair', u'pair', u'pair')\n",
-      "uuid.nodesunique (u'pair', u'pair', u'pair')\n",
-      "uuid.stores (u'pair', u'pair', u'pair')\n",
-      "uuid.varstore (u'pair', u'pair', u'pair')\n",
-      "varstore_uuid (u'varstore',)\n",
-      "varstore_value (u'varstore',)\n"
+      "attributes_cache ('attributes',)\n",
+      "attributes_json ('attributes',)\n",
+      "attributes_name ('attributes',)\n",
+      "attributes_uuid ('attributes',)\n",
+      "bool ('pair', 'pair', 'pair')\n",
+      "dict_json ('dict',)\n",
+      "dict_name ('dict',)\n",
+      "dict_uuid ('dict',)\n",
+      "dictimmutable_json ('dictimmutable',)\n",
+      "dictimmutable_name ('dictimmutable',)\n",
+      "dictimmutable_uuid ('dictimmutable',)\n",
+      "float ('pair', 'pair', 'pair')\n",
+      "index ('pair', 'pair', 'pair')\n",
+      "int ('pair', 'pair', 'pair')\n",
+      "json ('pair', 'pair', 'pair')\n",
+      "jsonobj ('pair', 'pair', 'pair')\n",
+      "lazyobj ('pair', 'pair', 'pair', 'pair')\n",
+      "lazyobj.attributes ('pair', 'pair', 'pair')\n",
+      "lazyobj.dict ('pair', 'pair', 'pair')\n",
+      "lazyobj.dictimmutable ('pair', 'pair', 'pair')\n",
+      "lazyobj.nodes ('pair', 'pair', 'pair')\n",
+      "lazyobj.nodesnamed ('pair', 'pair', 'pair')\n",
+      "lazyobj.nodesunique ('pair', 'pair', 'pair')\n",
+      "lazyobj.stores ('pair', 'pair', 'pair')\n",
+      "lazyobj.varstore ('pair', 'pair', 'pair')\n",
+      "lazyuuid.attributes ('pair', 'pair', 'pair')\n",
+      "lazyuuid.dict ('pair', 'pair', 'pair')\n",
+      "lazyuuid.dictimmutable ('pair', 'pair', 'pair')\n",
+      "lazyuuid.nodes ('pair', 'pair', 'pair')\n",
+      "lazyuuid.nodesnamed ('pair', 'pair', 'pair')\n",
+      "lazyuuid.nodesunique ('pair', 'pair', 'pair')\n",
+      "lazyuuid.stores ('pair', 'pair', 'pair')\n",
+      "lazyuuid.varstore ('pair', 'pair', 'pair')\n",
+      "length ('pair', 'pair', 'pair')\n",
+      "long ('pair', 'pair', 'pair')\n",
+      "nodes_json ('nodes',)\n",
+      "nodes_uuid ('nodes',)\n",
+      "nodesnamed_json ('nodesnamed',)\n",
+      "nodesnamed_name ('nodesnamed',)\n",
+      "nodesnamed_uuid ('nodesnamed',)\n",
+      "nodesunique_json ('nodesunique',)\n",
+      "nodesunique_name ('nodesunique',)\n",
+      "nodesunique_uuid ('nodesunique',)\n",
+      "numpy.float32 ('pair', 'pair', 'pair')\n",
+      "numpy.float64 ('pair', 'pair', 'pair')\n",
+      "numpy.int16 ('pair', 'pair', 'pair')\n",
+      "numpy.int32 ('pair', 'pair', 'pair')\n",
+      "numpy.int64 ('pair', 'pair', 'pair')\n",
+      "numpy.int8 ('pair', 'pair', 'pair')\n",
+      "numpy.uint16 ('pair', 'pair', 'pair')\n",
+      "numpy.uint32 ('pair', 'pair', 'pair')\n",
+      "numpy.uint64 ('pair', 'pair', 'pair')\n",
+      "numpy.uint8 ('pair', 'pair', 'pair')\n",
+      "obj ('pair', 'pair', 'pair', 'pair')\n",
+      "obj.attributes ('pair', 'pair', 'pair')\n",
+      "obj.dict ('pair', 'pair', 'pair')\n",
+      "obj.dictimmutable ('pair', 'pair', 'pair')\n",
+      "obj.nodes ('pair', 'pair', 'pair')\n",
+      "obj.nodesnamed ('pair', 'pair', 'pair')\n",
+      "obj.nodesunique ('pair', 'pair', 'pair')\n",
+      "obj.stores ('pair', 'pair', 'pair')\n",
+      "obj.varstore ('pair', 'pair', 'pair')\n",
+      "store ('pair', 'pair', 'pair')\n",
+      "stores_json ('stores',)\n",
+      "stores_name ('stores',)\n",
+      "stores_uuid ('stores',)\n",
+      "str ('pair', 'pair', 'pair')\n",
+      "uuid ('pair', 'pair', 'pair')\n",
+      "uuid.attributes ('pair', 'pair', 'pair')\n",
+      "uuid.dict ('pair', 'pair', 'pair')\n",
+      "uuid.dictimmutable ('pair', 'pair', 'pair')\n",
+      "uuid.nodes ('pair', 'pair', 'pair')\n",
+      "uuid.nodesnamed ('pair', 'pair', 'pair')\n",
+      "uuid.nodesunique ('pair', 'pair', 'pair')\n",
+      "uuid.stores ('pair', 'pair', 'pair')\n",
+      "uuid.varstore ('pair', 'pair', 'pair')\n",
+      "varstore_uuid ('varstore',)\n",
+      "varstore_value ('varstore',)\n"
      ]
     }
    ],
@@ -782,7 +783,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'Test': 3, 'Hallo': 2}\n"
+      "{'Hallo': 2, 'Test': 3}\n"
      ]
     }
    ],
@@ -809,8 +810,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'{\"_store\":\"nodes\",\"_hex_uuid\":\"0xebbeb5f0b75311e89830000000000024L\"}'\n",
-      " u'{\"Test\":3,\"Hallo\":2}']\n"
+      "['{\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f000000000026\",\"_store\":\"nodes\"}'\n",
+      " '{\"Hallo\":2,\"Test\":3}']\n"
      ]
     }
    ],
@@ -968,17 +969,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[u'ebbeb5f0-b753-11e8-9830-00000000002a'\n",
-      "   u'ebbeb5f0-b753-11e8-9830-00000000002e']\n",
-      "  [u'ebbeb5f0-b753-11e8-9830-00000000002c' u'']]\n",
+      "[[['e3d4c53a-0100-11ef-9d1f-00000000002c'\n",
+      "   'e3d4c53a-0100-11ef-9d1f-000000000030']\n",
+      "  ['e3d4c53a-0100-11ef-9d1f-00000000002e' '']]\n",
       "\n",
-      " [[u'' u'']\n",
-      "  [u'' u'']]]\n",
-      "[u'{\"_cls\":\"Node\",\"_dict\":{\"value\":10}}'\n",
-      " u'{\"_cls\":\"Node\",\"_dict\":{\"value\":10}}'\n",
-      " u'{\"_cls\":\"Node\",\"_dict\":{\"value\":1}}'\n",
-      " u'{\"_cls\":\"Node\",\"_dict\":{\"value\":\"Second\"}}'\n",
-      " u'{\"_cls\":\"Node\",\"_dict\":{\"value\":\"Third\"}}']\n"
+      " [['' '']\n",
+      "  ['' '']]]\n",
+      "['{\"_cls\":\"Node\",\"_dict\":{\"value\":10}}'\n",
+      " '{\"_cls\":\"Node\",\"_dict\":{\"value\":10}}'\n",
+      " '{\"_cls\":\"Node\",\"_dict\":{\"value\":1}}'\n",
+      " '{\"_cls\":\"Node\",\"_dict\":{\"value\":\"Second\"}}'\n",
+      " '{\"_cls\":\"Node\",\"_dict\":{\"value\":\"Third\"}}']\n"
      ]
     }
    ],
@@ -1048,7 +1049,7 @@
      "text": [
       "Type:    <class 'openpathsampling.netcdfplus.proxy.LoaderProxy'>\n",
       "Class:   <class '__main__.Node'>\n",
-      "Content: {'__uuid__': 313358805600210293968778471146830954544L, 'value': 'First'}\n",
+      "Content: {'__uuid__': 302839522207420201522962921396994310194, 'value': 'First'}\n",
       "Access:  First\n"
      ]
     }
@@ -1099,6 +1100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "obj = Node('BlaBla')\n",
     "st.nodes.save(obj);"
    ]
@@ -1272,7 +1274,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "### ObjectStores"
@@ -1387,6 +1392,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "st.nodesnamed.save(n);"
    ]
   },
@@ -1427,6 +1433,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "n2 = NamedNode(9)\n",
     "n2.name = 'MyNode'\n",
     "st.nodesnamed.save(n2);"
@@ -1448,7 +1455,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'MyNode': set([0, 1])}\n"
+      "{'MyNode': {0, 1}}\n"
      ]
     }
    ],
@@ -1477,6 +1484,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "st.nodesunique.save(n);"
    ]
   },
@@ -1527,7 +1535,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'MyNode': set([0])}\n"
+      "{'MyNode': {0}}\n"
      ]
     }
    ],
@@ -1549,6 +1557,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "n3 = NamedNode(10)\n",
     "n4 = NamedNode(12)\n",
     "st.nodesunique.save(n3);\n",
@@ -1602,6 +1611,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "st.nodesunique.save(n5, 'NextNode');"
    ]
   },
@@ -1807,7 +1817,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xebbeb5f0b75311e89830000000000048L\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xebbeb5f0b75311e8983000000000004aL\"}, {\"_store\":\"nodesunique\",\"_hex_uuid\":\"0xebbeb5f0b75311e8983000000000004cL\"} ]\n"
+      "[ {\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f00000000004a\",\"_store\":\"nodesunique\"}, {\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f00000000004c\",\"_store\":\"nodesunique\"}, {\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f00000000004e\",\"_store\":\"nodesunique\"} ]\n"
      ]
     }
    ],
@@ -1879,7 +1889,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "#### VariableStore"
@@ -1898,6 +1911,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "a = Node(30)\n",
     "st.varstore.save(a);"
    ]
@@ -2078,7 +2092,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0xebbeb5f0b75311e89830000000000012L\n"
+      "0xe3d4c53a010011ef9d1f000000000014\n"
      ]
     }
    ],
@@ -2122,7 +2136,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2136,7 +2150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.11.7"
   },
   "toc": {
    "base_numbering": 1,
@@ -2182,5 +2196,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/tests/test_openmm_integration.ipynb
+++ b/examples/tests/test_openmm_integration.ipynb
@@ -364,6 +364,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "st.save(traj);"
    ]
   },
@@ -534,5 +535,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/openpathsampling/experimental/storage/test_collective_variables.py
+++ b/openpathsampling/experimental/storage/test_collective_variables.py
@@ -26,7 +26,7 @@ else:
 
 
 class TestCollectiveVariable(object):
-    def setup(self):
+    def setup_method(self):
         self.cv = CollectiveVariable(lambda x: x.xyz[0][0])
         self.traj = make_1d_traj([1.0, 2.0, 3.0])
         ensemble = paths.LengthEnsemble(3)
@@ -47,7 +47,7 @@ class TestCollectiveVariable(object):
 # TODO: It turns out that trajectories don't currently store their reversed
 # partners. This test won't work until that idea is implemented.
 # class TestReversibleStorableFunction(object):
-    # def setup(self):
+    # def setup_method(self):
         # self.func = ReversibleStorableFunction(
             # func=mock.MagicMock(return_value=3.0),
             # result_type='float'
@@ -72,7 +72,7 @@ class TestCollectiveVariable(object):
 
 
 class TestCoordinateFunctionCV(object):
-    def setup(self):
+    def setup_method(self):
         # On using side_effect: https://stackoverflow.com/a/16162114
         mock_func = mock.MagicMock(side_effect=lambda s: s.xyz[0][0])
         self.func = CoordinateFunctionCV(mock_func)
@@ -117,7 +117,7 @@ class TestCoordinateFunctionCV(object):
 
 
 class TestMDTrajFunctionCV(object):
-    def setup(self):
+    def setup_method(self):
         if not HAS_MDTRAJ:
             pytest.skip("Unable to import MDTraj")
         pytest.importorskip('simtk.unit')

--- a/openpathsampling/experimental/storage/test_mdtraj_json.py
+++ b/openpathsampling/experimental/storage/test_mdtraj_json.py
@@ -10,7 +10,7 @@ from ..simstore.test_custom_json import CustomJSONCodingTest
 from openpathsampling.tests.test_helpers import data_filename
 
 class MDTrajCodingTest(CustomJSONCodingTest):
-    def setup(self):
+    def setup_method(self):
         if not HAS_MDTRAJ:
             pytest.skip()
 
@@ -36,8 +36,8 @@ class MDTrajCodingTest(CustomJSONCodingTest):
 
 
 class TestTopologyCoding(MDTrajCodingTest):
-    def setup(self):
-        super(TestTopologyCoding, self).setup()
+    def setup_method(self):
+        super(TestTopologyCoding, self).setup_method()
         self.codec = top_codec
         top = md.load(self.filename).topology
         dataframe, bonds = top.to_dataframe()
@@ -51,8 +51,8 @@ class TestTopologyCoding(MDTrajCodingTest):
 
 
 class TestTrajectoryCoding(MDTrajCodingTest):
-    def setup(self):
-        super(TestTrajectoryCoding, self).setup()
+    def setup_method(self):
+        super(TestTrajectoryCoding, self).setup_method()
         self.codec = traj_codec
         traj = md.load(self.filename)
         self.objs = [traj]

--- a/openpathsampling/experimental/storage/test_simtk_unit.py
+++ b/openpathsampling/experimental/storage/test_simtk_unit.py
@@ -11,7 +11,7 @@ from .simtk_unit import *
 from openpathsampling.integration_tools import HAS_SIMTK_UNIT, unit
 
 class TestSimtkUnitCodec(object):
-    def setup(self):
+    def setup_method(self):
         if not HAS_SIMTK_UNIT:
             pytest.skip("openmm.unit not installed")
         my_unit = unit.nanometer / unit.picosecond**2
@@ -37,7 +37,7 @@ class TestSimtkUnitCodec(object):
 
 
 class TestSimtkQuantityHandler(object):
-    def setup(self):
+    def setup_method(self):
         pytest.importorskip('simtk.unit')
         self.handlers = {
             'float': SimtkQuantityHandler(

--- a/openpathsampling/experimental/storage/test_snapshots_table.py
+++ b/openpathsampling/experimental/storage/test_snapshots_table.py
@@ -58,7 +58,7 @@ class MockBackend(object):
 
 
 class TestSnapshotsTable(object):
-    def setup(self):
+    def setup_method(self):
         self.engine_1 = make_engine()
         self.engine_2 = make_engine()
         snap_1_0 = toys.Snapshot(coordinates=np.array([0.0, 0.0]),

--- a/openpathsampling/tests/test_spring_shooting.py
+++ b/openpathsampling/tests/test_spring_shooting.py
@@ -38,20 +38,17 @@ class SelectorTest(object):
 
 class TestSpringShootingSelector(SelectorTest):
 
-    @staticmethod
-    def test_neg_delta():
+    def test_neg_delta(self):
         with pytest.raises(ValueError):
             SpringShootingSelector(delta_max=-1,
                                    k_spring=0.1)
 
-    @staticmethod
-    def test_0_delta():
+    def test_0_delta(self):
         with pytest.raises(ValueError):
             SpringShootingSelector(delta_max=0,
                                    k_spring=0.1)
 
-    @staticmethod
-    def test_pos_delta():
+    def test_pos_delta(self):
         delta_max = 1
         sel = SpringShootingSelector(delta_max=delta_max,
                                      k_spring=0.1)
@@ -59,14 +56,12 @@ class TestSpringShootingSelector(SelectorTest):
         assert len(sel._fw_prob_list) == 2*delta_max+1
         assert len(sel._bw_prob_list) == 2*delta_max+1
 
-    @staticmethod
-    def test_neg_k():
+    def test_neg_k(self):
         with pytest.raises(ValueError):
             SpringShootingSelector(delta_max=1,
                                    k_spring=-1)
 
-    @staticmethod
-    def test_0_k():
+    def test_0_k(self):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=0)
         ref_list = [1.0, 1.0, 1.0]
@@ -74,22 +69,19 @@ class TestSpringShootingSelector(SelectorTest):
         assert sel._fw_prob_list == ref_list
         assert sel._bw_prob_list == ref_list
 
-    @staticmethod
-    def test_pos_k():
+    def test_pos_k(self):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=1)
         assert sel.k_spring == 1
 
-    @staticmethod
-    def test_sanity_breaking_fw():
+    def test_sanity_breaking_fw(self):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=1)
         sel._fw_prob_list = [0, 0, 0]
         with pytest.raises(RuntimeError):
             sel.check_sanity()
 
-    @staticmethod
-    def test_sanity_breaking_bw():
+    def test_sanity_breaking_bw(self):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=1)
         sel._bw_prob_list = [0, 0, 0]
@@ -97,16 +89,14 @@ class TestSpringShootingSelector(SelectorTest):
         with pytest.raises(RuntimeError):
             sel.check_sanity()
 
-    @staticmethod
-    def test_sanity_breaking_total():
+    def test_sanity_breaking_total(self):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=1)
         sel._total_bias = sum([0, 0, 0])
         with pytest.raises(RuntimeError):
             sel.check_sanity()
 
-    @staticmethod
-    def test_probability_ratio():
+    def test_probability_ratio(self):
         sel = SpringShootingSelector(delta_max=1,
                                      k_spring=1)
         sel._acceptable_snapshot = True
@@ -141,8 +131,7 @@ class TestSpringShootingSelector(SelectorTest):
         with pytest.raises(RuntimeError):
             sel.pick(trajectory=self.mytraj, direction='forward')
 
-    @staticmethod
-    def test_initial_guess():
+    def test_initial_guess(self):
         sel = SpringShootingSelector(delta_max=1, k_spring=1, initial_guess=12)
         assert sel.trial_snapshot == 12
         assert sel.previous_snapshot == 12
@@ -272,16 +261,14 @@ class TestSpringShootingSelector(SelectorTest):
         assert sel.previous_snapshot == self.initial_guess
         assert sel._acceptable_snapshot is False
 
-    @staticmethod
-    def test_failed_loading():
+    def test_failed_loading(self):
         sel = SpringShootingSelector(delta_max=1, k_spring=0, initial_guess=3)
         details = Details(foo='bar')
         step = FakeStep(details)
         with pytest.raises(RuntimeError):
             sel.restart_from_step(step)
 
-    @staticmethod
-    def test_correct_loading():
+    def test_correct_loading(self):
         sel = SpringShootingSelector(delta_max=1, k_spring=0, initial_guess=3)
         details = Details(initial_trajectory='foo',
                           last_accepted_shooting_index='bar',
@@ -413,8 +400,7 @@ class TestSpringShootingMover(MoverTest):
 
 
 class TestSpringShootingStrategy(MoveStrategyTestSetup):
-    @staticmethod
-    def test_init():
+    def test_init(self):
         strategy = SpringShootingStrategy(delta_max=1, k_spring=0.0,
                                           initial_guess=3)
         assert strategy.delta_max == 1


### PR DESCRIPTION
In #1123, most of our setup/teardown methods were fixed to use pytest's preferred (and now required) `setup_method`/`teardown_method` nomenclature. This fixes a few more.

---

**UPDATE**: This fixes 3 problems caused by upstream breaking changes:

1. As mentioned above, pytest now requires `setup_method` / `teardown_method` instead of `setup` and `teardown`.
2. Newer versions of pytest only work with nbval 0.10.0 or later. nbval 0.10.0 introduced what I consider to be a bug, which is that return values that you hide in-notebook with a `;` are seen by nbval as output. This required using `NBVAL_IGNORE` in some notebooks.
3. pytest also broke XUnit-style tests that include staticmethods as tests (I consider this to also be a bug). The fix was to just make them instance methods.