### PR TITLE
SimStore performance improvements and fixes

### DIFF
--- a/openpathsampling/experimental/simstore/callable_codec.py
+++ b/openpathsampling/experimental/simstore/callable_codec.py
@@ -2,7 +2,8 @@ import types
 import dis
 import dill
 import codecs
-from .serialization_helpers import has_uuid, do_import
+from .serialization_helpers import do_import
+from .uuids import has_uuid
 from openpathsampling.deprecations \
         import SIMSTORE_CALLABLE_CODEC_STRING_NOT_BYTES
 

--- a/openpathsampling/experimental/simstore/class_info.py
+++ b/openpathsampling/experimental/simstore/class_info.py
@@ -2,9 +2,10 @@ import logging
 
 from . import tools
 from .serialization import SchemaSerializer, SchemaDeserializer
-from .serialization_helpers import SchemaFindUUIDs, has_uuid
+from .serialization_helpers import SchemaFindUUIDs
 from .serialization_helpers import encoded_uuid_re, get_reload_order
 from .serialization_helpers import get_all_uuids
+from .uuids import has_uuid
 from .my_types import uuid_types, uuid_list_types, json_obj_types
 
 from . import attribute_handlers

--- a/openpathsampling/experimental/simstore/class_lookup.py
+++ b/openpathsampling/experimental/simstore/class_lookup.py
@@ -1,4 +1,5 @@
 from . import tools
