### PR TITLE
OpenMMEngine: Persist `platform`; allow `openmm_properties` override in `initialize`

### DIFF
--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -242,19 +242,19 @@ class OpenMMEngine(DynamicsEngine):
 
     @staticmethod
     def _normalize_platform(platform):
-        if platform is None:
-            return None
-
-        if isinstance(platform, str):
-            return platform
-
-        try:
-            return platform.getName()
-        except (AttributeError, TypeError) as err:
-            raise TypeError(
-                "platform must be None, a platform name string, or an "
-                "openmm.Platform instance"
-            ) from err
+        match platform:
+            case None:
+                return None
+            case str() as name:
+                return name
+            case candidate if isinstance(candidate, openmm.Platform):
+                return candidate.getName()
+            case _:
+                raise TypeError(
+                    "platform must be None, a platform name string, or an "
+                    "openmm.Platform instance. "
+                    f"Got {type(platform)} instead"
+                )
 
     @property
     def simulation(self):

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -79,7 +79,8 @@ class OpenMMEngine(DynamicsEngine):
             system,
             integrator,
             openmm_properties=None,
-            options=None):
+            options=None,
+            platform=None):
         """
         Parameters
         ----------
@@ -95,8 +96,6 @@ class OpenMMEngine(DynamicsEngine):
             keys include GPU floating point precision.
             Note that by default the engine selects the fastest currently
             available OpenMM platform.
-            If you want to specify the platform you will have to call
-            `engine.initialize(platform)` after creating the engine.
         options : dict
             a dictionary that provides additional settings for the OPS engine.
             Allowed are
@@ -106,6 +105,11 @@ class OpenMMEngine(DynamicsEngine):
                 'n_frames_max' : int, default: 5000,
                     the maximal number of frames allowed for a returned
                     trajectory object
+        platform : str or :class:`openmm.Platform` or None
+            optional default platform for creating the OpenMM simulation.
+            This value is used by ``initialize`` and serialization. The
+            ``.platform`` property reflects the initialized simulation context
+            and remains ``None`` until initialization occurs.
 
         Notes
         -----
@@ -138,6 +142,8 @@ class OpenMMEngine(DynamicsEngine):
             openmm_properties = {}
 
         self.openmm_properties = openmm_properties
+        self._normalize_platform(platform)  # validate serializability
+        self._platform = platform
 
         # set no cached snapshot
         self._current_snapshot = None
@@ -202,7 +208,8 @@ class OpenMMEngine(DynamicsEngine):
             self.system,
             integrator,
             openmm_properties=openmm_properties,
-            options=new_options)
+            options=new_options,
+            platform=self._platform)
 
         if self._simulation is not None and \
                 integrator is self.integrator and \
@@ -220,13 +227,34 @@ class OpenMMEngine(DynamicsEngine):
     @property
     def platform(self):
         """
-        str : Return the name of the currently used platform
+        str or None : Return the name of the currently used platform.
+
+        This value is populated from the simulation context and is ``None``
+        until the simulation has been initialized. Configured platform values
+        may exist before initialization for serialization, but are not exposed
+        through this property.
 
         """
         if self._simulation is not None:
             return self._simulation.context.getPlatform().getName()
         else:
             return None
+
+    @staticmethod
+    def _normalize_platform(platform):
+        if platform is None:
+            return None
+
+        if isinstance(platform, str):
+            return platform
+
+        try:
+            return platform.getName()
+        except (AttributeError, TypeError) as err:
+            raise TypeError(
+                "platform must be None, a platform name string, or an "
+                "openmm.Platform instance"
+            ) from err
 
     @property
     def simulation(self):
@@ -261,7 +289,7 @@ class OpenMMEngine(DynamicsEngine):
     def _default_trajectory_writer(self):
         return TRRTrajectoryWriter()
 
-    def initialize(self, platform=None):
+    def initialize(self, platform=None, openmm_properties=None):
         """
         Create the final OpenMMEngine
 
@@ -270,6 +298,9 @@ class OpenMMEngine(DynamicsEngine):
         platform : str or :class:`openmm.Platform` or None
             either a string with a name of the platform or a platform object
             if None it will default to the fastest currently available platform
+        openmm_properties : dict or None
+            optional platform properties for this initialize call. If ``None``
+            the engine-stored ``openmm_properties`` are used.
 
         Notes
         -----
