### PR TITLE
Drop numpy pin

### DIFF
--- a/examples/tests/test_cv.ipynb
+++ b/examples/tests/test_cv.ipynb
@@ -115,7 +115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "283860163354172696480456782077640048652\n"
+      "306465958118793424807025199580056649754\n"
      ]
     }
    ],
@@ -141,7 +141,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048654L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048656L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048658L), (store.attributes[PseudoAttribute] : 4 object(s), 20, 283860163354172696480456782077640048660L)]\n"
+      "[(store.attributes[PseudoAttribute] : 4 object(s), 20, 306465958118793424807025199580056649756), (store.attributes[PseudoAttribute] : 4 object(s), 20, 306465958118793424807025199580056649758), (store.attributes[PseudoAttribute] : 4 object(s), 20, 306465958118793424807025199580056649760), (store.attributes[PseudoAttribute] : 4 object(s), 20, 306465958118793424807025199580056649762)]\n"
      ]
     }
    ],
@@ -159,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{283860163354172696480456782077640048656L: 1, 283860163354172696480456782077640048658L: 2, 283860163354172696480456782077640048660L: 3, 283860163354172696480456782077640048654L: 0}\n"
+      "{306465958118793424807025199580056649756: 0, 306465958118793424807025199580056649758: 1, 306465958118793424807025199580056649760: 2, 306465958118793424807025199580056649762: 3}\n"
      ]
     }
    ],
@@ -267,7 +267,7 @@
      "output_type": "stream",
      "text": [
       "[10.0, 10.0]\n",
-      "[3.3921003341674805, 3.3921003341674805]\n"
+      "[np.float32(3.3921003), np.float32(3.3921003)]\n"
      ]
     }
    ],
@@ -285,10 +285,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<type 'list'>\n",
-      "<type 'float'>\n",
-      "<type 'list'>\n",
-      "<type 'numpy.float64'>\n"
+      "<class 'list'>\n",
+      "<class 'float'>\n",
+      "<class 'list'>\n",
+      "<class 'numpy.float32'>\n"
      ]
     }
    ],
