### PR TITLE
Update to use setup-miniconda v3; use miniforge

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: "3.11"
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
       - name: "Install requirements"
         run: source devtools/conda_install_reqs.sh
       - name: "Install OPS"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           fetch-depth: 2
       - uses: actions/setup-python@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with: 
           auto-update-conda: true
           python-version: ${{ matrix.CONDA_PY }}
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
       - name: "Install requirements"
         env:
           MINIMAL: ${{ matrix.MINIMAL }}


### PR DESCRIPTION
Mambaforge has been deprecated. See https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

Now miniforge is effectively identical to the old mambaforge. At the same time, I'm updating the version action we're using.