### PR TITLE
Let UUID determine equality for ensembles

### DIFF
--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -253,7 +253,10 @@ class Ensemble(with_metaclass(abc.ABCMeta, StorableNamedObject)):
     def __eq__(self, other):
         if self is other:
             return True
-        if self.__uuid__ == other.__uuid__:
+        if (
+            self.__class__ == other.__class__
+            and self.__uuid__ == other.__uuid__
+        ):
             return True
 
         return str(self) == str(other)

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -253,6 +253,9 @@ class Ensemble(with_metaclass(abc.ABCMeta, StorableNamedObject)):
     def __eq__(self, other):
         if self is other:
             return True
+        if self.__uuid__ == other.__uuid__:
+            return True
+
         return str(self) == str(other)
 
     def __ne__(self, other):


### PR DESCRIPTION
Long ago, we tried to use the string representations of ensembles as the comparison for equality. This was a decent idea, although there are some issues with the ways we handle equality and hashing.

I recently came across a weird edge case where a periodic volume with an edge exactly at -pi was serialized in 2 different ways: one with the edge at -pi and one with the edge at +pi. I'd still like to look into what happened to make that happen, but this would fix the most obvious effect (which is that the resulting ensembles weren't equal). In any case, this is a good shortcut: the same UUID indicates the same object, assuming we can trust the meaning of UUID.