### PR TITLE
Trajectory Exports: Core and integration in `DynamicsEngine`

### DIFF
--- a/docs/developers/engines.rst
+++ b/docs/developers/engines.rst
@@ -29,4 +29,5 @@ implement engines that do not only deal with standard molecular dynamics.
     snapshot_features
     engines_direct_api
     engines_indirect_api
+    engines_trajectory_export
     advanced_engines

--- a/docs/developers/engines_trajectory_export.rst
+++ b/docs/developers/engines_trajectory_export.rst
@@ -1,0 +1,24 @@
+Trajectory Export from Engines
+==============================
+
+Users frequently want trajectories to be exported from Python into format
+that they can analyze with other tools. Since the expected trajectory format
+can differ between engines, a developer can set a default trajectory writer
+using the :meth:`._default_trajectory_writer` method. This method should
+return a callable that takes a trajectory, a filename, and the boolean flag
+``force``, where the ``force`` flag forces overwrite of an existing file (a
+``FileExistsError`` should be raised if the file exists and ``force`` is
+``False``. Note that the default writer should be lossless: output from this
+should be sufficient to perform an MD restart for, e.g., a shooting move.
+
+We recommend creating this callable as a subclass for the
+:class:`.TrajectoryWriter` class. To implement this, you only need to
+implement the :meth:`.TrajectoryWriter._write` method, which takes the
+trajectory and the filename to write to as arguments. Additional information
+that can't be extracted from the trajectory can be passed in the class
+``__init__`` method.
+
+If you do not implement :meth:`._default_trajectory_writer`, you will use
+the default from the base class, which creates a SimStore file for the
+trajectory. OPS should be able to read/write to SimStore for snapshots from
+any engine, so this will work, although it may not be convenient to users.

--- a/openpathsampling/collectivevariable.py
+++ b/openpathsampling/collectivevariable.py
@@ -57,7 +57,7 @@ class CollectiveVariable(PseudoAttribute):
             name,
             cv_time_reversible=False
     ):
-        super(CollectiveVariable, self).__init__(name, paths.BaseSnapshot)
+        super().__init__(name, paths.BaseSnapshot)
 
         self.cv_time_reversible = cv_time_reversible
         self.diskcache_allow_incomplete = not self.cv_time_reversible
@@ -207,7 +207,7 @@ class CallableCV(CollectiveVariable):
         ``mdtraj``
         """
 
-        super(CallableCV, self).__init__(
+        super().__init__(
             name,
             cv_time_reversible=cv_time_reversible
         )
@@ -323,7 +323,7 @@ class FunctionCV(CallableCV):
 
         """
 
