### PR TITLE
Volume shooting point selector

### DIFF
--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -271,3 +271,12 @@ class FirstFrameSelector(ShootingPointSelector):
         if new_snapshot is None:
             NEW_SNAPSHOT_SELECTOR.warn(stacklevel=3)
         return 1.0
+
+
+
+class VolumeShootingSelector(ShootingPointSelector):
+    def __init__(self, volume):
+        self.volume = volume
+
+    def f(self, frame, trajectory):
+        return float(self.volume(frame))

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -273,7 +273,6 @@ class FirstFrameSelector(ShootingPointSelector):
         return 1.0
 
 
-
 class VolumeSelector(ShootingPointSelector):
     def __init__(self, volume):
         self.volume = volume

--- a/openpathsampling/shooting.py
+++ b/openpathsampling/shooting.py
@@ -274,7 +274,7 @@ class FirstFrameSelector(ShootingPointSelector):
 
 
 
-class VolumeShootingSelector(ShootingPointSelector):
+class VolumeSelector(ShootingPointSelector):
     def __init__(self, volume):
         self.volume = volume
 

--- a/openpathsampling/tests/test_shooting.py
+++ b/openpathsampling/tests/test_shooting.py
@@ -251,6 +251,20 @@ class TestConstrainedSelector(SelectorTest):
         assert prob == expected
 
 
+class TestVolumeSelector(SelectorTest):
+    def setup_method(self):
+        super().setup_method()
+        self.cv = paths.FunctionCV("Id", lambda x: x.xyz[0][0])
+        vol = paths.CVDefinedVolume(self.cv, 0.15, 0.35)
+        self.sel = VolumeSelector(vol)
+
+    @pytest.mark.parametrize('frame,expected', [
+        (0, 0.0), (1, 0.0), (2, 1.0), (3, 1.0), (4, 0.0)
+    ])
+    def test_f(self, frame, expected):
+        assert self.sel.f(self.mytraj[frame], self.mytraj) == expected
+
+
 class TestDeprecations(object):
     @pytest.mark.parametrize('selector_class', [ShootingPointSelector,
                                                 FirstFrameSelector,


### PR DESCRIPTION
This adds a volume-based shooting point selector. It will only select points from a given volume.

(I thought we already had this? I thought this was implemented as part of "Shooting Range" by @hejung in one of our ESDWs? Guess that code never made it into main. Not too hard to recreate this much of it, though.)