@@ -309,10 +309,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'{\"_cls\":\"CollectiveVariable\",\"_dict\":{\"cv_time_reversible\":false,\"name\":\"func0\"}}'\n",
-      " u'{\"_cls\":\"FunctionCV\",\"_dict\":{\"name\":\"func1\",\"f\":{\"_marshal\":\"YwMAAAADAAAAAwAAAEMAAQBzGwAAAHwCAGoAAHwAAGoBAGoCAGQBABmDAQB8AQAYUygCAAAATmkAAAAAKAMAAAB0AwAAAHN1bXQLAAAAY29vcmRpbmF0ZXN0BgAAAF92YWx1ZSgDAAAAdAgAAABzbmFwc2hvdHQGAAAAY2VudGVydAIAAABucCgAAAAAKAAAAABzHgAAADxpcHl0aG9uLWlucHV0LTUtNzlhNzEwNDZhYjU1PnQEAAAAZGlzdAIAAABzAgAAAAAB\",\"_module_vars\":[],\"_global_vars\":[]},\"cv_time_reversible\":false,\"cv_wrap_numpy_array\":false,\"cv_requires_lists\":false,\"cv_scalarize_numpy_singletons\":false,\"kwargs\":{\"np\":{\"_import\":\"numpy\"},\"center\":1}}}'\n",
-      " u'{\"_cls\":\"FunctionCV\",\"_dict\":{\"name\":\"func2\",\"f\":{\"_marshal\":\"YwMAAAADAAAAAwAAAEMAAQBzGwAAAHwCAGoAAHwAAGoBAGoCAGQBABmDAQB8AQAYUygCAAAATmkAAAAAKAMAAAB0AwAAAHN1bXQLAAAAY29vcmRpbmF0ZXN0BgAAAF92YWx1ZSgDAAAAdAgAAABzbmFwc2hvdHQGAAAAY2VudGVydAIAAABucCgAAAAAKAAAAABzHgAAADxpcHl0aG9uLWlucHV0LTUtNzlhNzEwNDZhYjU1PnQEAAAAZGlzdAIAAABzAgAAAAAB\",\"_module_vars\":[],\"_global_vars\":[]},\"cv_time_reversible\":false,\"cv_wrap_numpy_array\":true,\"cv_requires_lists\":false,\"cv_scalarize_numpy_singletons\":false,\"kwargs\":{\"np\":{\"_import\":\"numpy\"},\"center\":1}}}'\n",
-      " u'{\"_cls\":\"FunctionCV\",\"_dict\":{\"name\":\"func3\",\"f\":{\"_marshal\":\"YwMAAAADAAAAAwAAAEMAAQBzGwAAAHwCAGoAAHwAAGoBAGoCAGQBABmDAQB8AQAYUygCAAAATmkAAAAAKAMAAAB0AwAAAHN1bXQLAAAAY29vcmRpbmF0ZXN0BgAAAF92YWx1ZSgDAAAAdAgAAABzbmFwc2hvdHQGAAAAY2VudGVydAIAAABucCgAAAAAKAAAAABzHgAAADxpcHl0aG9uLWlucHV0LTUtNzlhNzEwNDZhYjU1PnQEAAAAZGlzdAIAAABzAgAAAAAB\",\"_module_vars\":[],\"_global_vars\":[]},\"cv_time_reversible\":true,\"cv_wrap_numpy_array\":true,\"cv_requires_lists\":false,\"cv_scalarize_numpy_singletons\":false,\"kwargs\":{\"np\":{\"_import\":\"numpy\"},\"center\":1}}}']\n"
+      "['{\"_cls\":\"CollectiveVariable\",\"_dict\":{\"name\":\"func0\",\"cv_time_reversible\":false}}'\n",
+      " '{\"_cls\":\"FunctionCV\",\"_dict\":{\"name\":\"func1\",\"cv_time_reversible\":false,\"f\":{\"__callable_name__\":\"dist\",\"_dilled\":\"gASVpgEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\\\\nX2NvZGWUk5QoQwICAZRLA0sASwBLA0sESwNDUpcAfAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAfABq\\\\nAQAAAAAAAAAAagIAAAAAAAAAAGQBGQAAAAAAAAAAAKYBAACrAQAAAAAAAAAAfAF6CgAAUwCUTksA\\\\nhpSMA3N1bZSMC2Nvb3JkaW5hdGVzlIwGX3ZhbHVllIeUjAhzbmFwc2hvdJSMBmNlbnRlcpSMAm5w\\\\nlIeUjE4vdmFyL2ZvbGRlcnMvdmovMjhjMTA3NDk2c3E1ejR5MTByano1Z2RtMDAwMGduL1QvaXB5\\\\na2VybmVsXzk2Mjk5LzQxODQ5NTE0NDUucHmUjARkaXN0lGgRSwJDJIAA2AsNjzaKNpAo1BIm1BIt\\\\nqGHUEjDRCzHUCzGwRtELOtAEOpRDAJQpKXSUUpR9lIwIX19uYW1lX1+UjAhfX21haW5fX5RzaBFO\\\\nTnSUUpR9lH2UjA9fX2Fubm90YXRpb25zX1+UfZRzhpRiLg==\\\\n\"},\"cv_requires_lists\":false,\"cv_wrap_numpy_array\":false,\"cv_scalarize_numpy_singletons\":false,\"kwargs\":{\"center\":1,\"np\":{\"_import\":\"numpy\"}}}}'\n",
+      " '{\"_cls\":\"FunctionCV\",\"_dict\":{\"name\":\"func2\",\"cv_time_reversible\":false,\"f\":{\"__callable_name__\":\"dist\",\"_dilled\":\"gASVpgEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\\\\nX2NvZGWUk5QoQwICAZRLA0sASwBLA0sESwNDUpcAfAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAfABq\\\\nAQAAAAAAAAAAagIAAAAAAAAAAGQBGQAAAAAAAAAAAKYBAACrAQAAAAAAAAAAfAF6CgAAUwCUTksA\\\\nhpSMA3N1bZSMC2Nvb3JkaW5hdGVzlIwGX3ZhbHVllIeUjAhzbmFwc2hvdJSMBmNlbnRlcpSMAm5w\\\\nlIeUjE4vdmFyL2ZvbGRlcnMvdmovMjhjMTA3NDk2c3E1ejR5MTByano1Z2RtMDAwMGduL1QvaXB5\\\\na2VybmVsXzk2Mjk5LzQxODQ5NTE0NDUucHmUjARkaXN0lGgRSwJDJIAA2AsNjzaKNpAo1BIm1BIt\\\\nqGHUEjDRCzHUCzGwRtELOtAEOpRDAJQpKXSUUpR9lIwIX19uYW1lX1+UjAhfX21haW5fX5RzaBFO\\\\nTnSUUpR9lH2UjA9fX2Fubm90YXRpb25zX1+UfZRzhpRiLg==\\\\n\"},\"cv_requires_lists\":false,\"cv_wrap_numpy_array\":true,\"cv_scalarize_numpy_singletons\":false,\"kwargs\":{\"center\":1,\"np\":{\"_import\":\"numpy\"}}}}'\n",
+      " '{\"_cls\":\"FunctionCV\",\"_dict\":{\"name\":\"func3\",\"cv_time_reversible\":true,\"f\":{\"__callable_name__\":\"dist\",\"_dilled\":\"gASVpgEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\\\\nX2NvZGWUk5QoQwICAZRLA0sASwBLA0sESwNDUpcAfAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAfABq\\\\nAQAAAAAAAAAAagIAAAAAAAAAAGQBGQAAAAAAAAAAAKYBAACrAQAAAAAAAAAAfAF6CgAAUwCUTksA\\\\nhpSMA3N1bZSMC2Nvb3JkaW5hdGVzlIwGX3ZhbHVllIeUjAhzbmFwc2hvdJSMBmNlbnRlcpSMAm5w\\\\nlIeUjE4vdmFyL2ZvbGRlcnMvdmovMjhjMTA3NDk2c3E1ejR5MTByano1Z2RtMDAwMGduL1QvaXB5\\\\na2VybmVsXzk2Mjk5LzQxODQ5NTE0NDUucHmUjARkaXN0lGgRSwJDJIAA2AsNjzaKNpAo1BIm1BIt\\\\nqGHUEjDRCzHUCzGwRtELOtAEOpRDAJQpKXSUUpR9lIwIX19uYW1lX1+UjAhfX21haW5fX5RzaBFO\\\\nTnSUUpR9lH2UjA9fX2Fubm90YXRpb25zX1+UfZRzhpRiLg==\\\\n\"},\"cv_requires_lists\":false,\"cv_wrap_numpy_array\":true,\"cv_scalarize_numpy_singletons\":false,\"kwargs\":{\"center\":1,\"np\":{\"_import\":\"numpy\"}}}}']\n"
      ]
     }
    ],