+from .uuids import has_uuid
 
 class ClassIsSomething(object):
     """Method to test whether a class exhibits a given attribute.
@@ -41,3 +42,5 @@ def _is_iterable_method(obj):
 
 is_storage_iterable = ClassIsSomething(_is_iterable_method)
 is_storage_mappable = ClassIsSomething(tools.is_mappable)
+is_storage_string = ClassIsSomething(tools.is_string)
+has_storage_uuid = ClassIsSomething(has_uuid)

--- a/openpathsampling/experimental/simstore/custom_json.py
+++ b/openpathsampling/experimental/simstore/custom_json.py
@@ -3,10 +3,12 @@ import functools
 import inspect
 from collections import namedtuple, defaultdict
 from .tools import none_to_default
-from .serialization_helpers import (
-    has_uuid, replace_uuid, encode_uuid, get_uuid, set_uuid
+from .uuids import (
+    has_uuid, encode_uuid, get_uuid, set_uuid
 )
-from .serialization_helpers import do_import, from_dict_with_uuids
+from .serialization_helpers import (
+    do_import, from_dict_with_uuids, replace_uuid
+)
 
 class SimulationObjectSerialization(object):
     def __init__(self, json_encoder, json_decoder):

--- a/openpathsampling/experimental/simstore/serialization_helpers.py
+++ b/openpathsampling/experimental/simstore/serialization_helpers.py
@@ -14,7 +14,7 @@ from .class_lookup import (
 )
 from .proxy import GenericLazyLoader
 from .uuids import (
-    has_uuid, get_uuid, set_uuid, encode_uuid, decode_uuid, encoded_uuid_re,
+    get_uuid, set_uuid, encode_uuid, decode_uuid, encoded_uuid_re,
     is_uuid_string
 )
 

--- a/openpathsampling/experimental/simstore/sql_backend.py
+++ b/openpathsampling/experimental/simstore/sql_backend.py
@@ -35,7 +35,7 @@ sql_type = {
 }
 
 universal_sql_meta = {
-    'uuid': {'uuid': {'primary_key': True}},
+    'uuid': {'uuid': {'primary_key': True, 'index': True}},
     'tables': {'name': {'primary_key': True}},
     'sfr_result_types': {'uuid': {'primary_key': True}},
 }
@@ -48,7 +48,7 @@ def make_columns(table_name, schema, sql_schema_metadata, backend_types):
     if table_name not in universal_schema:
         columns.append(sql.Column('idx', sql.Integer,
                                   primary_key=True))
-        columns.append(sql.Column('uuid', sql.String))
+        columns.append(sql.Column('uuid', sql.String, index=True))
     for col, type_name in schema[table_name]:
         col_type = sql_type[type_mapping[type_name]]
         metadata = extract_backend_metadata(sql_schema_metadata,

--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -7,7 +7,8 @@ import numpy as np
 
 from .tools import none_to_default
 from .callable_codec import CallableCodec
-from .serialization_helpers import get_uuid, has_uuid, default_find_uuids
+from .serialization_helpers import default_find_uuids
+from .uuids import get_uuid, has_uuid
 from .class_info import ClassInfo
 from .serialization_helpers import from_json_obj as deserialize_sim
 from openpathsampling.netcdfplus import StorableNamedObject

--- a/openpathsampling/experimental/simstore/test_serialization_helpers.py
+++ b/openpathsampling/experimental/simstore/test_serialization_helpers.py
@@ -13,38 +13,6 @@ all_objects = create_test_objects()
 def get_obj_uuid(name):
     return get_uuid(all_objects[name])
 
-
-@pytest.mark.parametrize('obj', list(all_objects.values()))
-def test_has_uuid(obj):
-    assert has_uuid(obj)
-
-def test_has_uuid_no_uuid():
-    assert not has_uuid(10)
-    assert not has_uuid('foo')
-
-@pytest.mark.parametrize('name,obj', list(all_objects.items()))
-def test_get_uuid(name, obj):
-    assert get_uuid(obj) == str(int(hash(name)))
-
-def test_get_uuid_none():
-    assert get_uuid(None) is None
-
-def test_get_uuid_error():
-    with pytest.raises(AttributeError):
-        get_uuid(10)
-
-def test_set_uuid():
-    obj = MockUUIDObject(name="test", normal_attr=10)
-    fake_uuid = 100
-    assert get_uuid(obj) != str(fake_uuid)
-    set_uuid(obj, fake_uuid)
-    assert get_uuid(obj) == str(fake_uuid)
-
-def test_encode_uuid():
-    obj = MockUUIDObject(name="test", normal_attr=10)
-    set_uuid(obj, 100)
-    assert encode_uuid("UUID(100)")
-
 @pytest.mark.parametrize('obj,included_objs', [
     (all_objects['int'], []),
     (all_objects['str'], []),

--- a/openpathsampling/experimental/simstore/test_uuids.py
+++ b/openpathsampling/experimental/simstore/test_uuids.py
@@ -1,0 +1,39 @@
+import pytest
+
+from .uuids import *
+from .test_utils import create_test_objects, MockUUIDObject
+
+all_objects = create_test_objects()
+
+@pytest.mark.parametrize('obj', list(all_objects.values()))
+def test_has_uuid(obj):
+    assert has_uuid(obj)
+
+def test_has_uuid_no_uuid():
+    assert not has_uuid(10)
+    assert not has_uuid('foo')
+
+@pytest.mark.parametrize('name,obj', list(all_objects.items()))
+def test_get_uuid(name, obj):
+    assert get_uuid(obj) == str(int(hash(name)))
+
+def test_get_uuid_none():
+    assert get_uuid(None) is None
+
+def test_get_uuid_error():
+    with pytest.raises(AttributeError):
+        get_uuid(10)
+
+def test_set_uuid():
+    obj = MockUUIDObject(name="test", normal_attr=10)
+    fake_uuid = 100
+    assert get_uuid(obj) != str(fake_uuid)
+    set_uuid(obj, fake_uuid)
+    assert get_uuid(obj) == str(fake_uuid)
+
+def test_encode_uuid():
+    obj = MockUUIDObject(name="test", normal_attr=10)
+    set_uuid(obj, 100)
+    assert encode_uuid("UUID(100)")
+
+

--- a/openpathsampling/experimental/simstore/type_ident.py
+++ b/openpathsampling/experimental/simstore/type_ident.py
@@ -1,7 +1,7 @@
 import re
 import numbers
 import numpy as np
-from .serialization_helpers import has_uuid
+from .uuids import has_uuid
 
 
 class TypeStringError(RuntimeError):

--- a/openpathsampling/experimental/storage/monkey_patches.py
+++ b/openpathsampling/experimental/storage/monkey_patches.py
@@ -18,6 +18,9 @@ def callable_cv_from_dict(cls, dct):
     dct.update(kwargs)
     obj = cls(**dct)
     cv_callable = obj.cv_callable
+    if callable(cv_callable):
+        return obj
+
     try:
         cv_callable['_marshal'] = cv_callable['_marshal']['bytes']
     except:


### PR DESCRIPTION
This includes several performance improvements and minor fixes for SimStore. Quick manifest:

* Added and started using `is_storage_string` and `has_storage_uuid`, which use the fast `ClassIsSomething` model to cache classes with given attributes. The normal `is_string` and `has_uuid` methods were taking a larger fraction of time than they should.
* Added default support for SQL index on UUID (which should have been there all along).
* Fix an edge case where old-style CVs were no reloaded correctly in SimStore, because the new JSON serialization was already making a callable and the code to make a callable from the marshal data was no longer needed.

This also helps clear up some of the external testing in ops-storage-notebooks which has been off for a while.