### PR TITLE
Trajectory Exports: MDTraj and TRR formats; Gromacs and OpenMM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ target/
 
 # IPython
 .ipynb_checkpoints
+
+# pixi environments
+.pixi
+*.egg-info

--- a/openpathsampling/engines/gromacs/engine.py
+++ b/openpathsampling/engines/gromacs/engine.py
@@ -20,6 +20,7 @@ from openpathsampling.engines.topology import MDTrajTopology
 from openpathsampling.engines.external_snapshots import \
         ExternalMDSnapshot, InternalizedMDSnapshot
 from openpathsampling.tools import ensure_file
+from openpathsampling.exports.trajectories import TRRTrajectoryWriter
 
 import os
 import psutil
@@ -185,6 +186,9 @@ class GromacsEngine(ExternalEngine):
 
         super(GromacsEngine, self).__init__(options, descriptor, template,
                                              first_frame_in_file=True)
+
+    def _default_trajectory_writer(self):
+        return TRRTrajectoryWriter()
 
     def to_dict(self):
         dct = super(GromacsEngine, self).to_dict()

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -5,6 +5,7 @@ from openpathsampling.integration_tools import unit as u
 
 from openpathsampling.engines import DynamicsEngine, SnapshotDescriptor
 from openpathsampling.engines.openmm import tools
+from openpathsampling.exports.trajectories import TRRTrajectoryWriter
 from .snapshot import Snapshot
 import numpy as np
 
@@ -256,6 +257,9 @@ class OpenMMEngine(DynamicsEngine):
         if self._simulation is not None:
             del self._simulation.context
             self._simulation = None
