### PR TITLE
Fix SimStore problems with scalarize singletons in numpy 2

### DIFF
--- a/openpathsampling/experimental/simstore/storable_functions.py
+++ b/openpathsampling/experimental/simstore/storable_functions.py
@@ -56,10 +56,12 @@ def _scalarize_singletons(values):
     """
     if isinstance(values, np.ndarray):
         shape = tuple(n for n in values.shape if n != 1)
+        # NumPy >= 2.0 rejects float() for non-0D ndarrays, so use item()
+        # when singleton axes collapse to a scalar.
         if shape == tuple():
-            values = values.__float__()
+            values = float(values.item())
         else:
-            values.shape = shape
+            values = np.reshape(values, shape)
 
         # shape = values.shape
         # if len(shape) > 1 and shape[1] == 1:

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -66,6 +66,11 @@ def test_scalarize_singletons_to_float():
     assert not isinstance(scalarized, np.ndarray)
     assert isinstance(scalarized, float)
 
+def test_scalarize_singletons_non_0d_singleton_to_float():
+    scalarized = scalarize_singletons(np.array([[1.0]]))
+    assert not isinstance(scalarized, np.ndarray)
+    assert isinstance(scalarized, float)
+
 def test_wrap_numpy():
     for inp in [1, [1, 2]]:
         assert isinstance(wrap_numpy(inp), np.ndarray)

--- a/openpathsampling/experimental/simstore/test_storable_function.py
+++ b/openpathsampling/experimental/simstore/test_storable_function.py
@@ -65,11 +65,19 @@ def test_scalarize_singletons_to_float():
     scalarized = scalarize_singletons(arr)
     assert not isinstance(scalarized, np.ndarray)
     assert isinstance(scalarized, float)
+    assert scalarized == 1.0
+
+def test_scalarize_singletons_1d_singleton_to_float():
+    scalarized = scalarize_singletons(np.array([1.0]))
+    assert not isinstance(scalarized, np.ndarray)
+    assert isinstance(scalarized, float)
+    assert scalarized == 1.0
 
 def test_scalarize_singletons_non_0d_singleton_to_float():
     scalarized = scalarize_singletons(np.array([[1.0]]))
     assert not isinstance(scalarized, np.ndarray)
     assert isinstance(scalarized, float)
+    assert scalarized == 1.0
 
 def test_wrap_numpy():
     for inp in [1, [1, 2]]:


### PR DESCRIPTION
This is similar to one of the things we fixed in #1178 for array scalar conversion -- not sure why the tests for this one only started failing recently, but this will solve it.