@@ -374,7 +374,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(store.trajectories[Trajectory] : 1 object(s), 0, 283860163354172696480456782077640048728L)\n"
+      "(store.trajectories[Trajectory] : 1 object(s), 0, 306465958118793424807025199580056649838)\n"
      ]
     }
    ],
@@ -411,7 +411,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "283860163354172696480456782077640048730\n"
+      "306465958118793424807025199580056649840\n"
      ]
     }
    ],
@@ -587,7 +587,7 @@
     {
      "data": {
       "text/plain": [
-       "<openpathsampling.netcdfplus.attribute.FunctionPseudoAttribute at 0x7f2957bf4d50>"
+       "<openpathsampling.netcdfplus.attribute.FunctionPseudoAttribute at 0x16ed26390>"
       ]
      },
      "execution_count": 37,
@@ -634,7 +634,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/tests/test_netcdfplus.ipynb
+++ b/examples/tests/test_netcdfplus.ipynb
@@ -810,7 +810,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['{\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f000000000026\",\"_store\":\"nodes\"}'\n",
+      "['{\"_hex_uuid\":\"0x9e916aba419a11f0bd9a000000000026\",\"_store\":\"nodes\"}'\n",
       " '{\"Hallo\":2,\"Test\":3}']\n"
      ]
     }
