### PR TITLE
Combine step exporters with storage interface

### DIFF
--- a/openpathsampling/exports/steps/core.py
+++ b/openpathsampling/exports/steps/core.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+
+
+class StepExporter(ABC):
+    """Abstract interface for exporting simulation steps.
+
+    Implementations define how raw trajectory data and trial/active
+    references are represented. The default orchestration assumes
+    single-process use and does not provide locking around duplicate exports.
+    """
+
+    @abstractmethod
+    def export_raw_sample(self, step, sample):
+        """Export the raw trajectory data for ``sample``."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def export_trial_sample(self, step, sample):
+        """Export the trial reference/data for ``sample``."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def export_active_sample(self, step, sample):
+        """Export the active reference/data for ``sample``."""
+        raise NotImplementedError()
+
+    def export_step(self, step):
+        """Export all trial and active samples from ``step``."""
+        for sample in step.change.trials:
+            self.export_raw_sample(step, sample)
+            self.export_trial_sample(step, sample)
+
+        for sample in step.active:
+            self.export_active_sample(step, sample)

--- a/openpathsampling/exports/steps/symlink_step_exporter.py
+++ b/openpathsampling/exports/steps/symlink_step_exporter.py
@@ -169,7 +169,7 @@ class SymLinkStepExporter(StepExporter):
         # ensure parent directory exists
         raw_data_path.parent.mkdir(parents=True, exist_ok=True)
         writer = self._get_writer(sample)
