### PR TITLE
Custom `PathDensityHistogram._add_ops_trajectory`

### DIFF
--- a/openpathsampling/analysis/path_histogram.py
+++ b/openpathsampling/analysis/path_histogram.py
@@ -364,6 +364,10 @@ class PathDensityHistogram(PathHistogram):
         )
         self.cvs = cvs
 
+    def _add_ops_trajectory(self, trajectory, weight):
+        cv_traj = [cv(trajectory) for cv in self.cvs]
+        self.add_trajectory(list(zip(*cv_traj)), weight)
+
     def add_data_to_histogram(self, trajectories, weights=None):
         """Adds data to the internal histogram counter.
 
@@ -387,8 +391,7 @@ class PathDensityHistogram(PathHistogram):
 
         # TODO: add something so that we don't recalc the same traj twice
         for (traj, w) in self.progress(list(zip(trajectories, weights))):
-            cv_traj = [cv(traj) for cv in self.cvs]
-            self.add_trajectory(list(zip(*cv_traj)), w)
+            self._add_ops_trajectory(traj, w)
 
         return self._histogram.copy()
 


### PR DESCRIPTION
This adds a touch point for path density histogram subclasses to change what occurs when adding an OPS trajectory to a PathDensityHistogram.

I needed this when playing with the idea of having a custom histogram that would also track all trajectories that passed through a given histogram bin.

This doesn't break the API, and doesn't even need changes in the tests.