@@ -281,37 +312,45 @@ class OpenMMEngine(DynamicsEngine):
         """
 
         if self._simulation is None:
-            if type(platform) is str:
-                self._simulation = openmm.app.Simulation(
-                    topology=self.topology.mdtraj.to_openmm(),
-                    system=self.system,
-                    integrator=self.integrator,
-                    platform=openmm.Platform.getPlatformByName(platform),
-                    platformProperties=self.openmm_properties
-                )
-            elif platform is None:
-                # as of OpenMM 8.1, we can't give an empty props dict when
-                # platform is None. This will still raise the internal
-                # OpenMM error is platform is None and properties are
-                # provided.
-                openmm_props = self.openmm_properties
-                if openmm_props == {}:
-                    openmm_props = None
-
-                self._simulation = openmm.app.Simulation(
-                    topology=self.topology.mdtraj.to_openmm(),
-                    system=self.system,
-                    integrator=self.integrator,
-                    platformProperties=openmm_props,
-                )
+            if platform is None:
+                effective_platform = self._platform
             else:
-                self._simulation = openmm.app.Simulation(
-                    topology=self.topology.mdtraj.to_openmm(),
-                    system=self.system,
-                    integrator=self.integrator,
-                    platform=platform,
-                    platformProperties=self.openmm_properties
-                )
+                self._normalize_platform(platform)  # validate serializability
+                effective_platform = platform
+
+            if openmm_properties is None:
+                effective_properties = self.openmm_properties
+            else:
+                effective_properties = openmm_properties
+
+            simulation_kwargs = {
+                'topology': self.topology.mdtraj.to_openmm(),
+                'system': self.system,
+                'integrator': self.integrator,
+            }
+
+            if effective_platform is None:
+                if not effective_properties:
+                    openmm_props = None
+                else:
+                    openmm_props = effective_properties
+                    raise ValueError(
+                        "OpenMM platform-specific properties were provided, "
+                        "but no platform was specified."
+                    )
+                simulation_kwargs['platformProperties'] = openmm_props
+            else:
+                if isinstance(effective_platform, str):
+                    resolved_platform = openmm.Platform.getPlatformByName(
+                        effective_platform
+                    )
+                else:
+                    resolved_platform = effective_platform
+
+                simulation_kwargs['platform'] = resolved_platform
+                simulation_kwargs['platformProperties'] = effective_properties
+
+            self._simulation = openmm.app.Simulation(**simulation_kwargs)
 
             logger.info(
                 'Initialized OpenMM engine using platform `%s`' %
@@ -333,7 +372,8 @@ class OpenMMEngine(DynamicsEngine):
             'integrator_xml': integrator_xml,
             'topology': self.topology,
             'options': self.options,
-            'properties': self.openmm_properties
+            'properties': self.openmm_properties,
+            'platform': self._normalize_platform(self._platform)
         }
 
     @classmethod
@@ -343,6 +383,7 @@ class OpenMMEngine(DynamicsEngine):
         topology = dct['topology']
         options = dct['options']
         properties = dct['properties']
+        platform = dct.get('platform', None)
 
         # we need to have str as keys
         properties = {str(key): str(value)
@@ -355,7 +396,8 @@ class OpenMMEngine(DynamicsEngine):
             system=openmm.XmlSerializer.deserialize(system_xml),
             integrator=integrator,
             options=options,
-            openmm_properties=properties
+            openmm_properties=properties,
+            platform=platform
         )
 
     @property

--- a/openpathsampling/engines/openmm/engine.py
+++ b/openpathsampling/engines/openmm/engine.py
@@ -330,15 +330,12 @@ class OpenMMEngine(DynamicsEngine):
             }
 
             if effective_platform is None:
-                if not effective_properties:
-                    openmm_props = None
-                else:
-                    openmm_props = effective_properties
+                if effective_properties:
                     raise ValueError(
                         "OpenMM platform-specific properties were provided, "
                         "but no platform was specified."
                     )
-                simulation_kwargs['platformProperties'] = openmm_props
+                simulation_kwargs['platformProperties'] = None
             else:
                 if isinstance(effective_platform, str):
                     resolved_platform = openmm.Platform.getPlatformByName(

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -339,6 +339,27 @@ class TestOpenMMEngine(object):
         assert self.uninitialized_engine._platform is None
         assert self.uninitialized_engine.to_dict()['platform'] is None
 
+    def test_bad_platform_get_name_raises_typeerror(self):
+        class BadPlatform(object):
+            def getName(self):
+                raise TypeError("bad getName")
+
+        integrator = mm.LangevinIntegrator(
+            300*u.kelvin,
+            old_div(1.0, u.picoseconds),
+            2.0*u.femtoseconds
+        )
+        integrator.setConstraintTolerance(0.00001)
+
+        with pytest.raises(TypeError, match='platform must be None'):
+            peng.Engine(
+                template.topology,
+                system,
+                integrator,
+                options={'n_steps_per_frame': 2, 'n_frames_max': 5},
+                platform=BadPlatform()
+            )
+
     def test_from_dict_without_platform_key_is_backward_compatible(self):
         serialized = self.engine.to_dict()
         del serialized['platform']

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -83,6 +83,13 @@ class TestOpenMMEngine(object):
         )
         integrator.setConstraintTolerance(0.00001)
 
+        uninitialized_integrator = mm.LangevinIntegrator(
+            300*u.kelvin,
+            old_div(1.0, u.picoseconds),
+            2.0*u.femtoseconds
+        )
+        uninitialized_integrator.setConstraintTolerance(0.00001)
+
         # Engine options
         options = {
             'n_steps_per_frame': 2,
@@ -93,6 +100,13 @@ class TestOpenMMEngine(object):
             template.topology,
             system,
             integrator,
+            options=options
+        )
+
+        self.uninitialized_engine = peng.Engine(
+            template.topology,
+            system,
+            uninitialized_integrator,
             options=options
         )
 
@@ -296,3 +310,68 @@ class TestOpenMMEngine(object):
         assert len(reloaded) == len(traj)
         npt.assert_allclose(reloaded.xyz, traj.xyz)
 
+    def test_serialization_cycle(self):
+        integrator = mm.LangevinIntegrator(
+            300*u.kelvin,
+            old_div(1.0, u.picoseconds),
+            2.0*u.femtoseconds
+        )
+        integrator.setConstraintTolerance(0.00001)
+        engine = peng.Engine(
+            template.topology,
+            system,
+            integrator,
+            options={'n_steps_per_frame': 2, 'n_frames_max': 5},
+            platform='CPU'
+        )
+
+        dct = engine.to_dict()
+        rebuilt = peng.Engine.from_dict(dct)
+        dct2 = rebuilt.to_dict()
+        assert dct == dct2
+        assert dct2['platform'] == 'CPU'
+
+    def test_initialize_uses_exact_platform_object(self):
+        platform_obj = mm.Platform.getPlatformByName('CPU')
+        self.uninitialized_engine.initialize(platform=platform_obj)
+
+        assert self.uninitialized_engine.platform == 'CPU'
+        assert self.uninitialized_engine._platform is None
+        assert self.uninitialized_engine.to_dict()['platform'] is None
+
+    def test_from_dict_without_platform_key_is_backward_compatible(self):
+        serialized = self.engine.to_dict()
+        del serialized['platform']
+
+        restored = peng.Engine.from_dict(serialized)
+        assert restored is not None
+        assert restored.platform is None
+
+    def test_initialize_uses_stored_properties_when_override_is_none(
+            self):
+        self.uninitialized_engine.openmm_properties = {'__ops_bad__': '1'}
+        with pytest.raises(Exception, match='Illegal property name'):
+            self.uninitialized_engine.initialize(
+                platform='CPU',
+                openmm_properties=None
+            )
+
+    def test_initialize_explicit_properties_override_stored(self):
+        self.uninitialized_engine.openmm_properties = {'__ops_bad__': '1'}
+        self.uninitialized_engine.initialize(
+            platform='CPU',
+            openmm_properties={}
+        )
+        assert isinstance(self.uninitialized_engine.simulation, mm.app.Simulation)
+        assert self.uninitialized_engine.platform == 'CPU'
+
+    def test_initialize_nonempty_properties_without_platform_raises(self):
+        self.uninitialized_engine.openmm_properties = {'Threads': '1'}
+        with pytest.raises(ValueError, match='no platform was specified'):
+            self.uninitialized_engine.initialize()
+
+    def test_initialize_empty_properties_without_platform_is_valid(self):
+        self.uninitialized_engine.openmm_properties = {}
+        self.uninitialized_engine.initialize()
+        assert isinstance(self.uninitialized_engine.simulation, mm.app.Simulation)
+        assert self.uninitialized_engine.platform is not None

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -339,10 +339,10 @@ class TestOpenMMEngine(object):
         assert self.uninitialized_engine._platform is None
         assert self.uninitialized_engine.to_dict()['platform'] is None
 
-    def test_bad_platform_get_name_raises_typeerror(self):
-        class BadPlatform(object):
+    def test_duck_typed_platform_like_object_raises_typeerror(self):
+        class PlatformLikeObject(object):
             def getName(self):
-                raise TypeError("bad getName")
+                return 'CPU'
 
         integrator = mm.LangevinIntegrator(
             300*u.kelvin,
@@ -357,7 +357,7 @@ class TestOpenMMEngine(object):
                 system,
                 integrator,
                 options={'n_steps_per_frame': 2, 'n_frames_max': 5},
-                platform=BadPlatform()
+                platform=PlatformLikeObject()
             )
 
     def test_from_dict_without_platform_key_is_backward_compatible(self):

--- a/openpathsampling/tests/test_openmm_engine.py
+++ b/openpathsampling/tests/test_openmm_engine.py
@@ -351,7 +351,7 @@ class TestOpenMMEngine(object):
         )
         integrator.setConstraintTolerance(0.00001)
 
-        with pytest.raises(TypeError, match='platform must be None'):
+        with pytest.raises(TypeError, match=r'platform must be None.*PlatformLikeObject'):
             peng.Engine(
                 template.topology,
                 system,


### PR DESCRIPTION
This allows OpenMM engines to persist their platform (if given to `__init__`). It also allow override of `openmm_properties` (and `platform`) in the `initialization()` method.

Resolves part of #1177, following the approach proposed at https://github.com/openpathsampling/openpathsampling/issues/1177#issuecomment-3942235556.