-        super(FunctionCV, self).__init__(
+        super().__init__(
             name,
             cv_callable=f,
             cv_time_reversible=cv_time_reversible,
@@ -374,10 +374,11 @@ class CoordinateFunctionCV(FunctionCV):
         :class:`openpathsampling.collectivevariable.CallableCV`
 
         """
-
-        super(FunctionCV, self).__init__(
+        # not sure why this used to skip the parent init; all it does is
+        # rename anyway
+        super().__init__(
             name,
-            cv_callable=f,
+            f=f,
             cv_time_reversible=True,
             cv_requires_lists=cv_requires_lists,
             cv_wrap_numpy_array=cv_wrap_numpy_array,

--- a/openpathsampling/collectivevariables/plumed_wrapper.py
+++ b/openpathsampling/collectivevariables/plumed_wrapper.py
@@ -71,7 +71,7 @@ class PLUMEDCV(paths.collectivevariable.CoordinateFunctionCV):
         kwargs
         """
 
-        super(PLUMEDCV, self).__init__(
+        super().__init__(
                 name,
                 f=PLUMEDCV.compute_cv,
                 cv_requires_lists=cv_requires_lists,
@@ -184,6 +184,11 @@ class PLUMEDCV(paths.collectivevariable.CoordinateFunctionCV):
             'cv_wrap_numpy_array': self.cv_wrap_numpy_array,
             'cv_scalarize_numpy_singletons': self.cv_scalarize_numpy_singletons
         }
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(**dct)
+
 
 
 class PLUMEDInterface(StorableNamedObject):

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -10,6 +10,7 @@ import sys
 
 from openpathsampling.netcdfplus import StorableNamedObject
 from openpathsampling.integration_tools import is_simtk_unit_type
+from openpathsampling.exports.trajectories import SimStoreTrajectoryWriter
 
 from .snapshot import BaseSnapshot
 from .trajectory import Trajectory
@@ -344,7 +345,7 @@ class DynamicsEngine(StorableNamedObject):
         if writer is None:
             writer = self._default_trajectory_writer()
 
-        writer.write(trajectory, filename, force=force)
+        writer(trajectory, filename, force=force)
 
     @property
     def default_options(self):

--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -321,6 +321,31 @@ class DynamicsEngine(StorableNamedObject):
         import openpathsampling as p
         p.EngineMover.engine = self
 
+    def _default_trajectory_writer(self):
+        """Subclasses should override this to provide a default writer
+        suitable for their engine.
+
+        By default, we use the :class:`.SimStoreTrajectoryWriter`, because
+        it should be able to handle any OPS objects.
+        """
+        return SimStoreTrajectoryWriter()
+
+    def export_trajectory(self, trajectory, filename, *, writer=None,
+                          force=False):
+        """Export a trajectory to a file
+
+        Parameters
+        ----------
+        trajectory : :class:`.Trajectory`
+            the trajectory to export
+        filename : str
+            the name of the file to which to export the trajectory
+        """
+        if writer is None:
+            writer = self._default_trajectory_writer()
+
+        writer.write(trajectory, filename, force=force)
+
     @property
     def default_options(self):
         default_options = {}

--- a/openpathsampling/exports/trajectories/__init__.py
+++ b/openpathsampling/exports/trajectories/__init__.py
@@ -1,0 +1,1 @@
+from .core import TrajectoryWriter, SimStoreTrajectoryWriter

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -47,5 +47,11 @@ class SimStoreTrajectoryWriter(TrajectoryWriter):
     def _write(self, trajectory, filename):
         # TODO: maybe error if not monkey-patched?
         from openpathsampling.experimental.storage import Storage
+        from openpathsampling.experimental.storage.monkey_patch import (
+            _IS_PATCHED_SAVING
+        )
+        if not _IS_PATCHED_SAVING:
+            raise RuntimeError("SimStoreTrajectoryWriter requires the "
+                               "monkey-patch to be active")
         storage = Storage(filename, mode='w')
         storage.save(trajectory)

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -1,0 +1,51 @@
+import pathlib
+import contextlib
+import logging
+from openpathsampling.integrations import HAS_MDTRAJ
+
+import numpy as np
+
+_logger = logging.getLogger(__name__)
+
+
+class TrajectoryWriter:
+    """Base class for tools to write trajectories to extenral files.
+
+    This is essentially a wrapper for a function to write the trajectory to
+    a file. The function should take two arguments: the trajectory to write,
+    and the filename to write to.
+
+    We use an object-oriented approach here so that initialization can
+    inlude arbitrary parameters, but the interface used by other code is
+    consistent. Additionally, :meth:`__call__` is can handle some standard
+    error checking.
+    """
+    def __call__(self, trajectory, filename, force=False):
+        if not force and pathlib.Path(filename).exists():
+            raise FileExistsError(f"File {filename} already exists")
+
+        self._write(trajectory, filename)
+
+    def _write(self, trajectory, filename):
+        """Write the trajectory to the file.
+
+        Parameters
+        ----------
+        trajectory : openpathsampling.Trajectory
+            the trajectory to save
+        filename : str
+            the name of the file to save to
+        """
+        raise NotImplementedError()
+
+class SimStoreTrajectoryWriter(TrajectoryWriter):
+    """Trajectory writer that uses the OpenPathSampling storage format.
+
+    This is the default trajectory writer, since all engines should be able
+    to use it.
+    """
+    def _write(self, trajectory, filename):
+        # TODO: maybe error if not monkey-patched?
+        from openpathsampling.experimental.storage import Storage
+        storage = Storage(filename, mode='w')
+        storage.save(trajectory)

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -45,7 +45,6 @@ class SimStoreTrajectoryWriter(TrajectoryWriter):
     to use it.
     """
     def _write(self, trajectory, filename):
-        # TODO: maybe error if not monkey-patched?
         from openpathsampling.experimental.storage import Storage
         from openpathsampling.experimental.storage.monkey_patches import (
             _IS_PATCHED_SAVING

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -1,7 +1,7 @@
 import pathlib
 import contextlib
 import logging
-from openpathsampling.integrations import HAS_MDTRAJ
+from openpathsampling.integration_tools import HAS_MDTRAJ
 
 import numpy as np
 

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -47,7 +47,7 @@ class SimStoreTrajectoryWriter(TrajectoryWriter):
     def _write(self, trajectory, filename):
         # TODO: maybe error if not monkey-patched?
         from openpathsampling.experimental.storage import Storage
-        from openpathsampling.experimental.storage.monkey_patch import (
+        from openpathsampling.experimental.storage.monkey_patches import (
             _IS_PATCHED_SAVING
         )
         if not _IS_PATCHED_SAVING:

--- a/openpathsampling/tests/exports/trajectories/test_core.py
+++ b/openpathsampling/tests/exports/trajectories/test_core.py
@@ -130,3 +130,8 @@ class TestSimStoreTrajectoryWriter(TrajectoryWriterTestBase):
                                                  tmp_path / "test.db")
         finally:
             monkey_patches.unpatch(paths)
+
+    def test_call_not_patched_fail(self, request, tmp_path):
+        trajectory = request.getfixturevalue("ad_trajectory")
+        with pytest.raises(RuntimeError, match="monkey-patch"):
+            self.writer(trajectory, tmp_path / "test.db")

--- a/openpathsampling/tests/exports/trajectories/test_core.py
+++ b/openpathsampling/tests/exports/trajectories/test_core.py
@@ -1,0 +1,117 @@
+from openpathsampling.exports.trajectories import *
+
+from openpathsampling.tests.test_helpers import (
+    data_filename, make_1d_traj
+)
+import openpathsampling as paths
+
+import pytest
+import pathlib
+
+
+@pytest.fixture
+def _ad_gmx_engine():
+    engine = paths.engines.gromacs.Engine(
+        gro="conf.gro",
+        mdp="md.mdp",
+        top="topol.top",
+        options = {
+            'mdrun_args': '-nt 1',
+            'grompp_args': '-maxwarn 2',
+        },
+        base_dir=data_filename("gromacs_engine"),
+        prefix="project"
+    )
+    return engine
+
+
+@pytest.fixture
+def ad_trajpath():
+    test_dir = pathlib.Path(data_filename("gromacs_engine"))
+    trajfile = test_dir / "project_trr/0000000.trr"
+    return trajfile
+
+
+@pytest.fixture
+def ad_trajectory(ad_trajpath, _ad_gmx_engine):
+    traj = paths.Trajectory([
+        _ad_gmx_engine.read_frame_from_file(str(ad_trajpath), i)
+        for i in [0, 1, 2]
+    ])
+    return traj
+
+
+@pytest.fixture
+def toy_trajectory():
+    return make_1d_traj([1.0, 2.0, 3.0])
+
+
+class TrajectoryWriterTestBase:
+    def _read_trajectory(self, filename):
+        raise NotImplementedError()
+
+    def _test_trajectory(self, trajectory, outfile):
+        assert not outfile.exists()
+        self.writer(trajectory, outfile)
+        assert outfile.exists()
+
+        traj = self._read_trajectory(outfile)
+        assert len(traj) == len(trajectory)
+        assert traj == trajectory
+
+    def _test_call_outfile_exists(self, trajectory, outfile):
+        outfile.touch()
+        with pytest.raises(FileExistsError):
+            self.writer(trajectory, outfile)
+
+    def _test_call_outfile_exists_force(self, trajectory, outfile):
+        outfile.touch()
+        assert outfile.exists()
+        assert len(outfile.read_bytes()) == 0
+        self.writer(trajectory, outfile, force=True)
+        assert outfile.exists()
+        assert len(outfile.read_bytes()) > 0
+
+    def test_call(self, trajectory_fixture, request, tmp_path):
+        raise NotImplementedError()
+
+    def test_call_outfile_exists(self, request, tmp_path):
+        raise NotImplementedError()
+
+    def test_call_outfile_exists_force(self, request, tmp_path):
+        raise NotImplementedError()
+
+
+class TestSimStoreTrajectoryWriter(TrajectoryWriterTestBase):
+    def setup_method(self):
+        self.writer = SimStoreTrajectoryWriter()
+
+    def _read_trajectory(self, filename):
+        from openpathsampling.experimental.storage import Storage
+        storage = Storage(filename, mode='r')
+        return storage.trajectories[0]
+
+    @pytest.mark.parametrize("trajectory_fixture", [
+        "ad_trajectory",
+        "toy_trajectory",
+    ])
+    def test_call(self, trajectory_fixture, request, tmp_path):
+        # monkey patch for SimStore
+        trajectory = request.getfixturevalue(trajectory_fixture)
+        import openpathsampling as paths
+        from openpathsampling.experimental.storage import monkey_patches
+        paths = monkey_patches.monkey_patch_all(paths)
+
+        outfile = tmp_path / f"{trajectory_fixture}.nc"
+        self._test_trajectory(trajectory, outfile)
+
+        # undo the monkey patch
+        monkey_patches.unpatch(paths)
+
+    def test_call_outfile_exists(self, request, tmp_path):
+        trajectory = request.getfixturevalue("ad_trajectory")
+        self._test_call_outfile_exists(trajectory, tmp_path / "test.db")
+
+    def test_call_outfile_exists_force(self, request, tmp_path):
+        trajectory = request.getfixturevalue("ad_trajectory")
+        self._test_call_outfile_exists_force(trajectory, tmp_path / "test.db")

--- a/openpathsampling/tests/exports/trajectories/test_core.py
+++ b/openpathsampling/tests/exports/trajectories/test_core.py
@@ -102,16 +102,31 @@ class TestSimStoreTrajectoryWriter(TrajectoryWriterTestBase):
         from openpathsampling.experimental.storage import monkey_patches
         paths = monkey_patches.monkey_patch_all(paths)
 
-        outfile = tmp_path / f"{trajectory_fixture}.nc"
-        self._test_trajectory(trajectory, outfile)
-
-        # undo the monkey patch
-        monkey_patches.unpatch(paths)
+        try:
+            outfile = tmp_path / f"{trajectory_fixture}.nc"
+            self._test_trajectory(trajectory, outfile)
+        finally:
+            # undo the monkey patch
+            monkey_patches.unpatch(paths)
 
     def test_call_outfile_exists(self, request, tmp_path):
         trajectory = request.getfixturevalue("ad_trajectory")
-        self._test_call_outfile_exists(trajectory, tmp_path / "test.db")
+        import openpathsampling as paths
+        from openpathsampling.experimental.storage import monkey_patches
+        paths = monkey_patches.monkey_patch_all(paths)
+
+        try:
+            self._test_call_outfile_exists(trajectory, tmp_path / "test.db")
+        finally:
+            monkey_patches.unpatch(paths)
 
     def test_call_outfile_exists_force(self, request, tmp_path):
         trajectory = request.getfixturevalue("ad_trajectory")
-        self._test_call_outfile_exists_force(trajectory, tmp_path / "test.db")
+        import openpathsampling as paths
+        from openpathsampling.experimental.storage import monkey_patches
+        paths = monkey_patches.monkey_patch_all(paths)
+        try:
+            self._test_call_outfile_exists_force(trajectory,
+                                                 tmp_path / "test.db")
+        finally:
+            monkey_patches.unpatch(paths)

--- a/openpathsampling/tests/test_external_engine.py
+++ b/openpathsampling/tests/test_external_engine.py
@@ -138,6 +138,7 @@ class TestExternalEngine(object):
         self.ensemble = paths.LengthEnsemble(5)
 
     def test_deprecation(self):
+        NEW_DEFAULT_FILENAME_SETTER.has_warned = False
         slow_options = {'n_frames_max': 10000,
                         'engine_sleep': 100,
                         'name_prefix': "test",

--- a/openpathsampling/tests/test_pathmover.py
+++ b/openpathsampling/tests/test_pathmover.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 
 import openpathsampling as paths
-from openpathsampling.collectivevariable import FunctionCV
 from openpathsampling.engines.trajectory import Trajectory
 from openpathsampling.ensemble import LengthEnsemble
 from openpathsampling.pathmover import *
@@ -128,7 +127,7 @@ class TestShootingMover(object):
     def setup_method(self):
         self.dyn = CalvinistDynamics([-0.1, 0.1, 0.3, 0.5, 0.7,
                                       -0.1, 0.2, 0.4, 0.6, 0.8])
-        op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
+        op = paths.FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
         self.stateA = CVDefinedVolume(op, -100, 0.0)
         self.stateB = CVDefinedVolume(op, 0.65, 100)
         self.tps = A2BEnsemble(self.stateA, self.stateB)
@@ -509,7 +508,7 @@ class TestTwoWayShootingMover(TestShootingMover):
 
 class TestPathReversalMover(object):
     def setup_method(self):
-        op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
+        op = paths.FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
 
         volA = CVDefinedVolume(op, -100, 0.0)
         volB = CVDefinedVolume(op, 1.0, 100)
@@ -576,7 +575,7 @@ class TestReplicaIDChangeMover(object):
 
 class TestReplicaExchangeMover(object):
     def setup_method(self):
-        op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
+        op = paths.FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
 
         state1 = CVDefinedVolume(op, -100, 0.0)
         state2 = CVDefinedVolume(op, 1, 100)
@@ -724,7 +723,7 @@ class TestRandomAllowedChoiceMover(object):
                                       ])
         self.dyn.initialized = True
         # SampleMover.engine = self.dyn
-        op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
+        op = paths.FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
         stateA = CVDefinedVolume(op, -100, 0.0)
         stateB = CVDefinedVolume(op, 0.65, 100)
         volX = CVDefinedVolume(op, -100, 0.25)
@@ -1176,7 +1175,7 @@ class TestFinalSubtrajectorySelectMover(SubtrajectorySelectTester):
 
 class TestMinusMover(object):
     def setup_method(self):
-        op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
+        op = paths.FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
         volA = CVDefinedVolume(op, -100, 0.0)
         volB = CVDefinedVolume(op, 1.0, 100)
         volX = CVDefinedVolume(op, -100, 0.25)
@@ -1410,7 +1409,7 @@ class TestMinusMover(object):
 
 class TestSingleReplicaMinusMover(object):
     def setup_method(self):
-        op = FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
+        op = paths.FunctionCV("myid", f=lambda snap: snap.coordinates[0][0])
         volA = CVDefinedVolume(op, -100, 0.0)
         volB = CVDefinedVolume(op, 1.0, 100)
         volX = CVDefinedVolume(op, -100, 0.25)


### PR DESCRIPTION
One of the major things that came out of the path sampling software meeting in Leiden in September 2024 was a desire for OPS to export trajectories more easily into formats that people are more familiar with.

In this PR, I'm starting to add functionality for external trajectory export. The eventual goal is that you'll be able to export a trajectory using `engine.export_trajectory(trajectory, filename)`. That method will take an optional `writer` parameter that takes a callable to perform the actual output. This allows a single unified interface from the user perspective, but allows individual callable (as, e.g., instances of a class) to handle details of implementation; for example, allowing lossy output while defaulting to lossless. Different engines can also have different default trajectory writers.

This PR will add support for this in the base `DynamicsEngine` class, where the `_default_trajectory_writer` will return a `SimStoreTrajectoryWriter`, since all engines should be able to export in that format. A future PR will add better support for OpenMM and Gromacs engines, as well as lossy output using MDTraj.

- [x] `SimStoreTrajectoryWriter`
- [x] Tests for `SimStoreTrajectoryWriter`
- [x] `DynamicsEngine.export_trajectory`
- [x] Tests for `DynamicsEngine.export_trajectory`
- [x] Add to developer docs to explain this to engine developers.

Overall plan:
1. **This PR**: Add support for core functionality and defaults for SimStore exports.
2. Upcoming PR: Add support for TRR export for Gromacs and OpenMM engines (as defaults for those engines). Add support for MDTraj-based export for lossy exports.
3. Later PR: Add support to export a list of `MCStep`s, using a given `TrajectoryWriter` and some definition of where to store step information.
4. Later PR: Add new type of storage (based on SimStore) that uses lossless external trajectory storage for snapshot data storage.