@@ -969,9 +969,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[['e3d4c53a-0100-11ef-9d1f-00000000002c'\n",
-      "   'e3d4c53a-0100-11ef-9d1f-000000000030']\n",
-      "  ['e3d4c53a-0100-11ef-9d1f-00000000002e' '']]\n",
+      "[[['9e916aba-419a-11f0-bd9a-00000000002c'\n",
+      "   '9e916aba-419a-11f0-bd9a-000000000030']\n",
+      "  ['9e916aba-419a-11f0-bd9a-00000000002e' '']]\n",
       "\n",
       " [['' '']\n",
       "  ['' '']]]\n",
@@ -1049,7 +1049,7 @@
      "text": [
       "Type:    <class 'openpathsampling.netcdfplus.proxy.LoaderProxy'>\n",
       "Class:   <class '__main__.Node'>\n",
-      "Content: {'__uuid__': 302839522207420201522962921396994310194, 'value': 'First'}\n",
+      "Content: {'__uuid__': 210773071070663257590889269553700798514, 'value': 'First'}\n",
       "Access:  First\n"
      ]
     }
@@ -1817,7 +1817,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ {\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f00000000004a\",\"_store\":\"nodesunique\"}, {\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f00000000004c\",\"_store\":\"nodesunique\"}, {\"_hex_uuid\":\"0xe3d4c53a010011ef9d1f00000000004e\",\"_store\":\"nodesunique\"} ]\n"
+      "[ {\"_hex_uuid\":\"0x9e916aba419a11f0bd9a00000000004a\",\"_store\":\"nodesunique\"}, {\"_hex_uuid\":\"0x9e916aba419a11f0bd9a00000000004c\",\"_store\":\"nodesunique\"}, {\"_hex_uuid\":\"0x9e916aba419a11f0bd9a00000000004e\",\"_store\":\"nodesunique\"} ]\n"
      ]
     }
    ],
@@ -1965,11 +1965,13 @@
      "output_type": "stream",
      "text": [
       "# We had an exception\n",
-      "invalid literal for int() with base 10: 'test'\n"
+      "invalid literal for int() with base 10: np.str_('test')\n"
      ]
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# until we drop numpy 1.x support -- output differs for np.str_('test') vs. 'test'\n",
     "try:\n",
     "    a = Node('test')\n",
     "    print(st.varstore.save(a))\n",
@@ -2092,7 +2094,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0xe3d4c53a010011ef9d1f000000000014\n"
+      "0x9e916aba419a11f0bd9a000000000014\n"
      ]
     }
    ],
@@ -2150,7 +2152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/tests/test_openmm_integration.ipynb
+++ b/examples/tests/test_openmm_integration.ipynb
@@ -42,7 +42,27 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:pymbar.timeseries:Warning on use of the timeseries module: If the inherent timescales of the system are long compared to those being analyzed, this statistical inefficiency may be an underestimate.  The estimate presumes the use of many statistically independent samples.  Tests should be performed to assess whether this condition is satisfied.   Be cautious in the interpretation of the data.\n",
+      "WARNING:pymbar.mbar_solvers:\n",
+      "****** PyMBAR will use 64-bit JAX! *******\n",
+      "* JAX is currently set to 32-bit bitsize *\n",
+      "* which is its default.                  *\n",
+      "*                                        *\n",
+      "* PyMBAR requires 64-bit mode and WILL   *\n",
+      "* enable JAX's 64-bit mode when called.  *\n",
+      "*                                        *\n",
+      "* This MAY cause problems with other     *\n",
+      "* Uses of JAX in the same code.          *\n",
+      "******************************************\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "# hide stderr from openmmtools (apparently nbval still gets it)\n",
@@ -66,6 +86,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# apparently we get some weird output from openmmtools on this, too\n",
     "testsystem = omt.testsystems.AlanineDipeptideVacuum()"
    ]
   },
@@ -475,9 +497,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -489,7 +511,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >=3.10
 install_requires = 
     future
     psutil
-    numpy<2.0
+    numpy
     scipy
     pandas
     netcdf4


### PR DESCRIPTION
We pinned numpy to <2 while numpy 2 was in RC mode on testpypi because I was trying to release OPS 1.6.1, and MDTraj wasn't ready for numpy 2 yet. It's been a while. Let's release that pin. I'm hoping this will help make it easier to clean up some of the notebook tests.