+
+    def _default_trajectory_writer(self):
+        return TRRTrajectoryWriter()
 
     def initialize(self, platform=None):
         """

--- a/openpathsampling/exports/trajectories/__init__.py
+++ b/openpathsampling/exports/trajectories/__init__.py
@@ -1,1 +1,3 @@
 from .core import TrajectoryWriter, SimStoreTrajectoryWriter
+from .trrtrajectorywriter import TRRTrajectoryWriter
+from .mdtrajtrajectorywriter import MDTrajTrajectoryWriter

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -1,7 +1,6 @@
 import pathlib
 import contextlib
 import logging
-from openpathsampling.integration_tools import HAS_MDTRAJ
 
 import numpy as np
 

--- a/openpathsampling/exports/trajectories/mdtrajtrajectorywriter.py
+++ b/openpathsampling/exports/trajectories/mdtrajtrajectorywriter.py
@@ -14,22 +14,23 @@ class MDTrajTrajectoryWriter(TrajectoryWriter):
             raise ImportError("MDTraj is not available")
 
         self.mdtraj_selection = mdtraj_selection
+        self._sel = None  # the actual atom indices of selection
 
     def _write(self, trajectory, filename):
         mdt = trajectory.to_mdtraj()
 
-        sel = None
-        if isinstance(self.mdtraj_selection, str):
-            sel = mdt.topology.select(self.mdtraj_selection)
-        elif isinstance(self.mdtraj_selection, Iterable):
-            sel = list(self.mdtraj_selection)
-        elif self.mdtraj_selection is None:
-            pass
-        else:
-            raise TypeError("mdtraj_selection must be a string or an "
-                            f"iterable; got '{self.mdtraj_selection}'")
+        if self._sel is None:
+            if self.mdtraj_selection is None:
+                pass
+            elif isinstance(self.mdtraj_selection, str):
+                self._sel = mdt.topology.select(self.mdtraj_selection)
+            elif isinstance(self.mdtraj_selection, Iterable):
+                self._sel = list(self.mdtraj_selection)
+            else:
+                raise TypeError("mdtraj_selection must be a string or an "
+                                f"iterable; got '{self.mdtraj_selection}'")
 
-        if sel is not None:
-            mdt = mdt.atom_slice(sel)
+        if self._sel is not None:
+            mdt = mdt.atom_slice(self._sel)
 
         mdt.save(filename)

--- a/openpathsampling/exports/trajectories/mdtrajtrajectorywriter.py
+++ b/openpathsampling/exports/trajectories/mdtrajtrajectorywriter.py
@@ -14,23 +14,22 @@ class MDTrajTrajectoryWriter(TrajectoryWriter):
             raise ImportError("MDTraj is not available")
 
         self.mdtraj_selection = mdtraj_selection
-        self._sel = None  # the actual atom indices of selection
 
     def _write(self, trajectory, filename):
         mdt = trajectory.to_mdtraj()
 
-        if self._sel is None:
-            if self.mdtraj_selection is None:
-                pass
-            elif isinstance(self.mdtraj_selection, str):
-                self._sel = mdt.topology.select(self.mdtraj_selection)
-            elif isinstance(self.mdtraj_selection, Iterable):
-                self._sel = list(self.mdtraj_selection)
-            else:
-                raise TypeError("mdtraj_selection must be a string or an "
-                                f"iterable; got '{self.mdtraj_selection}'")
+        sel = None
+        if isinstance(self.mdtraj_selection, str):
+            sel = mdt.topology.select(self.mdtraj_selection)
+        elif isinstance(self.mdtraj_selection, Iterable):
+            sel = list(self.mdtraj_selection)
+        elif self.mdtraj_selection is None:
+            pass
+        else:
+            raise TypeError("mdtraj_selection must be a string or an "
+                            f"iterable; got '{self.mdtraj_selection}'")
 
-        if self._sel is not None:
-            mdt = mdt.atom_slice(self._sel)
+        if sel is not None:
+            mdt = mdt.atom_slice(sel)
 
         mdt.save(filename)

--- a/openpathsampling/exports/trajectories/mdtrajtrajectorywriter.py
+++ b/openpathsampling/exports/trajectories/mdtrajtrajectorywriter.py
@@ -1,0 +1,35 @@
+from .core import TrajectoryWriter
+from openpathsampling.integration_tools import HAS_MDTRAJ
+from collections.abc import Iterable
+
+
+class MDTrajTrajectoryWriter(TrajectoryWriter):
+    """Generic save to MDTraj.
+
+    Note that this will not include velocities, and therefore isn't suitable
+    for saving data that could be used in a restart.
+    """
+    def __init__(self, mdtraj_selection=None):
+        if not HAS_MDTRAJ:  # -no-cov-
+            raise ImportError("MDTraj is not available")
+
+        self.mdtraj_selection = mdtraj_selection
+
+    def _write(self, trajectory, filename):
+        mdt = trajectory.to_mdtraj()
+
+        sel = None
+        if isinstance(self.mdtraj_selection, str):
+            sel = mdt.topology.select(self.mdtraj_selection)
+        elif isinstance(self.mdtraj_selection, Iterable):
+            sel = list(self.mdtraj_selection)
+        elif self.mdtraj_selection is None:
+            pass
+        else:
+            raise TypeError("mdtraj_selection must be a string or an "
+                            f"iterable; got '{self.mdtraj_selection}'")
+
+        if sel is not None:
+            mdt = mdt.atom_slice(sel)
+
+        mdt.save(filename)

--- a/openpathsampling/exports/trajectories/trrtrajectorywriter.py
+++ b/openpathsampling/exports/trajectories/trrtrajectorywriter.py
@@ -1,0 +1,26 @@
+from openpathsampling.integration_tools import HAS_MDTRAJ
+import numpy as np
+from .core import TrajectoryWriter
+
+class TRRTrajectoryWriter(TrajectoryWriter):
+    """Write a trajectory to a Gromacs TRR file.
+
+    This inludes velocities, so it can be used for restarts.
+    """
+    def __init__(self):
+        if not HAS_MDTRAJ:  # -no-cov-
+            raise ImportError("MDTraj is not available")
+
+    def _write(self, trajectory, filename):
+        # this uses some "unofficial" MDTraj API
+        import mdtraj as md
+        nframes = len(trajectory)
+        xyz = np.asarray(trajectory.xyz, dtype=np.float32)
+        time = np.asarray([0.0]*nframes, dtype=np.float32)
+        box = np.asarray(trajectory.box_vectors, dtype=np.float32)
+        lambd = np.asarray([0.0]*nframes, dtype=np.float32)
+        vel = np.asarray(trajectory.velocities, dtype=np.float32)
+        trr = md.formats.TRRTrajectoryFile(str(filename), 'w')
+        step = np.arange(0, nframes, dtype=np.int32)
+        trr._write(xyz, time, step, box, lambd, vel)
+        trr.close()

--- a/openpathsampling/tests/exports/trajectories/conftest.py
+++ b/openpathsampling/tests/exports/trajectories/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+import pathlib
+from openpathsampling.tests.test_helpers import data_filename
+import openpathsampling as paths
+
+@pytest.fixture
+def ad_trajpath():
+    test_dir = pathlib.Path(data_filename("gromacs_engine"))
+    trajfile = test_dir / "project_trr/0000000.trr"
+    return trajfile
+
+@pytest.fixture
+def ad_grofile():
+    test_dir = pathlib.Path(data_filename("gromacs_engine"))
+    topfile = test_dir / "conf.gro"
+    return str(topfile)
+
+
+@pytest.fixture
+def ad_trajectory(ad_trajpath):
+    engine = paths.engines.gromacs.Engine(
+        gro="conf.gro",
+        mdp="md.mdp",
+        top="topol.top",
+        options = {
+            'mdrun_args': '-nt 1',
+            'grompp_args': '-maxwarn 2',
+        },
+        base_dir=data_filename("gromacs_engine"),
+        prefix="project"
+    )
+
+    traj = paths.Trajectory([
+        engine.read_frame_from_file(str(ad_trajpath), i)
+        for i in [0, 1, 2]
+    ])
+    return traj

--- a/openpathsampling/tests/exports/trajectories/test_core.py
+++ b/openpathsampling/tests/exports/trajectories/test_core.py
@@ -10,38 +10,6 @@ import pathlib
 
 
 @pytest.fixture
-def _ad_gmx_engine():
-    engine = paths.engines.gromacs.Engine(
-        gro="conf.gro",
-        mdp="md.mdp",
-        top="topol.top",
-        options = {
-            'mdrun_args': '-nt 1',
-            'grompp_args': '-maxwarn 2',
-        },
-        base_dir=data_filename("gromacs_engine"),
-        prefix="project"
-    )
-    return engine
-
-
-@pytest.fixture
-def ad_trajpath():
-    test_dir = pathlib.Path(data_filename("gromacs_engine"))
-    trajfile = test_dir / "project_trr/0000000.trr"
-    return trajfile
-
-
-@pytest.fixture
-def ad_trajectory(ad_trajpath, _ad_gmx_engine):
-    traj = paths.Trajectory([
-        _ad_gmx_engine.read_frame_from_file(str(ad_trajpath), i)
-        for i in [0, 1, 2]
-    ])
-    return traj
-
-
-@pytest.fixture
 def toy_trajectory():
     return make_1d_traj([1.0, 2.0, 3.0])
 

--- a/openpathsampling/tests/exports/trajectories/test_mdtrajtrajectorywriter.py
+++ b/openpathsampling/tests/exports/trajectories/test_mdtrajtrajectorywriter.py
@@ -1,0 +1,63 @@
+import pytest
+
+from openpathsampling.exports.trajectories.mdtrajtrajectorywriter import *
+from openpathsampling.integration_tools import HAS_MDTRAJ
+import numpy.testing as npt
+
+def test_mdtraj_trajectory_writer(ad_trajectory, ad_grofile, tmp_path):
+    if not HAS_MDTRAJ:
+        pytest.skip("mdtraj is not available")
+
+    import mdtraj as md
+    outfile = tmp_path / "test.xtc"
+    writer = MDTrajTrajectoryWriter()
+    assert not outfile.exists()
+    writer(ad_trajectory, outfile)
+    assert outfile.exists()
+
+    reloaded = md.load(str(outfile), top=ad_grofile)
+    assert len(reloaded) == len(ad_trajectory)
+    assert reloaded.xyz.shape == ad_trajectory.xyz.shape
+    npt.assert_allclose(reloaded.xyz, ad_trajectory.xyz, atol=1e-3)
+
+
+@pytest.mark.parametrize("selection", [
+    "backbone", 
+    [4,  5,  6,  8, 14, 15, 16, 18]
+])
+def test_subtrajectory_selection(ad_trajectory, selection, tmp_path):
+    if not HAS_MDTRAJ:
+        pytest.skip("mdtraj is not available")
+
+    import mdtraj as md
+    outfile = tmp_path / "test.xtc"
+    writer = MDTrajTrajectoryWriter(mdtraj_selection=selection)
+    assert not outfile.exists()
+    writer(ad_trajectory, outfile)
+    assert outfile.exists()
+
+    # save file for the modified topology
+    mdt = ad_trajectory.to_mdtraj()
+    if isinstance(selection, str):
+        subset = mdt.topology.select(selection)
+    else:
+        subset = selection
+
+    subtraj = mdt.atom_slice(subset)
+    subgro = tmp_path / "subset.gro"
+    subtraj[0].save(str(subgro))
+
+    reloaded = md.load(str(outfile), top=subgro)
+    assert len(reloaded) == len(ad_trajectory)
+    assert reloaded.xyz.shape == subtraj.xyz.shape
+    assert reloaded.xyz.shape != ad_trajectory.xyz.shape
+    npt.assert_allclose(reloaded.xyz, subtraj.xyz, atol=1e-3)
+
+
+def test_mdtraj_trajectory_writer_selection_error(ad_trajectory, tmp_path):
+    if not HAS_MDTRAJ:
+        pytest.skip("mdtraj is not available")
+
+    writer = MDTrajTrajectoryWriter(mdtraj_selection=object())
+    with pytest.raises(TypeError):
+        writer(ad_trajectory, tmp_path / "test.xtc")

--- a/openpathsampling/tests/exports/trajectories/test_trrtrajectorywriter.py
+++ b/openpathsampling/tests/exports/trajectories/test_trrtrajectorywriter.py
@@ -1,0 +1,30 @@
+import pytest
+
+from openpathsampling.exports.trajectories.trrtrajectorywriter import *
+from openpathsampling.integration_tools import HAS_MDTRAJ
+import numpy.testing as npt
+
+def test_trr_trajectory_writer(ad_trajectory, tmp_path):
+    if not HAS_MDTRAJ:
+        pytest.skip("mdtraj is not available")
+
+    import mdtraj as md
+    outfile = tmp_path / "test.trr"
+    writer = TRRTrajectoryWriter()
+    assert not outfile.exists()
+    writer(ad_trajectory, outfile)
+    assert outfile.exists()
+
+    trr = md.formats.TRRTrajectoryFile(str(outfile), mode='r')
+    xyz, time, step, box, lambd, vel, forces = trr._read(
+        int(len(ad_trajectory)),
+        atom_indices=None,
+        get_velocities=True,
+    )
+
+    assert forces is None
+    npt.assert_allclose(xyz, ad_trajectory.xyz)
+    npt.assert_allclose(vel, ad_trajectory.velocities)
+    npt.assert_allclose(box, ad_trajectory.box_vectors)
+    npt.assert_allclose(lambd, np.zeros(len(ad_trajectory)))
+    npt.assert_allclose(time, np.zeros(len(ad_trajectory)))


### PR DESCRIPTION
Add support in OpenMM and Gromacs engines to export trajectories. This includes lossless export (as TRR) and lossy export (via MDTraj, where the export format will be determined from the filename). We use TRR format as the default lossless format for both OpenMM and Gromacs.

- [x] Lossless: TRRTrajectoryWriter
- [x] Tests for TRRTrajectoryWriter
- [x] Lossy: MDTrajTrajectoryWriter
- [x] Tests for MDTrajTrajectoryWriter
- [x] OpenMMEngine._default_trajectory_writer and tests for OpenMMEngine.export_trajectories
- [x] GromacsEngine._default_trajectory_writer and tests for GromacsEngine.export_trajectories

Overall plan:

* Add support for core functionality and defaults for SimStore exports. (#1170)
* **This PR**: Add support for TRR export for Gromacs and OpenMM engines (as defaults for those engines). Add support for MDTraj-based export for lossy exports.
* Later PR: Add support to export a list of MCSteps, using a given TrajectoryWriter and some definition of where to store step information.
* Later PR: Add new type of storage (based on SimStore) that uses lossless external trajectory storage for snapshot data storage.