### PR TITLE
Fix histogram xvals

### DIFF
--- a/openpathsampling/numerics/histogram.py
+++ b/openpathsampling/numerics/histogram.py
@@ -147,8 +147,8 @@ class SparseHistogram(object):
         np.array :
             The values of the bin edges
         """
-        int_bins = np.array(self._histogram.keys())
-        left_bins = int_bins * self.bin_widths + self.left_bin_edges
+        int_bins = np.array(list(self._histogram.keys()))
+        left_bins = int_bins * np.array(self.bin_widths) + self.left_bin_edges
         return self._left_edge_to_bin_edge_type(left_bins, self.bin_widths,
                                                 bin_edge_type)
 

--- a/openpathsampling/tests/test_histogram.py
+++ b/openpathsampling/tests/test_histogram.py
@@ -5,6 +5,7 @@ from builtins import object
 from .test_helpers import assert_items_almost_equal, assert_items_equal
 import pytest
 import logging
+from numpy import testing as npt
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
@@ -211,6 +212,14 @@ class TestSparseHistogram(object):
         assert histo_fcn((0.61, 0.89)) == 1
         # empty voxel gives 0
         assert histo_fcn((2.00, 2.00)) == 0
+
+    @pytest.mark.parametrize('side,expected', [
+        ('l', [[0.0, -0.1], [0.0, 0.5], [0.5, 0.8]]),
+        ('r', [[0.5, 0.2], [0.5, 0.8], [1.0, 1.1]]),
+        ('m', [[0.25, 0.05], [0.25, 0.65], [0.75, 0.95]]),
+    ])
+    def test_xvals(self, side, expected):
+        npt.assert_almost_equal(self.histo.xvals(side), expected)
 
     def test_normalized(self):
         raw_prob_normed = self.histo.normalized(raw_probability=True)


### PR DESCRIPTION
Turns out that a line of old uncovered code hadn't been updated for Python 3! Fixed the line, added test coverage.