### PR TITLE
Fix `SQLStorageBackend.load_storable_function_table`

### DIFF
--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -474,7 +474,7 @@ class SQLStorageBackend(StorableNamedObject):
         except KeyError:
             # TODO: this should be removed eventually
             deserialize = lambda x: x
-        return {row['uuid']: deserialize(row['value'])
+        return {row.uuid: deserialize(row.value)
                 for row in self.table_iterator(table_name)}
 
     def add_tag(self, table_name, name, content):


### PR DESCRIPTION
This looks like a SQLAlchemy 2.0 issue that isn't covered in the current unit tests, but is covered in some more extensive external tests.