-        writer(sample.trajectory, raw_data_path)
+        writer(sample.trajectory, os.fspath(raw_data_path))
 
 
 def export_steps(steps, writer=None, *, export_trials=True,

--- a/openpathsampling/exports/steps/symlink_step_exporter.py
+++ b/openpathsampling/exports/steps/symlink_step_exporter.py
@@ -6,7 +6,10 @@ import os
 import collections
 import pathlib
 
-class SymLinkStepExporter:
+from .core import StepExporter
+
+
+class SymLinkStepExporter(StepExporter):
     """Export steps as raw data and symlink to the raw data.
 
     In the patterns used for raw data, trials, and active data, the
@@ -35,6 +38,12 @@ class SymLinkStepExporter:
        File pattern for the trial data symlinks.
     active_pattern : str
        File pattern for the active data symlinks.
+
+    Notes
+    -----
+    This exporter is filesystem-specific and is intended for single-process
+    export workflows. It uses best-effort existence checks to avoid duplicate
+    writes, but it does not lock files against concurrent exporters.
     """
     def __init__(
         self,
@@ -51,6 +60,15 @@ class SymLinkStepExporter:
         self.raw_data_pattern = raw_data_pattern
         self.trial_pattern = trial_pattern
         self.active_pattern = active_pattern
+
+    def _resolve_path(self, path):
+        path = pathlib.Path(path)
+        if path.is_absolute():
+            return path
+        return self.base_dir / path
+
+    def _formatted_path(self, pattern, subs_dict):
+        return self._resolve_path(pattern.format(**subs_dict))
 
     def _get_ensemble_id(self, sample):
         """Get the ensemble ID (used in file names) for a sample.
@@ -96,18 +114,18 @@ class SymLinkStepExporter:
             return
 
         subs_dict = self._substitution_dict(step, sample)
-        path = pattern.format(**subs_dict)
-        raw_data_path = self.raw_data_pattern.format(**subs_dict)
-        if not pathlib.Path(raw_data_path).exists():
+        path = self._formatted_path(pattern, subs_dict)
+        raw_data_path = self._formatted_path(self.raw_data_pattern, subs_dict)
+        if not raw_data_path.exists():
             self.export_raw_sample(step, sample)
 
-        pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
-        symlink_path = pathlib.Path(path)
-        target_path = pathlib.Path(raw_data_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        symlink_path = path
+        target_path = raw_data_path
         relative_target = os.path.relpath(target_path, symlink_path.parent)
 
         if not symlink_path.exists():
-            os.symlink(relative_target, path)
+            os.symlink(relative_target, symlink_path)
 
     def export_trial_sample(self, step, sample):
         """Export a symlink to the raw data for a trial sample.
@@ -144,37 +162,23 @@ class SymLinkStepExporter:
            The sample to export.
         """
         subs_dict = self._substitution_dict(step, sample)
-        raw_data_path = self.raw_data_pattern.format(**subs_dict)
-        if os.path.exists(raw_data_path):
+        raw_data_path = self._formatted_path(self.raw_data_pattern, subs_dict)
+        if raw_data_path.exists():
             return
 
         # ensure parent directory exists
-        pathlib.Path(raw_data_path).parent.mkdir(parents=True, exist_ok=True)
+        raw_data_path.parent.mkdir(parents=True, exist_ok=True)
         writer = self._get_writer(sample)
         writer(sample.trajectory, raw_data_path)
 
-    def export_step(self, step):
-        """Export a step.
-
-        Parameters
-        ----------
-        step : Step
-           The step to export.
-        """
-        for sample in step.change.trials:
-            self.export_raw_sample(step, sample)
-            self.export_trial_sample(step, sample)
-
-        for sample in step.active:
-            self.export_active_sample(step, sample)
-
 
 def export_steps(steps, writer=None, *, export_trials=True,
-                 export_active=True):
+                 export_active=True, base_dir='.'):
     trial_pattern = _DEFAULT_TRIAL_PATTERN if export_trials else None
     active_pattern = _DEFAULT_ACTIVE_PATTERN if export_active else None
     exporter = SymLinkStepExporter(
         writer=writer,
+        base_dir=base_dir,
         trial_pattern=trial_pattern,
         active_pattern=active_pattern,
     )

--- a/openpathsampling/exports/trajectories/core.py
+++ b/openpathsampling/exports/trajectories/core.py
@@ -1,37 +1,77 @@
 import pathlib
-import contextlib
 import logging
 
-import numpy as np
+from openpathsampling.utils.storage_interfaces import LocalFileStorageInterface
 
 _logger = logging.getLogger(__name__)
 
 
 class TrajectoryWriter:
-    """Base class for tools to write trajectories to extenral files.
+    """Base class for tools to write trajectories to external storage.
 
     This is essentially a wrapper for a function to write the trajectory to
-    a file. The function should take two arguments: the trajectory to write,
-    and the filename to write to.
+    a path. Most trajectory libraries require a local filename, so the
+    primary storage-aware API uses :meth:`StorageInterface.as_path` to
+    provide one.
 
     We use an object-oriented approach here so that initialization can
-    inlude arbitrary parameters, but the interface used by other code is
-    consistent. Additionally, :meth:`__call__` is can handle some standard
-    error checking.
+    include arbitrary parameters, but the interface used by other code is
+    consistent. Additionally, :meth:`write` handles standard error checking
+    through the storage interface.
     """
     def __call__(self, trajectory, filename, force=False):
-        if not force and pathlib.Path(filename).exists():
-            raise FileExistsError(f"File {filename} already exists")
+        self.write_file(trajectory, filename, force=force)
 
-        self._write(trajectory, filename)
+    def write(self, trajectory, storage, storage_label, *, force=False,
+              atomic=False):
+        """Write ``trajectory`` to ``storage_label`` in ``storage``.
+
+        Parameters
+        ----------
+        trajectory : openpathsampling.Trajectory
+            the trajectory to save
+        storage : openpathsampling.utils.storage_interfaces.StorageInterface
+            destination storage interface
+        storage_label : str
+            storage key for the trajectory
+        force : bool
+            overwrite an existing storage label if True
+        atomic : bool
+            if True, request staged/atomic path handling from storage
+        """
+        suffix = self._suffix_for_label(storage_label)
+        with storage.as_path(storage_label, mode='wb', suffix=suffix,
+                             force=force, atomic=atomic) as path:
+            self._write_path(trajectory, path)
+
+    def write_file(self, trajectory, filename, *, force=False):
+        """Write ``trajectory`` directly to a filesystem path."""
+        filename = pathlib.Path(filename)
+        storage = LocalFileStorageInterface(filename.parent)
+        self.write(trajectory, storage, filename.name, force=force,
+                   atomic=False)
+
+    def _suffix_for_label(self, storage_label):
+        suffix = pathlib.Path(storage_label).suffix
+        if suffix:
+            return suffix
+        try:
+            ext = self.ext
+        except NotImplementedError:
+            return None
+        return f".{ext}" if ext else None
 
     @property
     def ext(self):
         """The file extension used by this writer."""
         raise NotImplementedError()
 
+    def _write_path(self, trajectory, filename):
+        """Write the trajectory to the local filesystem path ``filename``."""
+        self._write(trajectory, filename)
+
     def _write(self, trajectory, filename):
-        """Write the trajectory to the file.
+        """Write the trajectory to the local filesystem path ``filename``.
 
         Parameters
         ----------

--- a/openpathsampling/tests/exports/steps/test_step_exporter_core.py
+++ b/openpathsampling/tests/exports/steps/test_step_exporter_core.py
@@ -1,0 +1,35 @@
+from openpathsampling.exports.steps.core import StepExporter
+
+
+class FakeStepExporter(StepExporter):
+    def __init__(self):
+        self.calls = []
+
+    def export_raw_sample(self, step, sample):
+        self.calls.append(("raw", sample))
+
+    def export_trial_sample(self, step, sample):
+        self.calls.append(("trial", sample))
+
+    def export_active_sample(self, step, sample):
+        self.calls.append(("active", sample))
+
+
+def test_step_exporter_export_step():
+    class Change:
+        trials = ["trial-1", "trial-2"]
+
+    class Step:
+        change = Change()
+        active = ["active-1"]
+
+    exporter = FakeStepExporter()
+    exporter.export_step(Step())
+
+    assert exporter.calls == [
+        ("raw", "trial-1"),
+        ("trial", "trial-1"),
+        ("raw", "trial-2"),
+        ("trial", "trial-2"),
+        ("active", "active-1"),
+    ]

--- a/openpathsampling/tests/exports/steps/test_symlink_step_exporter.py
+++ b/openpathsampling/tests/exports/steps/test_symlink_step_exporter.py
@@ -9,6 +9,7 @@ from openpathsampling.exports.steps.symlink_step_exporter import (
     _DEFAULT_TRIAL_PATTERN, _DEFAULT_ACTIVE_PATTERN, _DEFAULT_RAW_DATA_PATTERN,
     export_steps,
 )
+from openpathsampling.exports.steps.core import StepExporter
 
 from openpathsampling.tests.analysis.utils.mock_movers import (
     MockForwardShooting, MockRepex,
@@ -109,6 +110,9 @@ class TestSymLinkStepExporter:
         sample = Mock()
         sample.ensemble = ensemble
         assert self.exporter._get_ensemble_id(sample) == expected
+
+    def test_is_step_exporter(self):
+        assert isinstance(self.exporter, StepExporter)
 
     @pytest.mark.parametrize("source", ["obj", "most_common"])
     def test_get_writer(self, source):
@@ -246,6 +250,27 @@ class TestSymLinkStepExporter:
         finally:
             os.chdir(original_cwd)
 
+    def test_base_dir_without_chdir(self, shooting_step, tmp_path):
+        step = shooting_step
+        sample = step.change.trials[0]
+
+        exporter = SymLinkStepExporter(
+            base_dir=tmp_path, writer=self.mock_writer
+        )
+
+        exporter.export_trial_sample(step, sample)
+
+        subs_dict = exporter._substitution_dict(step, sample)
+        raw_data_path = tmp_path / exporter.raw_data_pattern.format(
+            **subs_dict
+        )
+        trial_path = tmp_path / exporter.trial_pattern.format(**subs_dict)
+
+        assert raw_data_path.exists()
+        assert trial_path.exists()
+        assert trial_path.is_symlink()
+        assert raw_data_path.samefile(trial_path)
+
     @pytest.mark.parametrize("step_type", ["shooting", "repex",
                                            "pathreversal"])
     def test_export_step(self, step_type, request, tmp_path):
@@ -359,6 +384,39 @@ def test_export_steps(all_steps, tmp_path):
 
     finally:
         os.chdir(original_cwd)
+
+
+def test_export_steps_base_dir_without_chdir(all_steps, tmp_path):
+    mock_writer = Mock()
+    mock_writer.ext = "db"
+
+    def mock_write_func(trajectory, filename):
+        pathlib.Path(filename).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(filename).touch()
+
+    mock_writer.side_effect = mock_write_func
+
+    export_steps(all_steps, writer=mock_writer, base_dir=tmp_path)
+
+    samples = [
+        sample
+        for step in all_steps
+        for sample in step.change.trials + list(step.active)
+    ]
+    expected_raw_files = {
+        tmp_path / "raw_data" / f"{sample.trajectory.__uuid__}."
+        f"{mock_writer.ext}"
+        for sample in samples
+    }
+    actual_raw_files = set(
+        (tmp_path / "raw_data").glob(f"*.{mock_writer.ext}")
+    )
+
+    assert actual_raw_files == expected_raw_files
+    assert mock_writer.call_count == len(expected_raw_files)
+    assert {call.args[1] for call in mock_writer.call_args_list} == (
+        expected_raw_files
+    )
 
 
 def test_default_raw_pattern_paths(shooting_step):

--- a/openpathsampling/tests/exports/steps/test_symlink_step_exporter.py
+++ b/openpathsampling/tests/exports/steps/test_symlink_step_exporter.py
@@ -250,6 +250,25 @@ class TestSymLinkStepExporter:
         finally:
             os.chdir(original_cwd)
 
+    def test_export_raw_sample_writer_gets_string_path(self, shooting_step,
+                                                       tmp_path):
+        step = shooting_step
+        sample = step.active[0]
+        filenames = []
+
+        def writer(trajectory, filename):
+            filenames.append(filename)
+            pathlib.Path(filename).parent.mkdir(parents=True, exist_ok=True)
+            pathlib.Path(filename).touch()
+
+        writer.ext = "dat"
+        exporter = SymLinkStepExporter(base_dir=tmp_path, writer=writer)
+
+        exporter.export_raw_sample(step, sample)
+
+        assert len(filenames) == 1
+        assert isinstance(filenames[0], str)
+
     def test_base_dir_without_chdir(self, shooting_step, tmp_path):
         step = shooting_step
         sample = step.change.trials[0]
@@ -415,7 +434,7 @@ def test_export_steps_base_dir_without_chdir(all_steps, tmp_path):
     assert actual_raw_files == expected_raw_files
     assert mock_writer.call_count == len(expected_raw_files)
     assert {call.args[1] for call in mock_writer.call_args_list} == (
-        expected_raw_files
+        {os.fspath(path) for path in expected_raw_files}
     )
 
 

--- a/openpathsampling/tests/exports/trajectories/test_core.py
+++ b/openpathsampling/tests/exports/trajectories/test_core.py
@@ -1,4 +1,7 @@
 from openpathsampling.exports.trajectories import *
+from openpathsampling.utils.storage_interfaces import (
+    LocalFileStorageInterface, MemoryStorageInterface
+)
 
 from openpathsampling.tests.test_helpers import (
     data_filename, make_1d_traj
@@ -39,6 +42,17 @@ class TrajectoryWriterTestBase:
         self.writer(trajectory, outfile, force=True)
         assert outfile.exists()
         assert len(outfile.read_bytes()) > 0
+
+    def _test_write_storage(self, trajectory, storage, storage_label,
+                            read_filename):
+        assert storage_label not in storage
+        self.writer.write(trajectory, storage, storage_label)
+        assert storage_label in storage
+
+        storage.load(storage_label, read_filename)
+        traj = self._read_trajectory(read_filename)
+        assert len(traj) == len(trajectory)
+        assert traj == trajectory
 
     def test_call(self, trajectory_fixture, request, tmp_path):
         raise NotImplementedError()
@@ -98,6 +112,41 @@ class TestSimStoreTrajectoryWriter(TrajectoryWriterTestBase):
                                                  tmp_path / "test.db")
         finally:
             monkey_patches.unpatch(paths)
+
+    def test_write_memory_storage(self, request, tmp_path):
+        trajectory = request.getfixturevalue("ad_trajectory")
+        import openpathsampling as paths
+        from openpathsampling.experimental.storage import monkey_patches
+        paths = monkey_patches.monkey_patch_all(paths)
+
+        try:
+            storage = MemoryStorageInterface()
+            self._test_write_storage(
+                trajectory, storage, "traj.db", tmp_path / "read.db"
+            )
+        finally:
+            monkey_patches.unpatch(paths)
+
+    def test_write_local_storage(self, request, tmp_path):
+        trajectory = request.getfixturevalue("ad_trajectory")
+        import openpathsampling as paths
+        from openpathsampling.experimental.storage import monkey_patches
+        paths = monkey_patches.monkey_patch_all(paths)
+
+        try:
+            storage = LocalFileStorageInterface(tmp_path / "storage")
+            self._test_write_storage(
+                trajectory, storage, "traj.db", tmp_path / "read.db"
+            )
+        finally:
+            monkey_patches.unpatch(paths)
+
+    def test_write_storage_exists(self, request):
+        trajectory = request.getfixturevalue("ad_trajectory")
+        storage = MemoryStorageInterface()
+        storage.store_bytes("traj.db", b"existing")
+        with pytest.raises(FileExistsError):
+            self.writer.write(trajectory, storage, "traj.db")
 
     def test_call_not_patched_fail(self, request, tmp_path):
         trajectory = request.getfixturevalue("ad_trajectory")

--- a/openpathsampling/tests/exports/trajectories/test_mdtrajtrajectorywriter.py
+++ b/openpathsampling/tests/exports/trajectories/test_mdtrajtrajectorywriter.py
@@ -2,6 +2,9 @@ import pytest
 
 from openpathsampling.exports.trajectories.mdtrajtrajectorywriter import *
 from openpathsampling.integration_tools import HAS_MDTRAJ
+from openpathsampling.utils.storage_interfaces import (
+    LocalFileStorageInterface, MemoryStorageInterface
+)
 import numpy.testing as npt
 
 def test_mdtraj_trajectory_writer(ad_trajectory, ad_grofile, tmp_path):
@@ -15,6 +18,30 @@ def test_mdtraj_trajectory_writer(ad_trajectory, ad_grofile, tmp_path):
     writer(ad_trajectory, outfile)
     assert outfile.exists()
 
+    reloaded = md.load(str(outfile), top=ad_grofile)
+    assert len(reloaded) == len(ad_trajectory)
+    assert reloaded.xyz.shape == ad_trajectory.xyz.shape
+    npt.assert_allclose(reloaded.xyz, ad_trajectory.xyz, atol=1e-3)
+
+
+@pytest.mark.parametrize("storage_type", ["memory", "local"])
+def test_mdtraj_trajectory_writer_storage(ad_trajectory, ad_grofile,
+                                          storage_type, tmp_path):
+    if not HAS_MDTRAJ:
+        pytest.skip("mdtraj is not available")
+
+    import mdtraj as md
+    storage = {
+        "memory": MemoryStorageInterface(),
+        "local": LocalFileStorageInterface(tmp_path / "storage"),
+    }[storage_type]
+    writer = MDTrajTrajectoryWriter(ext="xtc")
+
+    writer.write(ad_trajectory, storage, "test.xtc")
+    assert "test.xtc" in storage
+
+    outfile = tmp_path / "test.xtc"
+    storage.load("test.xtc", outfile)
     reloaded = md.load(str(outfile), top=ad_grofile)
     assert len(reloaded) == len(ad_trajectory)
     assert reloaded.xyz.shape == ad_trajectory.xyz.shape

--- a/openpathsampling/tests/exports/trajectories/test_trrtrajectorywriter.py
+++ b/openpathsampling/tests/exports/trajectories/test_trrtrajectorywriter.py
@@ -2,6 +2,9 @@ import pytest
 
 from openpathsampling.exports.trajectories.trrtrajectorywriter import *
 from openpathsampling.integration_tools import HAS_MDTRAJ
+from openpathsampling.utils.storage_interfaces import (
+    LocalFileStorageInterface, MemoryStorageInterface
+)
 import numpy.testing as npt
 
 def test_trr_trajectory_writer(ad_trajectory, tmp_path):
@@ -15,6 +18,39 @@ def test_trr_trajectory_writer(ad_trajectory, tmp_path):
     writer(ad_trajectory, outfile)
     assert outfile.exists()
 
+    trr = md.formats.TRRTrajectoryFile(str(outfile), mode='r')
+    xyz, time, step, box, lambd, vel, forces = trr._read(
+        int(len(ad_trajectory)),
+        atom_indices=None,
+        get_velocities=True,
+    )
+
+    assert forces is None
+    npt.assert_allclose(xyz, ad_trajectory.xyz)
+    npt.assert_allclose(vel, ad_trajectory.velocities)
+    npt.assert_allclose(box, ad_trajectory.box_vectors)
+    npt.assert_allclose(lambd, np.zeros(len(ad_trajectory)))
+    npt.assert_allclose(time, np.zeros(len(ad_trajectory)))
+
+
+@pytest.mark.parametrize("storage_type", ["memory", "local"])
+def test_trr_trajectory_writer_storage(ad_trajectory, storage_type,
+                                       tmp_path):
+    if not HAS_MDTRAJ:
+        pytest.skip("mdtraj is not available")
+
+    import mdtraj as md
+    storage = {
+        "memory": MemoryStorageInterface(),
+        "local": LocalFileStorageInterface(tmp_path / "storage"),
+    }[storage_type]
+    writer = TRRTrajectoryWriter()
+
+    writer.write(ad_trajectory, storage, "test.trr")
+    assert "test.trr" in storage
+
+    outfile = tmp_path / "test.trr"
+    storage.load("test.trr", outfile)
     trr = md.formats.TRRTrajectoryFile(str(outfile), mode='r')
     xyz, time, step, box, lambd, vel, forces = trr._read(
         int(len(ad_trajectory)),

--- a/openpathsampling/tests/utils/test_storage_interfaces.py
+++ b/openpathsampling/tests/utils/test_storage_interfaces.py
@@ -187,6 +187,36 @@ class TestLocalFileStorageInterface(StorageInterfaceTest):
         with open(stored_target, mode='r') as f:
             assert f.read() == "localfile contents"
 
+    def test_store_rejects_path_escape(self):
+        with pytest.raises(ValueError, match="inside the storage root"):
+            self.interface.store("../escape", self.localfile)
+
+        assert not (self.tmpdir / "escape").exists()
+
+    def test_store_rejects_symlink_escape(self):
+        outside = self.tmpdir / "outside"
+        outside.mkdir()
+        (self.interface.root / "link-out").symlink_to(outside,
+                                                       target_is_directory=True)
+
+        with pytest.raises(ValueError, match="inside the storage root"):
+            self.interface.store("link-out/escape", self.localfile)
+
+        assert not (outside / "escape").exists()
+
+    def test_store_accepts_normalized_relative_path(self):
+        stored_target = self.interface.root / "normalized/foo"
+
+        self.interface.store("nested/../normalized/foo", self.localfile)
+
+        assert stored_target.exists()
+        with open(stored_target, mode='r') as f:
+            assert f.read() == "localfile contents"
+
+    def test_store_rejects_anchored_label(self):
+        with pytest.raises(ValueError, match="unanchored relative"):
+            self.interface.store("/anchored", self.localfile)
+
     def test_as_path_direct_write_uses_final_path(self):
         stored_target = self.interface.root / "direct/foo"
         with self.interface.as_path("direct/foo", mode="wb",
@@ -220,6 +250,25 @@ class TestLocalFileStorageInterface(StorageInterfaceTest):
 
         with pytest.raises(ValueError, match="is a directory"):
             self.interface.transfer("directory", source_dir)
+
+    def test_transfer_existing_directory_target(self):
+        existing_dir = self.interface.root / "existing-dir"
+        existing_dir.mkdir()
+
+        with pytest.raises(ValueError, match="existing directory"):
+            self.interface.transfer("existing-dir", self.localfile)
+
+        assert self.localfile.exists()
+
+    def test_transfer_existing_directory_target_force(self):
+        existing_dir = self.interface.root / "existing-dir"
+        existing_dir.mkdir()
+
+        with pytest.raises(ValueError, match="existing directory"):
+            self.interface.transfer("existing-dir", self.localfile,
+                                    force=True)
+
+        assert self.localfile.exists()
 
     def test_list_directory_not_directory(self):
         with pytest.raises(ValueError, match="is not a directory"):

--- a/openpathsampling/tests/utils/test_storage_interfaces.py
+++ b/openpathsampling/tests/utils/test_storage_interfaces.py
@@ -93,6 +93,10 @@ class StorageInterfaceTest:
             f.write(b"opened contents")
         assert self.interface.load_bytes("opened") == b"opened contents"
 
+    def test_open_binary_mode_order_flexible(self):
+        with self.interface.open("prestored", mode="br") as f:
+            assert f.read() == b"prestored contents"
+
     def test_open_write_exception_does_not_commit(self):
         with pytest.raises(RuntimeError):
             with self.interface.open("failed-open", mode="wb") as f:
@@ -103,6 +107,12 @@ class StorageInterfaceTest:
     def test_open_text_mode_error(self):
         with pytest.raises(ValueError, match="binary"):
             with self.interface.open("prestored", mode="r"):
+                pass
+
+    @pytest.mark.parametrize("mode", ["ab", "ba", "r+b", "rb+", "br+"])
+    def test_open_unsupported_mode_error(self, mode):
+        with pytest.raises(ValueError, match="append/update"):
+            with self.interface.open("prestored", mode=mode):
                 pass
 
     def test_as_path_read(self):
@@ -116,6 +126,11 @@ class StorageInterfaceTest:
                 f.write(b"as-path contents")
         assert self.interface.load_bytes("as-path") == b"as-path contents"
 
+    def test_as_path_binary_mode_order_flexible(self):
+        with self.interface.as_path("prestored", mode="br") as path:
+            with open(path, mode="rb") as f:
+                assert f.read() == b"prestored contents"
+
     def test_as_path_atomic_exception_does_not_commit(self):
         with pytest.raises(RuntimeError):
             with self.interface.as_path("failed-path", mode="wb",
@@ -124,6 +139,12 @@ class StorageInterfaceTest:
                     f.write(b"failed contents")
                 raise RuntimeError("fail")
         assert "failed-path" not in self.interface
+
+    @pytest.mark.parametrize("mode", ["ab", "ba", "r+b", "rb+", "br+"])
+    def test_as_path_unsupported_mode_error(self, mode):
+        with pytest.raises(ValueError, match="append/update"):
+            with self.interface.as_path("prestored", mode=mode):
+                pass
 
 
 class TestLocalFileStorageInterface(StorageInterfaceTest):

--- a/openpathsampling/tests/utils/test_storage_interfaces.py
+++ b/openpathsampling/tests/utils/test_storage_interfaces.py
@@ -64,6 +64,67 @@ class StorageInterfaceTest:
         assert "nested" not in self.interface
         assert "nonexistent" not in self.interface
 
+    def test_store_existing_no_force(self):
+        with pytest.raises(FileExistsError):
+            self.interface.store("prestored", self.localfile)
+
+    def test_store_existing_force(self):
+        self.interface.store("prestored", self.localfile, force=True)
+        assert self.interface.load_bytes("prestored") == b"localfile contents"
+
+    def test_store_bytes(self):
+        self.interface.store_bytes("bytes", b"bytes contents")
+        assert "bytes" in self.interface
+        assert self.interface.load_bytes("bytes") == b"bytes contents"
+
+    def test_store_bytes_existing_no_force(self):
+        with pytest.raises(FileExistsError):
+            self.interface.store_bytes("prestored", b"new")
+
+    def test_load_bytes(self):
+        assert self.interface.load_bytes("prestored") == b"prestored contents"
+
+    def test_open_read(self):
+        with self.interface.open("prestored", mode="rb") as f:
+            assert f.read() == b"prestored contents"
+
+    def test_open_write(self):
+        with self.interface.open("opened", mode="wb") as f:
+            f.write(b"opened contents")
+        assert self.interface.load_bytes("opened") == b"opened contents"
+
+    def test_open_write_exception_does_not_commit(self):
+        with pytest.raises(RuntimeError):
+            with self.interface.open("failed-open", mode="wb") as f:
+                f.write(b"failed contents")
+                raise RuntimeError("fail")
+        assert "failed-open" not in self.interface
+
+    def test_open_text_mode_error(self):
+        with pytest.raises(ValueError, match="binary"):
+            with self.interface.open("prestored", mode="r"):
+                pass
+
+    def test_as_path_read(self):
+        with self.interface.as_path("prestored", mode="rb") as path:
+            with open(path, mode="rb") as f:
+                assert f.read() == b"prestored contents"
+
+    def test_as_path_write(self):
+        with self.interface.as_path("as-path", mode="wb") as path:
+            with open(path, mode="wb") as f:
+                f.write(b"as-path contents")
+        assert self.interface.load_bytes("as-path") == b"as-path contents"
+
+    def test_as_path_atomic_exception_does_not_commit(self):
+        with pytest.raises(RuntimeError):
+            with self.interface.as_path("failed-path", mode="wb",
+                                        atomic=True) as path:
+                with open(path, mode="wb") as f:
+                    f.write(b"failed contents")
+                raise RuntimeError("fail")
+        assert "failed-path" not in self.interface
+
 
 class TestLocalFileStorageInterface(StorageInterfaceTest):
     def _initialize_interface(self):
@@ -116,6 +177,36 @@ class TestLocalFileStorageInterface(StorageInterfaceTest):
         assert not self.localfile.exists()
         with open(stored_target, mode='r') as f:
             assert f.read() == "localfile contents"
+
+    def test_transfer_nested(self):
+        stored_target = self.interface.root / "nested_transfer/foo"
+        assert not stored_target.exists()
+        self.interface.transfer("nested_transfer/foo", self.localfile)
+        assert stored_target.exists()
+        assert not self.localfile.exists()
+        with open(stored_target, mode='r') as f:
+            assert f.read() == "localfile contents"
+
+    def test_as_path_direct_write_uses_final_path(self):
+        stored_target = self.interface.root / "direct/foo"
+        with self.interface.as_path("direct/foo", mode="wb",
+                                    atomic=False) as path:
+            assert path == stored_target
+            assert not path.exists()
+            with open(path, mode="wb") as f:
+                f.write(b"direct contents")
+        assert stored_target.read_bytes() == b"direct contents"
+
+    def test_as_path_atomic_write_stages_then_commits(self):
+        stored_target = self.interface.root / "atomic/foo"
+        with self.interface.as_path("atomic/foo", mode="wb",
+                                    atomic=True) as path:
+            assert path != stored_target
+            assert path.parent == stored_target.parent
+            with open(path, mode="wb") as f:
+                f.write(b"atomic contents")
+            assert not stored_target.exists()
+        assert stored_target.read_bytes() == b"atomic contents"
 
     def test_transfer_directory(self):
         source_dir = self.localdir / "directory"

--- a/openpathsampling/utils/storage_interfaces.py
+++ b/openpathsampling/utils/storage_interfaces.py
@@ -12,6 +12,32 @@ _logger = logging.getLogger(__name__)
 
 
 
+def _validate_storage_mode(mode):
+    """Validate storage-interface modes and return the base operation."""
+    valid_flags = set("rbwxa+t")
+    invalid = set(mode) - valid_flags
+    if invalid:
+        raise ValueError(f"invalid mode: {mode!r}")
+
+    repeated = [flag for flag in valid_flags if mode.count(flag) > 1]
+    if repeated:
+        raise ValueError(f"invalid mode: {mode!r}")
+
+    if 'b' not in mode or 't' in mode:
+        raise ValueError("Storage interfaces only support binary modes")
+
+    if 'a' in mode or '+' in mode:
+        raise ValueError("Storage interfaces do not support append/update "
+                         "modes")
+
+    operations = [flag for flag in "rwx" if flag in mode]
+    if len(operations) != 1:
+        raise ValueError("Storage interfaces require exactly one of read, "
+                         "write, or exclusive-create mode")
+
+    return operations[0]
+
+
 class StorageInterface(ABC):
     """Abstract treatment of a key-value-like file/object store.
 
@@ -107,10 +133,8 @@ class StorageInterface(ABC):
         Only binary modes are supported. Write modes commit on successful
         context exit; exceptions leave the storage label unchanged.
         """
-        if 'b' not in mode:
-            raise ValueError("StorageInterface.open only supports binary "
-                             "modes")
-        if _mode_writes(mode):
+        operation = _validate_storage_mode(mode)
+        if operation != 'r':
             if not force and storage_label in self:
                 raise FileExistsError(f"Storage label {storage_label} "
                                       "already exists")
@@ -134,7 +158,8 @@ class StorageInterface(ABC):
         fd, tmp_path = tempfile.mkstemp(suffix=suffix)
         os.close(fd)
         tmp_path = pathlib.Path(tmp_path)
-        write_mode = _mode_writes(mode)
+        operation = _validate_storage_mode(mode)
+        write_mode = operation != 'r'
         try:
             if write_mode:
                 if not force and storage_label in self:
@@ -160,7 +185,7 @@ class StorageInterface(ABC):
 
 def _mode_writes(mode):
     """Return True when a file mode can modify storage contents."""
-    return any(flag in mode for flag in ('w', 'a', 'x', '+'))
+    return _validate_storage_mode(mode) != 'r'
 
 
 class LocalFileStorageInterface(StorageInterface):
@@ -248,9 +273,6 @@ class LocalFileStorageInterface(StorageInterface):
 
     @contextlib.contextmanager
     def open(self, storage_label, mode='rb', *, force=False):
-        if 'b' not in mode:
-            raise ValueError("StorageInterface.open only supports binary "
-                             "modes")
         if _mode_writes(mode):
             with super().open(storage_label, mode=mode, force=force) as f:
                 yield f

--- a/openpathsampling/utils/storage_interfaces.py
+++ b/openpathsampling/utils/storage_interfaces.py
@@ -174,21 +174,34 @@ class LocalFileStorageInterface(StorageInterface):
     def __init__(self, root):
         self.root = pathlib.Path(root)
         self.root.mkdir(parents=True, exist_ok=True)
+        self.root = self.root.resolve()
 
     def _local_path(self, storage_label):
         storage_label = pathlib.Path(storage_label)
-        if storage_label.is_absolute():
-            raise ValueError("Storage labels must be relative paths")
-        return self.root / storage_label
+        if storage_label.anchor:
+            raise ValueError("Storage labels must be unanchored relative paths")
+
+        local_path = (self.root / storage_label).resolve(strict=False)
+        try:
+            local_path.relative_to(self.root)
+        except ValueError as exc:
+            raise ValueError("Storage labels must resolve inside the storage "
+                             "root") from exc
+        return local_path
 
     def _check_can_write(self, storage_label, force):
-        if not force and storage_label in self:
-            raise FileExistsError(f"Storage label {storage_label} "
-                                  "already exists")
+        local_path = self._local_path(storage_label)
+        if local_path.exists():
+            if local_path.is_dir():
+                raise ValueError(f"Storage label {storage_label} refers to an "
+                                 "existing directory")
+            if not force:
+                raise FileExistsError(f"Storage label {storage_label} "
+                                      "already exists")
+        return local_path
 
     def store(self, storage_label, source_path, *, force=False):
-        self._check_can_write(storage_label, force)
-        local_path = self._local_path(storage_label)
+        local_path = self._check_can_write(storage_label, force)
         local_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source_path, local_path)
 
@@ -217,16 +230,14 @@ class LocalFileStorageInterface(StorageInterface):
         if pathlib.Path(source_path).is_dir():
             raise ValueError(f"'{source_path}' is a directory, and can't "
                              "be transferred.")
-        self._check_can_write(storage_label, force)
-        target_path = self._local_path(storage_label)
+        target_path = self._check_can_write(storage_label, force)
         target_path.parent.mkdir(parents=True, exist_ok=True)
         if force and target_path.exists():
             os.remove(target_path)
         shutil.move(source_path, target_path)
 
     def store_bytes(self, storage_label, data, *, force=False):
-        self._check_can_write(storage_label, force)
-        local_path = self._local_path(storage_label)
+        local_path = self._check_can_write(storage_label, force)
         local_path.parent.mkdir(parents=True, exist_ok=True)
         with builtins.open(local_path, mode='wb') as f:
             f.write(data)
@@ -263,13 +274,13 @@ class LocalFileStorageInterface(StorageInterface):
         write_mode = _mode_writes(mode)
         if not atomic:
             if write_mode:
-                self._check_can_write(storage_label, force)
+                local_path = self._check_can_write(storage_label, force)
                 local_path.parent.mkdir(parents=True, exist_ok=True)
             yield local_path
             return
 
         if write_mode:
-            self._check_can_write(storage_label, force)
+            local_path = self._check_can_write(storage_label, force)
             local_path.parent.mkdir(parents=True, exist_ok=True)
             suffix = suffix or local_path.suffix
             fd, tmp_path = tempfile.mkstemp(

--- a/openpathsampling/utils/storage_interfaces.py
+++ b/openpathsampling/utils/storage_interfaces.py
@@ -1,7 +1,11 @@
 from abc import ABC, abstractmethod
+import builtins
+import contextlib
+import io
 import os
 import pathlib
 import shutil
+import tempfile
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -14,9 +18,14 @@ class StorageInterface(ABC):
     This is generally assuming file-based semantics. This may typically mean
     putting things into a temporary directory. This is particularly focused
     on checkpointing, where we will copy the data to put it in a zip file.
+
+    The default implementations are intended for single-process export
+    workflows. ``force=False`` performs a best-effort existence check, but
+    this interface does not provide cross-process locking or distributed
+    consistency guarantees.
     """
     @abstractmethod
-    def store(self, storage_label, source_path):
+    def store(self, storage_label, source_path, *, force=False):
         """Store the data in ``source_path`` at key ``storage_label``
 
         Parameters
@@ -25,6 +34,8 @@ class StorageInterface(ABC):
             The key to store the data at.
         source_path : os.PathLike
             The path to the data to store.
+        force : bool
+            If False, raise FileExistsError when ``storage_label`` exists.
         """
         raise NotImplementedError()
 
@@ -51,7 +62,7 @@ class StorageInterface(ABC):
     def __contains__(self, storage_label):
         raise NotImplementedError()
 
-    def transfer(self, storage_label, source_path):
+    def transfer(self, storage_label, source_path, *, force=False):
         """Transfer a file to the storage label from the source path.
 
         In some cases, this can be made faster than store followed by
@@ -61,14 +72,95 @@ class StorageInterface(ABC):
         if pathlib.Path(source_path).is_dir():
             raise ValueError(f"'{source_path}' is a directory, and can't "
                              "be transferred.")
-        self.store(storage_label, source_path)
+        self.store(storage_label, source_path, force=force)
         os.remove(source_path)
+
+    def store_bytes(self, storage_label, data, *, force=False):
+        """Store bytes at key ``storage_label``."""
+        fd, tmp_path = tempfile.mkstemp()
+        tmp_path = pathlib.Path(tmp_path)
+        try:
+            with os.fdopen(fd, mode='wb') as f:
+                f.write(data)
+            self.store(storage_label, tmp_path, force=force)
+        finally:
+            if tmp_path.exists():
+                os.remove(tmp_path)
+
+    def load_bytes(self, storage_label):
+        """Load bytes stored at key ``storage_label``."""
+        fd, tmp_path = tempfile.mkstemp()
+        os.close(fd)
+        tmp_path = pathlib.Path(tmp_path)
+        try:
+            self.load(storage_label, tmp_path)
+            with builtins.open(tmp_path, mode='rb') as f:
+                return f.read()
+        finally:
+            if tmp_path.exists():
+                os.remove(tmp_path)
+
+    @contextlib.contextmanager
+    def open(self, storage_label, mode='rb', *, force=False):
+        """Open an in-memory binary file object for ``storage_label``.
+
+        Only binary modes are supported. Write modes commit on successful
+        context exit; exceptions leave the storage label unchanged.
+        """
+        if 'b' not in mode:
+            raise ValueError("StorageInterface.open only supports binary "
+                             "modes")
+        if _mode_writes(mode):
+            if not force and storage_label in self:
+                raise FileExistsError(f"Storage label {storage_label} "
+                                      "already exists")
+            fileobj = io.BytesIO()
+            yield fileobj
+            self.store_bytes(storage_label, fileobj.getvalue(), force=force)
+        else:
+            fileobj = io.BytesIO(self.load_bytes(storage_label))
+            yield fileobj
+
+    @contextlib.contextmanager
+    def as_path(self, storage_label, mode='rb', *, suffix=None, force=False,
+                atomic=False):
+        """Yield a local filesystem path for ``storage_label``.
+
+        This supports libraries that only write to filenames. For non-local
+        storage and for local atomic writes, implementations may stage through
+        a temporary path and commit on successful context exit.
+        """
+        suffix = suffix or pathlib.Path(storage_label).suffix
+        fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+        os.close(fd)
+        tmp_path = pathlib.Path(tmp_path)
+        write_mode = _mode_writes(mode)
+        try:
+            if write_mode:
+                if not force and storage_label in self:
+                    raise FileExistsError(f"Storage label {storage_label} "
+                                          "already exists")
+            else:
+                self.load(storage_label, tmp_path)
+
+            yield tmp_path
+
+            if write_mode:
+                self.transfer(storage_label, tmp_path, force=force)
+        finally:
+            if tmp_path.exists():
+                os.remove(tmp_path)
 
     @abstractmethod
     def list_directory(self, storage_label):
         """List all objects in subdirectories of the given storage label.
         """
         raise NotImplementedError()
+
+
+def _mode_writes(mode):
+    """Return True when a file mode can modify storage contents."""
+    return any(flag in mode for flag in ('w', 'a', 'x', '+'))
 
 
 class LocalFileStorageInterface(StorageInterface):
@@ -83,20 +175,33 @@ class LocalFileStorageInterface(StorageInterface):
         self.root = pathlib.Path(root)
         self.root.mkdir(parents=True, exist_ok=True)
 
-    def store(self, storage_label, source_path):
-        local_path = self.root / storage_label
+    def _local_path(self, storage_label):
+        storage_label = pathlib.Path(storage_label)
+        if storage_label.is_absolute():
+            raise ValueError("Storage labels must be relative paths")
+        return self.root / storage_label
+
+    def _check_can_write(self, storage_label, force):
+        if not force and storage_label in self:
+            raise FileExistsError(f"Storage label {storage_label} "
+                                  "already exists")
+
+    def store(self, storage_label, source_path, *, force=False):
+        self._check_can_write(storage_label, force)
+        local_path = self._local_path(storage_label)
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(source_path, self.root / storage_label)
+        shutil.copyfile(source_path, local_path)
 
     def load(self, storage_label, target_path):
+        target_path = pathlib.Path(target_path)
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        local_path = self.root / storage_label
+        local_path = self._local_path(storage_label)
         _logger.debug("Copying file from {str(local_path)} "
                       f"to {str(target_path)}")
         shutil.copyfile(local_path, target_path)
 
     def delete(self, storage_label):
-        obj = self.root / storage_label
+        obj = self._local_path(storage_label)
         if obj.is_dir():
             raise ValueError(f"'{obj}' is a directory, and can't be "
                              "deleted.")
@@ -105,17 +210,88 @@ class LocalFileStorageInterface(StorageInterface):
             os.remove(obj)
 
     def __contains__(self, storage_label):
-        expected = self.root / storage_label
+        expected = self._local_path(storage_label)
         return expected.exists() and not expected.is_dir()
 
-    def transfer(self, storage_label, source_path):
+    def transfer(self, storage_label, source_path, *, force=False):
         if pathlib.Path(source_path).is_dir():
             raise ValueError(f"'{source_path}' is a directory, and can't "
                              "be transferred.")
-        shutil.move(source_path, self.root / storage_label)
+        self._check_can_write(storage_label, force)
+        target_path = self._local_path(storage_label)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if force and target_path.exists():
+            os.remove(target_path)
+        shutil.move(source_path, target_path)
+
+    def store_bytes(self, storage_label, data, *, force=False):
+        self._check_can_write(storage_label, force)
+        local_path = self._local_path(storage_label)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        with builtins.open(local_path, mode='wb') as f:
+            f.write(data)
+
+    def load_bytes(self, storage_label):
+        with builtins.open(self._local_path(storage_label), mode='rb') as f:
+            return f.read()
+
+    @contextlib.contextmanager
+    def open(self, storage_label, mode='rb', *, force=False):
+        if 'b' not in mode:
+            raise ValueError("StorageInterface.open only supports binary "
+                             "modes")
+        if _mode_writes(mode):
+            with super().open(storage_label, mode=mode, force=force) as f:
+                yield f
+        else:
+            local_path = self._local_path(storage_label)
+            with builtins.open(local_path, mode=mode) as f:
+                yield f
+
+    @contextlib.contextmanager
+    def as_path(self, storage_label, mode='rb', *, suffix=None, force=False,
+                atomic=False):
+        """Yield a local path for ``storage_label``.
+
+        With ``atomic=False`` and a write mode, this yields the final path
+        directly for performance and disk-space efficiency. Failed or
+        interrupted writes may therefore leave partial contents. Use
+        ``atomic=True`` to stage through a temporary file and commit only on
+        successful context exit. Neither mode provides cross-process locking.
+        """
+        local_path = self._local_path(storage_label)
+        write_mode = _mode_writes(mode)
+        if not atomic:
+            if write_mode:
+                self._check_can_write(storage_label, force)
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+            yield local_path
+            return
+
+        if write_mode:
+            self._check_can_write(storage_label, force)
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            suffix = suffix or local_path.suffix
+            fd, tmp_path = tempfile.mkstemp(
+                suffix=suffix,
+                dir=str(local_path.parent)
+            )
+            os.close(fd)
+            tmp_path = pathlib.Path(tmp_path)
+            try:
+                yield tmp_path
+                if not force and storage_label in self:
+                    raise FileExistsError(f"Storage label {storage_label} "
+                                          "already exists")
+                os.replace(tmp_path, local_path)
+            finally:
+                if tmp_path.exists():
+                    os.remove(tmp_path)
+        else:
+            yield local_path
 
     def list_directory(self, storage_label):
-        path = self.root / storage_label
+        path = self._local_path(storage_label)
         if not path.is_dir():
             raise ValueError(f"'{path}' is not a directory.")
         return [
@@ -133,13 +309,28 @@ class MemoryStorageInterface(StorageInterface):
     def __init__(self):
         self._data = {}
 
-    def store(self, storage_label, source_path):
-        with open(source_path, mode='rb') as f:
+    def _check_can_write(self, storage_label, force):
+        if not force and storage_label in self:
+            raise FileExistsError(f"Storage label {storage_label} "
+                                  "already exists")
+
+    def store(self, storage_label, source_path, *, force=False):
+        self._check_can_write(storage_label, force)
+        with builtins.open(source_path, mode='rb') as f:
             self._data[storage_label] = f.read()
 
     def load(self, storage_label, target_path):
-        with open(target_path, mode='wb') as f:
+        target_path = pathlib.Path(target_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with builtins.open(target_path, mode='wb') as f:
             f.write(self._data[storage_label])
+        return self._data[storage_label]
+
+    def store_bytes(self, storage_label, data, *, force=False):
+        self._check_can_write(storage_label, force)
+        self._data[storage_label] = data
+
+    def load_bytes(self, storage_label):
         return self._data[storage_label]
 
     def delete(self, storage_label):

--- a/openpathsampling/utils/storage_interfaces.py
+++ b/openpathsampling/utils/storage_interfaces.py
@@ -234,8 +234,7 @@ class LocalFileStorageInterface(StorageInterface):
         target_path = pathlib.Path(target_path)
         target_path.parent.mkdir(parents=True, exist_ok=True)
         local_path = self._local_path(storage_label)
-        _logger.debug("Copying file from {str(local_path)} "
-                      f"to {str(target_path)}")
+        _logger.debug("Copying file from %s to %s", local_path, target_path)
         shutil.copyfile(local_path, target_path)
 
     def delete(self, storage_label):
@@ -244,7 +243,7 @@ class LocalFileStorageInterface(StorageInterface):
             raise ValueError(f"'{obj}' is a directory, and can't be "
                              "deleted.")
         else:
-            _logger.debug("Deleting file {str(obj)}")
+            _logger.debug("Deleting file %s", obj)
             os.remove(obj)
 
     def __contains__(self, storage_label):


### PR DESCRIPTION
This should, in principle, make it so that we're no longer requiring that exports go to files. This will help us add flexibility in the future to export to non-filesystem setups (e.g., S3 or similar).

Assisted-by: Codex.app:GPT-5.5